### PR TITLE
docs: align documentation with current architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Audit navigation, locale parity, and relative links
+        run: node scripts/audit-docs.mjs
 
       - name: Install dependencies
         run: pip install mkdocs-material mkdocs-static-i18n mkdocs-git-revision-date-localized-plugin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Audit navigation, locale parity, and relative links
+        run: node scripts/audit-docs.mjs
 
       - name: Install dependencies
         run: pip install mkdocs-material mkdocs-static-i18n mkdocs-git-revision-date-localized-plugin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Stocket Documentation
+
+This repository contains the public documentation for Stocket. The site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/), published at [stocketfr.github.io/documentation](https://stocketfr.github.io/documentation/), and maintained in English and French.
+
+Stocket itself is split across several repositories. The [`meta`](https://github.com/stocketfr/meta) repository assembles them into a local workspace, while this repository can also be cloned and edited independently.
+
+## Local preview
+
+CI uses Node.js 22 for the dependency-free audit and Python 3.12 for MkDocs.
+Create the same documentation dependency environment locally:
+
+```sh
+python3.12 -m venv .venv
+. .venv/bin/activate
+python -m pip install mkdocs-material mkdocs-static-i18n mkdocs-git-revision-date-localized-plugin
+mkdocs serve
+```
+
+Open <http://127.0.0.1:8000> to preview the site.
+
+The repository also contains a `flake.nix`, but its current development shell does not provide `mkdocs-static-i18n` successfully. Until that shell is corrected, use the Python environment above for a reproducible preview and build.
+
+## Verification
+
+Run the same strict build used for pull requests:
+
+```sh
+node scripts/audit-docs.mjs
+mkdocs build --strict
+```
+
+The audit checks EN/FR pairing and structure, relative links, and complete one-to-one navigation coverage. The build must complete successfully, and content or navigation warnings should be resolved before review. A push to `main` publishes the site to GitHub Pages through the repository's deploy workflow.
+
+## Repository layout
+
+```text
+docs/                  Documentation source
+  getting-started/     Installation and first-use guides
+  user-guide/          Product documentation
+  development/         Architecture and development guides
+  contributing/        Contribution and pull-request workflow
+  reference/           Commands, configuration, and troubleshooting
+mkdocs.yml              Site navigation, theme, and localization
+scripts/audit-docs.mjs  Dependency-free documentation consistency audit
+flake.nix               Nix development-shell definition (see limitation above)
+```
+
+## Languages
+
+English is the default locale:
+
+- `page.md` is the English source.
+- `page.fr.md` is its French counterpart.
+- Both versions should keep the same structure, facts, links, and examples.
+- Pages without a French counterpart fall back to English, but new or substantially changed user-facing content should update both locales together.
+
+When adding a page, also add it to `mkdocs.yml` and add any required French navigation label under `nav_translations`.
+
+## Contributing
+
+Start with the [contribution overview](docs/contributing/index.md), then read the [contribution guidelines](docs/contributing/guidelines.md) and [pull-request process](docs/contributing/pull-requests.md).
+
+Documentation should be checked against the current implementation and repository workflows. Do not copy an older README or guide without verifying that its commands, environment variables, routes, and deployment claims still exist.

--- a/docs/contributing/guidelines.fr.md
+++ b/docs/contributing/guidelines.fr.md
@@ -1,131 +1,188 @@
 # Directives de contribution
 
-Ce document décrit les directives pour contribuer à Stocket Inventory.
+Stocket est un projet composé de plusieurs dépôts. Une contribution doit être réalisée et revue dans le dépôt responsable du comportement modifié.
 
-## Workflow de développement
+## Choisir le dépôt responsable
 
-### 1. Fork et clone
+| Domaine | Dépôt |
+| --- | --- |
+| API Effect, base de données, tâches en arrière-plan | `backend` |
+| Application web TanStack Start et PWA | `frontend` |
+| Contrats partagés, modèles d'e-mails, configuration TypeScript et lint | `packages` |
+| Bootstrap du workspace et orchestration des services locaux | `meta` |
+| Terraform, Ansible, Caddy, sauvegardes et opérations de production | `infrastructure` |
+| Client desktop Tauri | `remote-desktop` |
+| Documentation publique | `documentation` |
+| Site marketing | `landing` |
 
-```bash
-# Fork le repository sur GitHub, puis :
-git clone https://github.com/VOTRE-NOM/meta.git
+Si un changement touche plusieurs dépôts, gardez chaque modification indépendante et facile à revoir, puis reliez les pull requests en indiquant explicitement leur ordre de merge.
+
+## Configurer un checkout
+
+Pour une contribution limitée à la documentation, clonez directement ce dépôt :
+
+```sh
+git clone git@github.com:stocketfr/documentation.git
+cd documentation
+```
+
+Pour travailler sur le produit, utilisez le dépôt de contrôle du workspace :
+
+```sh
+mkdir stocketfr
+cd stocketfr
+git clone git@github.com:stocketfr/meta.git
 cd meta
+./scripts/bootstrap
+cd ..
 ```
 
-### 2. Initialiser le workspace
+Le bootstrap clone les dépôts déclarés dans `meta/repos.yaml`, crée l'overlay du workspace local et installe les dépendances JavaScript. L'infrastructure est exploitée dans un dépôt séparé et doit être clonée séparément lorsqu'elle fait partie du changement.
 
-```bash
-# Installer les dépendances et configurer tous les dépôts
-./meta/scripts/bootstrap
+Chaque répertoire enfant reste un dépôt indépendant. Créez les commits et pull requests depuis le dépôt cible, pas depuis la racine générée du workspace.
+
+## Créer une branche ciblée
+
+Créez une branche depuis la branche `main` à jour du dépôt cible :
+
+```sh
+git switch main
+git pull --ff-only
+git switch -c feat/description-courte
 ```
 
-### 3. Créer une branche
+Utilisez un préfixe `fix/`, `docs/`, `refactor/` ou un autre préfixe descriptif lorsqu'il représente mieux le travail. Les personnes qui utilisent un autre client de gestion de versions compatible peuvent suivre le workflow équivalent.
 
-```bash
-git checkout -b feature/nom-de-votre-fonctionnalite
-# ou
-git checkout -b fix/description-du-probleme
-```
+## Réaliser le changement
 
-### 4. Faire des modifications
+- Suivez le [guide de style de code](../development/code-style.md) approprié.
+- Limitez le changement à un résultat cohérent.
+- Ajoutez ou mettez à jour les tests pour tout changement de comportement.
+- Mettez à jour les documentations utilisateur, développeur, opérations et référence lorsque leur comportement observable évolue.
+- Ne commitez pas d'identifiants, de sorties de build générées, de fichiers d'environnement locaux ou de liens symboliques du workspace.
 
-- Suivez le [guide de style de code](../development/code-style.md)
-- Écrivez des tests pour les nouvelles fonctionnalités
-- Mettez à jour la documentation si nécessaire
+### Conventions backend
 
-### 5. Tester vos modifications
+- Utilisez les layers, services, routers et helpers de plateforme Effect actuels sous `backend/src/effect/`.
+- Définissez les contrats publics de requête et de réponse avec les schémas Effect partagés de `@stocket/types` ; le package source publié est `@stocketfr/types`.
+- Appliquez de manière cohérente le contexte tenant, les permissions, les droits liés aux fonctionnalités, la validation et les helpers de mutation auditée.
+- Exécutez les imports longs et les autres travaux durables via le système persistant de tâches en arrière-plan, et non dans une fibre non gérée liée à la requête.
 
-```bash
-# Exécuter le linting backend
+Consultez le [guide de développement API](../development/api-development.md) pour les patterns actuels.
+
+### Conventions frontend
+
+- Préservez la frontière serveur/client de TanStack Start et le proxy same-origin `/api/v1`.
+- Utilisez l'alias source `@/`, la couche de données TanStack Query et les helpers existants de contrôle des routes et fonctionnalités.
+- Respectez la composition StyleX, Tailwind et shadcn déjà utilisée dans la zone modifiée.
+- Ne modifiez pas manuellement l'arbre de routes généré.
+- Prenez en compte le SSR, les hôtes tenant et plateforme, les états de chargement et d'erreur, l'accessibilité et le comportement offline/PWA.
+
+Consultez le [guide de développement frontend](../development/frontend-development.md) pour plus de détails.
+
+### Conventions des packages partagés
+
+- Les packages utilisent le scope de publication `@stocketfr/*`.
+- Ajoutez un Changeset pour chaque modification de package publiable.
+- Générez et buildez les barrels de types avant de les commiter lorsqu'un contrat partagé change.
+- Si nécessaire, coordonnez les changements consommateurs avec la version snapshot immuable publiée par la pull request du package.
+
+### Conventions de documentation
+
+- Les pages anglaises utilisent `nom.md` ; leurs équivalents français utilisent `nom.fr.md`.
+- Gardez les deux langues synchronisées dans leur structure et leurs informations.
+- Vérifiez les commandes, chemins, routes, variables d'environnement et affirmations sur les workflows dans les sources actuelles.
+- Utilisez des liens relatifs pour les pages de ce site et mettez à jour `mkdocs.yml` lors de l'ajout ou du déplacement d'une page.
+
+## Vérifier le changement
+
+Exécutez les vérifications les plus petites qui couvrent le comportement modifié. Les commandes fréquentes incluent :
+
+### Backend, depuis la racine du workspace
+
+```sh
+pnpm --filter @stocket/api type-check
 pnpm --filter @stocket/api lint
-
-# Exécuter le linting frontend
-pnpm --filter @stocket/web lint
-
-# Exécuter les tests backend
 pnpm --filter @stocket/api test
-
-# Exécuter les tests E2E frontend
-pnpm --filter @stocket/web test:e2e
-
-# Build backend pour vérifier les erreurs de type
 pnpm --filter @stocket/api build
+```
 
-# Build frontend pour vérifier les erreurs de type
+Exécutez également `test:integration` lorsque le comportement de la base de données ou HTTP change.
+
+### Frontend, depuis la racine du workspace
+
+```sh
+pnpm --filter @stocket/web validate
+pnpm --filter @stocket/web test:unit
 pnpm --filter @stocket/web build
 ```
 
-### 6. Committer vos modifications
+Exécutez les tests Playwright concernés lorsqu'un parcours utilisateur, une route, l'authentification, la gestion des tenants ou le proxy serveur change.
 
-Utilisez des messages de commit clairs et descriptifs :
+### Packages partagés, depuis `packages/`
 
-```bash
-git commit -m "feat: ajouter la fonctionnalité de recherche de produits"
-git commit -m "fix: résoudre l'erreur de suppression de catégorie"
-git commit -m "docs: mettre à jour le guide de développement API"
+```sh
+pnpm build
+pnpm --filter @stocketfr/emails test
 ```
 
-Suivez le format [Conventional Commits](https://www.conventionalcommits.org/) :
+### Documentation, depuis `documentation/`
 
-- `feat:` - Nouvelle fonctionnalité
-- `fix:` - Correction de bug
-- `docs:` - Modifications de documentation
-- `style:` - Modifications de style de code (formatage, etc.)
-- `refactor:` - Refactoring de code
-- `test:` - Ajout ou mise à jour de tests
-- `chore:` - Tâches de maintenance
-
-### 7. Push et créer une PR
-
-```bash
-git push origin feature/nom-de-votre-fonctionnalite
+```sh
+node scripts/audit-docs.mjs
+mkdocs build --strict
 ```
 
-Puis créez une pull request sur GitHub.
+### Infrastructure, depuis `infrastructure/`
 
-## Standards de code
+```sh
+terraform fmt -check -recursive
+bash tests/production-destroy-guard.spec.sh
+```
 
-### TypeScript
+La CI de l'infrastructure exécute des vérifications supplémentaires : plan Terraform, syntaxe Ansible, sauvegardes, helper de déploiement, Caddy et rendu de la configuration Compose.
 
-- Utiliser TypeScript strict
-- Fournir des types pour tous les paramètres de fonction et valeurs de retour
-- Éviter le type `any`
+### Client desktop, depuis `remote-desktop/`
 
-### Développement API
+```sh
+pnpm lint
+pnpm test
+```
 
-- Suivre le [guide de développement API](../development/api-development.md)
-- Ajouter des décorateurs Swagger pour les nouveaux endpoints
-- Inclure des décorateurs de validation sur les DTOs
+Si une vérification requise dépend d'identifiants indisponibles ou d'une infrastructure externe, indiquez précisément ce qui n'a pas été exécuté et fournissez la meilleure preuve locale disponible.
 
-### Développement Frontend
+## Commiter et pousser
 
-- Suivre le [guide de développement frontend](../development/frontend-development.md)
-- Préférer les composants serveur quand c'est possible
-- Utiliser les hooks API générés
+Utilisez un message de commit clair et à l'impératif. Les préfixes Conventional Commits facilitent la lecture de l'historique :
 
-### Tests
+```sh
+git commit -m "feat: add product search"
+git commit -m "fix: preserve tenant host during sign-in"
+git commit -m "docs: refresh workspace setup"
+```
 
-- Écrire des tests unitaires pour les nouvelles fonctionnalités
-- Suivre le [guide de tests](../development/testing.md)
-- Viser une couverture de tests significative
+Poussez la branche et ouvrez une pull request dans le même dépôt :
 
-## Documentation
+```sh
+git push --set-upstream origin feat/description-courte
+```
 
-Lors de vos contributions :
+Suivez ensuite le [processus de pull request](pull-requests.md).
 
-- Mettez à jour la documentation pertinente
-- Ajoutez des commentaires JSDoc pour les APIs publiques
-- Incluez des exemples pour les fonctionnalités complexes
+## Critères de review
 
-## Processus de review
+Les reviewers doivent pouvoir déterminer :
 
-1. **Vérifications automatiques** - La CI doit passer
-2. **Code review** - Au moins une approbation requise
-3. **Review de documentation** - Pour les changements significatifs
-4. **Merge** - Squash and merge vers main
+1. Quel résultat utilisateur ou opérationnel évolue.
+2. Pourquoi ce dépôt est responsable du changement.
+3. Comment l'implémentation respecte la gestion des tenants, les permissions, la sécurité et la compatibilité.
+4. Quelles vérifications automatiques et manuelles ont été exécutées.
+5. Quelles documentations ou pull requests associées complètent le changement.
+
+Gardez les échanges techniques et concrets. Résolvez ou répondez explicitement aux fils de review avant de demander une nouvelle review.
 
 ## Obtenir de l'aide
 
-- Consultez les issues et la documentation existantes
-- Posez des questions dans votre PR
-- Contactez les mainteneurs
+- Lisez les guides de développement et de référence concernés.
+- Recherchez dans les issues et pull requests du dépôt responsable.
+- Posez une question précise dans l'issue ou la pull request, en incluant les éléments déjà recueillis.

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -1,131 +1,188 @@
 # Contribution Guidelines
 
-This document outlines the guidelines for contributing to Stocket Inventory.
+Stocket is a multi-repository project. A contribution should be made and reviewed in the repository that owns the behavior being changed.
 
-## Development Workflow
+## Choose the owning repository
 
-### 1. Fork and Clone
+| Area | Repository |
+| --- | --- |
+| Effect API, database, background tasks | `backend` |
+| TanStack Start web application and PWA | `frontend` |
+| Shared contracts, email templates, TypeScript and lint configuration | `packages` |
+| Workspace bootstrap and local service orchestration | `meta` |
+| Terraform, Ansible, Caddy, backups and production operations | `infrastructure` |
+| Tauri desktop client | `remote-desktop` |
+| Public documentation | `documentation` |
+| Marketing site | `landing` |
 
-```bash
-# Fork the repository on GitHub, then:
-git clone https://github.com/YOUR-USERNAME/meta.git
+If a change spans repositories, keep each repository's change independently reviewable and connect the pull requests with links and an explicit merge order.
+
+## Set up a checkout
+
+For a documentation-only contribution, clone this repository directly:
+
+```sh
+git clone git@github.com:stocketfr/documentation.git
+cd documentation
+```
+
+For product work, use the workspace control plane:
+
+```sh
+mkdir stocketfr
+cd stocketfr
+git clone git@github.com:stocketfr/meta.git
 cd meta
+./scripts/bootstrap
+cd ..
 ```
 
-### 2. Bootstrap the Workspace
+Bootstrap clones the repositories declared in `meta/repos.yaml`, creates the local workspace overlay, and installs JavaScript dependencies. Infrastructure is operated as a separate repository and must be cloned separately when it is part of the change.
 
-```bash
-# Install dependencies and set up all repos
-./meta/scripts/bootstrap
+Each child directory remains an independent repository. Create commits and pull requests from the target repository, not from the generated workspace root.
+
+## Create a focused branch
+
+Create a branch from the current `main` branch of the target repository:
+
+```sh
+git switch main
+git pull --ff-only
+git switch -c feat/short-description
 ```
 
-### 3. Create a Branch
+Use a `fix/`, `docs/`, `refactor/`, or similarly descriptive prefix when it better represents the work. Contributors using another compatible version-control client can follow the equivalent workflow.
 
-```bash
-git checkout -b feature/your-feature-name
-# or
-git checkout -b fix/issue-description
-```
+## Make the change
 
-### 4. Make Changes
+- Follow the relevant [code style guide](../development/code-style.md).
+- Keep the change scoped to one coherent outcome.
+- Add or update tests for behavior changes.
+- Update user, developer, operations, and reference documentation when their observable behavior changes.
+- Do not commit credentials, generated build output, local environment files, or workspace symlinks.
 
-- Follow the [code style guide](../development/code-style.md)
-- Write tests for new functionality
-- Update documentation as needed
+### Backend conventions
 
-### 5. Test Your Changes
+- Use the current Effect layers, services, routers, and platform helpers under `backend/src/effect/`.
+- Define public request and response contracts with shared Effect schemas from `@stocket/types`; the published source package is `@stocketfr/types`.
+- Apply tenant context, permissions, feature entitlements, validation, and audited mutation helpers consistently.
+- Run long-running imports and other durable work through the persisted background-task system rather than an unmanaged request fiber.
 
-```bash
-# Run backend linting
+See the [API development guide](../development/api-development.md) for the current patterns.
+
+### Frontend conventions
+
+- Preserve TanStack Start's server/client boundary and the same-origin `/api/v1` proxy.
+- Use the `@/` source alias, TanStack Query data layer, and the existing route access and feature-gate helpers.
+- Follow the established StyleX, Tailwind, and shadcn composition in the area being changed.
+- Do not edit generated route-tree output manually.
+- Consider SSR, tenant and platform hosts, loading/error states, accessibility, and offline/PWA behavior.
+
+See the [frontend development guide](../development/frontend-development.md) for details.
+
+### Shared package conventions
+
+- Package names use the `@stocketfr/*` publishing scope.
+- Add a Changeset for every publishable package change.
+- Build regenerated type barrels before committing them when shared contracts change.
+- Coordinate consumer changes with the immutable snapshot version published by the package pull request when necessary.
+
+### Documentation conventions
+
+- English pages use `name.md`; French counterparts use `name.fr.md`.
+- Keep both locales structurally and factually synchronized.
+- Verify commands, paths, routes, environment variables, and workflow claims against current source files.
+- Use relative links for pages within this site and update `mkdocs.yml` when adding or moving a page.
+
+## Verify the change
+
+Run the smallest checks that cover the changed behavior. Common checks include:
+
+### Backend, from the workspace root
+
+```sh
+pnpm --filter @stocket/api type-check
 pnpm --filter @stocket/api lint
-
-# Run frontend linting
-pnpm --filter @stocket/web lint
-
-# Run backend tests
 pnpm --filter @stocket/api test
-
-# Run frontend E2E tests
-pnpm --filter @stocket/web test:e2e
-
-# Build backend to check for type errors
 pnpm --filter @stocket/api build
+```
 
-# Build frontend to check for type errors
+Run `test:integration` as well when database or HTTP behavior changes.
+
+### Frontend, from the workspace root
+
+```sh
+pnpm --filter @stocket/web validate
+pnpm --filter @stocket/web test:unit
 pnpm --filter @stocket/web build
 ```
 
-### 6. Commit Your Changes
+Run the relevant Playwright tests when a user flow, route, authentication, tenancy, or server-proxy behavior changes.
 
-Use clear, descriptive commit messages:
+### Shared packages, from `packages/`
 
-```bash
-git commit -m "feat: add product search functionality"
-git commit -m "fix: resolve category deletion error"
-git commit -m "docs: update API development guide"
+```sh
+pnpm build
+pnpm --filter @stocketfr/emails test
 ```
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+### Documentation, from `documentation/`
 
-- `feat:` - New feature
-- `fix:` - Bug fix
-- `docs:` - Documentation changes
-- `style:` - Code style changes (formatting, etc.)
-- `refactor:` - Code refactoring
-- `test:` - Adding or updating tests
-- `chore:` - Maintenance tasks
-
-### 7. Push and Create PR
-
-```bash
-git push origin feature/your-feature-name
+```sh
+node scripts/audit-docs.mjs
+mkdocs build --strict
 ```
 
-Then create a pull request on GitHub.
+### Infrastructure, from `infrastructure/`
 
-## Code Standards
+```sh
+terraform fmt -check -recursive
+bash tests/production-destroy-guard.spec.sh
+```
 
-### TypeScript
+Infrastructure CI performs additional Terraform planning, Ansible syntax, backup, deploy-helper, Caddy, and rendered Compose checks.
 
-- Use strict TypeScript
-- Provide types for all function parameters and return values
-- Avoid `any` type
+### Remote desktop, from `remote-desktop/`
 
-### API Development
+```sh
+pnpm lint
+pnpm test
+```
 
-- Follow the [API development guide](../development/api-development.md)
-- Add Swagger decorators for new endpoints
-- Include validation decorators on DTOs
+If a required check needs unavailable credentials or external infrastructure, state exactly what was not run and provide the strongest local evidence available.
 
-### Frontend Development
+## Commit and push
 
-- Follow the [frontend development guide](../development/frontend-development.md)
-- Prefer server components when possible
-- Use generated API hooks
+Use a clear, imperative commit message. Conventional Commit prefixes make repository history easier to scan:
 
-### Testing
+```sh
+git commit -m "feat: add product search"
+git commit -m "fix: preserve tenant host during sign-in"
+git commit -m "docs: refresh workspace setup"
+```
 
-- Write unit tests for new functionality
-- Follow the [testing guide](../development/testing.md)
-- Aim for meaningful test coverage
+Push the branch and open a pull request in the same repository:
 
-## Documentation
+```sh
+git push --set-upstream origin feat/short-description
+```
 
-When contributing:
+Then follow the [pull-request process](pull-requests.md).
 
-- Update relevant documentation
-- Add JSDoc comments for public APIs
-- Include examples for complex functionality
+## Review standards
 
-## Review Process
+Reviewers should be able to determine:
 
-1. **Automated checks** - CI must pass
-2. **Code review** - At least one approval required
-3. **Documentation review** - For significant changes
-4. **Merge** - Squash and merge to main
+1. What user or operational outcome changes.
+2. Why this repository owns the change.
+3. How the implementation respects tenancy, permissions, security, and compatibility.
+4. Which automated and manual checks were run.
+5. Which documentation or companion pull requests complete the change.
 
-## Getting Help
+Keep discussion technical and concrete. Resolve or explicitly answer review threads before requesting another review.
 
-- Check existing issues and documentation
-- Ask questions in your PR
-- Reach out to maintainers
+## Getting help
+
+- Read the relevant development and reference guides.
+- Search issues and pull requests in the owning repository.
+- Ask a focused question in the issue or pull request, including the evidence already collected.

--- a/docs/contributing/index.fr.md
+++ b/docs/contributing/index.fr.md
@@ -1,29 +1,38 @@
 # Contribuer
 
-Merci de votre intérêt pour contribuer à Stocket Inventory ! Cette section explique comment contribuer au projet.
+Merci d'aider à améliorer Stocket. Les contributions peuvent concerner le produit, ses projets associés ou cette documentation.
+
+## Un projet composé de plusieurs dépôts
+
+Stocket est développé dans des dépôts séparés pour le backend, le frontend, les packages partagés, l'infrastructure, le client desktop, la landing page, la documentation et les outils du workspace. Le dépôt `meta` assemble ces projets dans un workspace local pratique, mais chaque projet conserve son propre historique, sa CI et ses pull requests.
+
+Ouvrez une issue ou une pull request dans le dépôt responsable du changement. Utilisez le [suivi des issues de la documentation](https://github.com/stocketfr/documentation/issues) pour ce site et le dépôt du projet concerné pour les problèmes d'implémentation. Les changements qui touchent plusieurs dépôts doivent utiliser des pull requests liées plutôt que mélanger des historiques indépendants.
 
 ## Façons de contribuer
 
-- **Signaler des bugs** - Trouvé un problème ? [Ouvrez une issue](https://github.com/stocketfr/meta/issues)
-- **Suggérer des fonctionnalités** - Vous avez une idée ? Partagez-la avec nous
-- **Soumettre du code** - Corriger des bugs ou ajouter des fonctionnalités
-- **Améliorer la documentation** - Aider les autres à comprendre le projet
+- **Signaler un défaut** — Indiquez les étapes de reproduction, le comportement attendu et le projet concerné.
+- **Proposer une amélioration** — Expliquez le problème utilisateur et le résultat souhaité.
+- **Soumettre du code** — Corrigez un bug, ajoutez une fonctionnalité testée ou améliorez la maintenabilité.
+- **Améliorer la documentation** — Corrigez un comportement obsolète, ajoutez des exemples ou maintenez les contenus anglais et français alignés.
 
 ## Pour commencer
 
-1. **Lire les directives** - Consultez nos [directives de contribution](guidelines.md)
-2. **Configurer votre environnement** - Suivez la [configuration de développement](../development/setup.md)
-3. **Trouver une issue** - Cherchez les labels `good first issue`
-4. **Soumettre une PR** - Suivez notre [processus de pull request](pull-requests.md)
+1. Lisez les [directives de contribution](guidelines.md).
+2. Suivez la [configuration de développement](../development/setup.md) pour un workspace complet, ou clonez uniquement le dépôt nécessaire.
+3. Confirmez le problème et le dépôt qui en est responsable avant de modifier le code.
+4. Réalisez le plus petit changement cohérent et vérifiez-le localement.
+5. Suivez le [processus de pull request](pull-requests.md).
 
-## Code de conduite
+## Exigences documentaires
 
-Nous nous engageons à fournir un environnement accueillant et inclusif. Soyez respectueux et constructif dans toutes vos interactions.
+Considérez le code source actuel, les manifests de packages, les modèles d'environnement et les workflows CI comme les sources de vérité. Si un changement produit affecte les utilisateurs, l'exploitation, la configuration ou les contrats publics, mettez à jour le guide concerné dans le même travail. Gardez les versions anglaises et françaises synchronisées.
 
-## Questions ?
+## Conduite
 
-Si vous avez des questions sur la contribution :
+Soyez respectueux, constructif et précis. Présumez de la bonne foi, discutez ouvertement des compromis techniques et ne partagez jamais d'identifiants, de données client ou d'autres informations sensibles dans les issues et pull requests.
 
-- Consultez les [issues](https://github.com/stocketfr/meta/issues) existantes
-- Parcourez la [documentation](../index.md)
-- Posez vos questions dans les discussions
+## Obtenir de l'aide
+
+- Recherchez dans les issues et pull requests existantes du dépôt concerné.
+- Consultez la [documentation de développement](../development/index.md) et la [carte des projets](../development/project-map.md).
+- Posez une question précise dans l'issue ou la pull request qui contient déjà le contexte.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,29 +1,38 @@
 # Contributing
 
-Thank you for your interest in contributing to Stocket Inventory! This section covers how to contribute to the project.
+Thank you for helping improve Stocket. Contributions can cover the product, its supporting projects, or this documentation.
 
-## Ways to Contribute
+## A multi-repository project
 
-- **Report bugs** - Found an issue? [Open an issue](https://github.com/stocketfr/meta/issues)
-- **Suggest features** - Have an idea? Share it with us
-- **Submit code** - Fix bugs or add features
-- **Improve documentation** - Help others understand the project
+Stocket is developed across separate repositories for the backend, frontend, shared packages, infrastructure, desktop client, landing page, documentation, and workspace tooling. The `meta` repository assembles these projects into a convenient local workspace, but each project keeps its own history, CI workflow, and pull requests.
 
-## Getting Started
+Open an issue or pull request in the repository that owns the change. Use the [documentation issue tracker](https://github.com/stocketfr/documentation/issues) for this site and the relevant project repository for implementation issues. Cross-repository work should use linked pull requests rather than combining unrelated histories.
 
-1. **Read the guidelines** - Review our [contribution guidelines](guidelines.md)
-2. **Set up your environment** - Follow the [development setup](../development/setup.md)
-3. **Find an issue** - Look for `good first issue` labels
-4. **Submit a PR** - Follow our [pull request process](pull-requests.md)
+## Ways to contribute
 
-## Code of Conduct
+- **Report a defect** — Include reproducible steps, expected behavior, and the affected project.
+- **Suggest an improvement** — Explain the user problem and the desired outcome.
+- **Submit code** — Fix a bug, add a tested feature, or improve maintainability.
+- **Improve documentation** — Correct stale behavior, add examples, or keep English and French content aligned.
 
-We are committed to providing a welcoming and inclusive environment. Please be respectful and constructive in all interactions.
+## Getting started
 
-## Questions?
+1. Read the [contribution guidelines](guidelines.md).
+2. Follow the [development setup](../development/setup.md) for a full workspace, or clone only the repository you need.
+3. Confirm the issue and its owning repository before changing code.
+4. Make the smallest coherent change and verify it locally.
+5. Follow the [pull-request process](pull-requests.md).
 
-If you have questions about contributing:
+## Documentation expectations
 
-- Check existing [issues](https://github.com/stocketfr/meta/issues)
-- Review the [documentation](../index.md)
-- Ask in discussions
+Treat current source code, package manifests, environment templates, and CI workflows as the source of truth. If a product change affects users, operations, configuration, or public contracts, update the relevant guide in the same work. Keep English and French counterparts synchronized.
+
+## Conduct
+
+Be respectful, constructive, and specific. Assume good intent, discuss technical trade-offs openly, and avoid sharing credentials, customer data, or other sensitive information in issues and pull requests.
+
+## Getting help
+
+- Search the relevant repository's existing issues and pull requests.
+- Review the [development documentation](../development/index.md) and [project map](../development/project-map.md).
+- Ask a focused question in the issue or pull request where the context already exists.

--- a/docs/contributing/pull-requests.fr.md
+++ b/docs/contributing/pull-requests.fr.md
@@ -1,145 +1,137 @@
-# Processus de Pull Request
+# Processus de pull request
 
-Ce guide explique comment créer et gérer les pull requests pour Stocket Inventory.
+Les pull requests sont propres à chaque dépôt. Ouvrez la pull request dans le dépôt responsable du changement, même si vous l'avez développé depuis le workspace local combiné.
 
-## Créer une Pull Request
+## Avant d'ouvrir une pull request
 
-### Prérequis
+Vérifiez que :
 
-Avant de créer une PR :
+- La branche contient un seul changement cohérent, sans fichiers générés du workspace ni modifications sans rapport.
+- Les tests, le lint, la vérification des types et les builds pertinents ont été exécutés comme indiqué dans les [directives de contribution](guidelines.md).
+- Le nouveau comportement dispose de tests ciblés, ou la description explique pourquoi un test automatique n'est pas réalisable.
+- Les documentations utilisateur, développeur, opérations et référence ont été mises à jour si nécessaire.
+- Les versions anglaises et françaises de la documentation restent synchronisées.
+- Aucun identifiant, token, donnée de production, fichier d'environnement local ou log sensible n'est présent.
+- La branche repose sur une version suffisamment récente de `main` pour que le résultat CI soit pertinent.
 
-1. **Les tests passent localement**
-   ```bash
-   pnpm --filter @stocket/api test
-   pnpm --filter @stocket/web test:e2e
-   ```
+N'exécutez pas systématiquement toutes les vérifications de tous les projets. Exécutez localement le plus petit ensemble pertinent et laissez la CI du dépôt cible appliquer la validation complète du dépôt.
 
-2. **Le linting passe**
-   ```bash
-   pnpm --filter @stocket/api lint
-   pnpm --filter @stocket/web lint
-   ```
+## Changements multi-dépôts
 
-3. **Le build réussit**
-   ```bash
-   pnpm --filter @stocket/api build
-   pnpm --filter @stocket/web build
-   ```
+Un checkout du workspace ne transforme pas les projets en un dépôt unique. Lorsqu'un changement touche plusieurs dépôts :
 
-4. **La branche est à jour**
-   ```bash
-   git fetch origin
-   git rebase origin/main
-   ```
+1. Ouvrez une pull request séparée dans chaque dépôt concerné.
+2. Liez toutes les pull requests associées dans chaque description.
+3. Indiquez les dépendances et l'ordre de merge.
+4. Préservez autant que possible la compatibilité pendant la transition.
+5. Pour un changement publiable d'un package `@stocketfr/*`, ajoutez un Changeset et utilisez si nécessaire la version snapshot publiée par la pull request du package pour tester les pull requests consommatrices.
+6. Mettez à jour cette documentation avec le comportement public qui existera une fois l'ensemble mergé.
 
-### Template de PR
+Ne présentez pas une pull request associée comme déployée simplement parce qu'elle a été mergée. L'automatisation des releases et déploiements varie selon le dépôt.
 
-Lors de la création d'une PR, incluez :
+## Description de la pull request
+
+Utilisez une description qui donne aux reviewers assez d'éléments pour évaluer le résultat :
 
 ```markdown
 ## Résumé
 
-Brève description des changements.
+Décrivez le résultat utilisateur ou opérationnel et la raison du changement.
 
 ## Changements
 
-- Ajout de la fonctionnalité X
-- Correction du bug Y
-- Mise à jour de la documentation Z
+- Décrivez les modifications d'implémentation importantes.
+- Signalez les migrations, décisions de compatibilité ou comportements sensibles pour la sécurité.
 
-## Plan de test
+## Travaux liés
 
-- [ ] Tests unitaires ajoutés/mis à jour
-- [ ] Tests manuels effectués
-- [ ] Documentation mise à jour
+- Closes #123
+- Depends on stocketfr/packages#456
+- Companion documentation: stocketfr/documentation#789
 
-## Captures d'écran (si applicable)
+## Vérification
 
-[Ajouter des captures pour les changements UI]
+- `commande exécutée` — réussie
+- Scénario manuel — résultat
+- Non exécuté : vérification et raison
+
+## Documentation
+
+- [ ] Documentation utilisateur/développeur/référence mise à jour
+- [ ] Versions anglaises et françaises synchronisées
+- [ ] Aucun changement documentaire requis, avec justification
+
+## Captures d'écran
+
+Ajoutez des captures avant/après ou un court enregistrement pour les changements visuels.
 ```
 
-## Processus de review
+Supprimez les sections qui ne s'appliquent réellement pas, mais conservez toujours un résumé concret et les preuves de vérification.
 
-### 1. Vérifications automatiques
+## Vérifications automatiques
 
-Quand vous ouvrez une PR, les vérifications suivantes s'exécutent automatiquement :
+Les vérifications sont définies par dépôt dans l'architecture actuelle :
 
-- **Linting** - Validation du style de code
-- **Vérification des types** - Compilation TypeScript
-- **Tests** - Tests unitaires et d'intégration
-- **Build** - Vérifier que tous les packages buildent
+| Dépôt | Vérifications des pull requests |
+| --- | --- |
+| `backend` | Audit des dépendances, lint, vérification des types, tests unitaires, tests d'intégration PostgreSQL, build Node 22 |
+| `frontend` | Audit des dépendances, lint, formatage, vérification des types, tests unitaires, build de production, tests Playwright full-stack avec PostgreSQL et stockage compatible S3 |
+| `packages` | Build des packages ; les changements publiables peuvent aussi produire des snapshots immuables de PR |
+| `documentation` | `node scripts/audit-docs.mjs` pour parité/liens/nav, puis `mkdocs build --strict` pour les deux langues |
+| `infrastructure` | Tests du garde-fou de destruction, formatage/validation/plan Terraform, vérifications Ansible et des services rendus |
+| `remote-desktop` | Lint de l'interface et tests unitaires |
 
-Toutes les vérifications doivent passer avant le merge.
+Les dépôts `meta` et `landing` n'ont actuellement aucun workflow local de pull request. Leur description doit donc préciser les vérifications manuelles effectuées.
 
-### 2. Code Review
+Les pull requests backend et frontend valident les artefacts applicatifs sans les publier ni les déployer. Le chemin ponctuel de juillet 2026 était un dispatch manuel séparé, limité au `main` courant après réussite de sa CI push. L'application de l'infrastructure est aussi une action manuelle protégée et séparée ; un plan réussi ne modifie pas la production.
 
-- Au moins une approbation est requise
-- Les reviewers vérifieront :
-    - Qualité et style du code
-    - Couverture de tests
-    - Mises à jour de documentation
-    - Considérations de sécurité
+Toutes les vérifications requises du dépôt cible doivent réussir avant le merge. Si une vérification échoue pour une raison sans rapport avec la pull request, documentez les preuves au lieu de relancer aveuglément ou d'affaiblir la vérification.
 
-### 3. Répondre aux retours
+## Review
 
-- Répondez à tous les commentaires
-- Poussez des commits supplémentaires pour adresser les retours
-- Demandez une nouvelle review après les changements
+Les reviewers évaluent :
 
-## Merge
+- La correction et la clarté de l'implémentation.
+- L'isolation des tenants, l'autorisation, la gestion des secrets et les autres frontières de sécurité.
+- La compatibilité des contrats partagés et des dépendances multi-dépôts.
+- La qualité des tests et les comportements d'échec.
+- L'expérience utilisateur, l'accessibilité, le SSR et les implications offline pour le frontend.
+- La sécurité opérationnelle, les possibilités de rollback/récupération et l'observabilité pour l'infrastructure ou les traitements en arrière-plan.
+- L'exactitude et la parité linguistique de la documentation.
 
-Une fois approuvé :
+Répondez à chaque fil de discussion actionnable. Poussez des commits de suivi ciblés, expliquez les désaccords avec des éléments techniques et demandez une nouvelle review lorsque les échanges et les vérifications sont à jour.
 
-1. **Squash and merge** - Stratégie de merge par défaut
-2. **Supprimer la branche** - Nettoyer après le merge
-3. **CI sur main** - Vérifier le merge
+## Mettre à jour la branche
 
-## Bonnes pratiques
+Si la branche cible a évolué et que la pull request ne peut plus être mergée ou que son résultat est obsolète, mettez votre branche à jour selon le workflow accepté par le dépôt. Pour une branche de fonctionnalité privée, un rebase peut être effectué avec :
 
-### Garder les PRs petites
-
-- Plus faciles à review
-- Plus rapides à merger
-- Moins de risque de conflits
-
-### Écrire des descriptions claires
-
-- Expliquer le "pourquoi", pas seulement le "quoi"
-- Lier aux issues concernées
-- Inclure du contexte pour les reviewers
-
-### Répondre rapidement
-
-- Adresser les retours rapidement
-- Maintenir la conversation en mouvement
-- Poser des questions si quelque chose n'est pas clair
-
-### Mettre à jour la documentation
-
-- Changements README si nécessaire
-- Documentation API pour les nouveaux endpoints
-- Guide utilisateur pour les nouvelles fonctionnalités
-
-## Gérer les conflits de merge
-
-Si des conflits surviennent :
-
-```bash
-# Mettre à jour votre branche
+```sh
 git fetch origin
 git rebase origin/main
-
-# Résoudre les conflits
-# Éditer les fichiers en conflit
-git add <fichiers-resolus>
-git rebase --continue
-
-# Force push (uniquement pour les branches de PR)
 git push --force-with-lease
 ```
 
+Ne force-pushez jamais une branche partagée sans coordination avec ses autres contributeurs. Résolvez les conflits dans le dépôt responsable et réexécutez les vérifications affectées.
+
+## Frontières de merge et de release
+
+Les mainteneurs mergent après la review et la réussite des vérifications requises. Le merge n'a pas le même effet dans chaque dépôt :
+
+- `documentation` : un push sur `main` exécute le workflow de déploiement GitHub Pages.
+- `packages` : Changesets met à jour ou crée une pull request de release ; le merge de cette pull request de versions publie les packages stables et les releases GitHub.
+- `infrastructure` : l'application en production requiert une option explicite du workflow et un environnement protégé ; le merge d'un plan ne l'applique pas.
+- `remote-desktop` : le packaging est géré par un workflow de release séparé déclenché par tag ou dispatch, et non par la CI normale.
+- `backend` et `frontend` : le merge ne publie ni ne déploie automatiquement.
+  Un workflow ponctuel temporaire, lorsqu'il existe pour un rollout audité,
+  exige encore un dispatch explicite et n'accepte que le `main` courant après
+  une CI réussie.
+
+Lorsqu'un rollout, une migration, une publication de package ou une vérification manuelle reste à effectuer, gardez l'issue associée ouverte jusqu'à la fin de ce travail.
+
 ## Après le merge
 
-- Supprimer votre branche de fonctionnalité
-- Vérifier que la CI passe sur main
-- Vérifier le déploiement (si applicable)
+- Supprimez la branche de fonctionnalité lorsqu'elle n'est plus nécessaire.
+- Vérifiez que les issues liées et les pull requests associées reflètent le travail réellement restant.
+- Pour la documentation, vérifiez le workflow Pages et la navigation publiée.
+- Pour les packages, suivez la pull request de release Changesets jusqu'aux mises à jour des consommateurs.
+- Créez une issue pour tout nettoyage ou suivi opérationnel différé au lieu de le laisser uniquement dans une discussion mergée.

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -1,145 +1,136 @@
 # Pull Request Process
 
-This guide explains how to create and manage pull requests for Stocket Inventory.
+Pull requests are repository-scoped. Open the pull request in the repository that owns the change, even when you developed it through the combined local workspace.
 
-## Creating a Pull Request
+## Before opening a pull request
 
-### Prerequisites
+Confirm that:
 
-Before creating a PR:
+- The branch contains one coherent change and does not include generated workspace files or unrelated edits.
+- Relevant tests, linting, type checks, and builds have been run as described in the [contribution guidelines](guidelines.md).
+- New behavior has focused tests, or the description explains why an automated test is not practical.
+- User, developer, operations, and reference documentation have been updated where applicable.
+- English and French documentation counterparts remain synchronized.
+- No credentials, tokens, production data, local environment files, or sensitive logs are present.
+- The branch is based on a sufficiently recent `main` to make the CI result meaningful.
 
-1. **Tests pass locally**
-   ```bash
-   pnpm --filter @stocket/api test
-   pnpm --filter @stocket/web test:e2e
-   ```
+Do not run every project check by default. Run the smallest relevant set locally and let the target repository's CI provide the full repository gate.
 
-2. **Linting passes**
-   ```bash
-   pnpm --filter @stocket/api lint
-   pnpm --filter @stocket/web lint
-   ```
+## Cross-repository changes
 
-3. **Build succeeds**
-   ```bash
-   pnpm --filter @stocket/api build
-   pnpm --filter @stocket/web build
-   ```
+A workspace checkout does not turn the projects into one repository. When a change spans repositories:
 
-4. **Branch is up to date**
-   ```bash
-   git fetch origin
-   git rebase origin/main
-   ```
+1. Open a separate pull request in each affected repository.
+2. Link every companion pull request in each description.
+3. State the dependency and merge order.
+4. Keep compatibility across the transition whenever possible.
+5. For a publishable `@stocketfr/*` package change, include a Changeset and use the package pull request's snapshot version to test consumer pull requests when needed.
+6. Update this documentation with the public behavior that will exist after the complete set lands.
 
-### PR Template
+Do not describe a companion pull request as deployed merely because it has merged. Release and deployment automation differs by repository.
 
-When creating a PR, include:
+## Pull-request description
+
+Use a description that gives reviewers enough evidence to evaluate the outcome:
 
 ```markdown
 ## Summary
 
-Brief description of the changes.
+Describe the user or operational outcome and why the change is needed.
 
 ## Changes
 
-- Added X feature
-- Fixed Y bug
-- Updated Z documentation
+- Describe the important implementation changes.
+- Call out migrations, compatibility decisions, or security-sensitive behavior.
 
-## Test Plan
+## Related work
 
-- [ ] Unit tests added/updated
-- [ ] Manual testing performed
-- [ ] Documentation updated
+- Closes #123
+- Depends on stocketfr/packages#456
+- Companion documentation: stocketfr/documentation#789
 
-## Screenshots (if applicable)
+## Verification
 
-[Add screenshots for UI changes]
+- `command that was run` — passed
+- Manual scenario — result
+- Not run: check and reason
+
+## Documentation
+
+- [ ] User/developer/reference documentation updated
+- [ ] English and French counterparts synchronized
+- [ ] No documentation change required, with reason
+
+## Screenshots
+
+Add before/after screenshots or a short recording for visible UI changes.
 ```
 
-## Review Process
+Remove sections that genuinely do not apply, but always retain a concrete summary and verification evidence.
 
-### 1. Automated Checks
+## Automated checks
 
-When you open a PR, the following checks run automatically:
+Checks are defined per repository at the current architecture:
 
-- **Linting** - Code style validation
-- **Type checking** - TypeScript compilation
-- **Tests** - Unit and integration tests
-- **Build** - Ensure all packages build
+| Repository | Pull-request checks |
+| --- | --- |
+| `backend` | Dependency audit, lint, type check, unit tests, PostgreSQL integration tests, Node 22 build |
+| `frontend` | Dependency audit, lint, formatting, type check, unit tests, production build, full-stack Playwright tests with Postgres and S3-compatible storage |
+| `packages` | Package build; publishable changes can also produce immutable PR snapshots |
+| `documentation` | `node scripts/audit-docs.mjs` for parity/links/nav, then `mkdocs build --strict` for both locales |
+| `infrastructure` | Destroy-guard tests, Terraform format/validate/plan, Ansible and rendered-service checks |
+| `remote-desktop` | UI lint and unit tests |
 
-All checks must pass before merging.
+The `meta` and `landing` repositories currently have no repository-local pull-request workflow, so their descriptions must identify the manual checks that were performed.
 
-### 2. Code Review
+Backend and frontend pull requests validate application artifacts but do not publish or deploy them. The temporary July 2026 one-off rollout path was a separate manual dispatch restricted to current `main` after successful push CI. Infrastructure apply is also a separate, protected manual action; a successful plan does not change production.
 
-- At least one approval is required
-- Reviewers will check:
-    - Code quality and style
-    - Test coverage
-    - Documentation updates
-    - Security considerations
+All required checks for the target repository must pass before merge. If a check fails for a reason unrelated to the pull request, document the evidence rather than retrying blindly or weakening the check.
 
-### 3. Addressing Feedback
+## Review
 
-- Respond to all comments
-- Push additional commits to address feedback
-- Request re-review after changes
+Reviewers evaluate:
 
-## Merging
+- Correctness and clarity of the implementation.
+- Tenant isolation, authorization, secrets handling, and other security boundaries.
+- Compatibility of shared contracts and cross-repository dependencies.
+- Test quality and failure behavior.
+- User experience, accessibility, SSR, and offline implications for frontend work.
+- Operational safety, rollback/recovery considerations, and observability for infrastructure or background work.
+- Accuracy and language parity of documentation.
 
-Once approved:
+Respond to each actionable thread. Push focused follow-up commits, explain disagreements with technical evidence, and request another review once the discussion and checks are current.
 
-1. **Squash and merge** - Default merge strategy
-2. **Delete branch** - Clean up after merge
-3. **CI runs on main** - Verify the merge
+## Updating the branch
 
-## Best Practices
+If the target branch has moved and the pull request cannot be merged or its result is stale, update your branch using the repository's accepted workflow. For a private feature branch, a rebase can be performed with:
 
-### Keep PRs Small
-
-- Easier to review
-- Faster to merge
-- Less risk of conflicts
-
-### Write Clear Descriptions
-
-- Explain the "why", not just the "what"
-- Link to related issues
-- Include context for reviewers
-
-### Respond Promptly
-
-- Address feedback quickly
-- Keep the conversation moving
-- Ask questions if unclear
-
-### Update Documentation
-
-- README changes if needed
-- API documentation for new endpoints
-- User guide for new features
-
-## Handling Merge Conflicts
-
-If conflicts arise:
-
-```bash
-# Update your branch
+```sh
 git fetch origin
 git rebase origin/main
-
-# Resolve conflicts
-# Edit conflicting files
-git add <resolved-files>
-git rebase --continue
-
-# Force push (only for PR branches)
 git push --force-with-lease
 ```
 
-## After Merging
+Never force-push a shared branch without coordinating with its other contributors. Resolve conflicts in the owning repository and rerun the affected checks.
 
-- Delete your feature branch
-- Verify CI passes on main
-- Check the deployment (if applicable)
+## Merge and release boundaries
+
+Maintainers merge after review and required checks. Merge does not have the same downstream effect in every repository:
+
+- `documentation`: a push to `main` runs the GitHub Pages deployment workflow.
+- `packages`: Changesets updates or creates a release pull request; merging that version pull request publishes stable packages and GitHub releases.
+- `infrastructure`: production apply requires an explicit workflow input and protected environment; merging a plan does not apply it.
+- `remote-desktop`: packaging is handled by a separate tag or dispatch release workflow, not by normal CI.
+- `backend` and `frontend`: merge does not publish or deploy automatically. A
+  temporary one-off workflow, when present for an audited rollout, still needs
+  an explicit dispatch and accepts only current `main` after successful CI.
+
+Where rollout, migration, package publication, or manual verification remains, keep the related issue open until that work is complete.
+
+## After merge
+
+- Remove the feature branch when it is no longer needed.
+- Confirm linked issues and companion pull requests reflect the actual remaining work.
+- For documentation changes, verify the Pages workflow and published navigation.
+- For package changes, follow the Changesets release pull request through consumer updates.
+- Record any deferred cleanup or operational follow-up as an issue rather than leaving it only in a merged discussion.

--- a/docs/development/api-development.fr.md
+++ b/docs/development/api-development.fr.md
@@ -1,376 +1,378 @@
 # Développement API
 
-Ce guide couvre les patterns de développement Effect.ts pour le backend Stocket Inventory, qui tourne sur Bun avec Drizzle ORM et PostgreSQL.
+Le backend Stocket s'exécute avec Node.js 22, Effect, Drizzle ORM et PostgreSQL. `tsx` lance les points d'entrée de développement ; esbuild produit des bundles CommonJS pour Node 22 en production. Bun n'est pas le runtime du backend.
 
-## Structure des modules
+## Runtime et composition de l'application
 
-Chaque fonctionnalité suit cette structure :
+Les points d'entrée restent volontairement légers :
 
-```
-modules/<feature>/
-├── router.ts              # Gestionnaires de routes HTTP
-├── service.ts             # Logique métier (service Effect)
-├── repository.ts          # Accès aux données (requêtes Drizzle)
-├── <feature>.schema.ts    # Schémas de validation (Effect Schema)
-├── <feature>.errors.ts    # Définitions d'erreurs de domaine
-└── <feature>.utils.ts     # Mappers, helpers (optionnel)
-```
+- `src/effect/main.ts` valide `NODE_ENV` et `PORT`, construit les layers applicatifs et HTTP, puis appelle `NodeRuntime.runMain()`.
+- `src/effect/task-worker.ts` construit le worker de tâches durables sans démarrer de serveur HTTP.
+- `src/effect/application/layers.ts` centralise la composition des services et de la plateforme.
+- `src/effect/application/startup.ts` gère les migrations de démarrage, le seed des rôles par défaut et le scanner de notifications.
+- `src/effect/modules/index.ts` monte les routers des modules sous `/api/v1`.
+- `src/effect/http/app.ts` assemble les routers, Better Auth, l'API de santé, Swagger et les middlewares.
 
-## Créer un nouveau module
-
-### 1. Définitions de schémas
-
-Les schémas définissent la validation des corps de requête et paramètres avec Effect Schema :
+Le point d'entrée de l'API suit cette forme :
 
 ```typescript
-// products.schema.ts
-import { Schema } from "effect";
+const applicationLayer = makeApplicationLayer({
+  nodeEnv,
+  runBetterAuthMigrations:
+    process.env.RUN_BETTER_AUTH_MIGRATIONS === 'true',
+});
 
-export const CreateProductSchema = Schema.Struct({
-  sku: Schema.Trim.pipe(Schema.minLength(1), Schema.maxLength(50)),
-  name: Schema.Trim.pipe(Schema.minLength(1), Schema.maxLength(200)),
-  category_id: Schema.optionalWith(Schema.NullOr(Schema.UUID), {
-    default: () => null,
-  }),
-}).annotations({ identifier: "CreateProduct" });
-```
-
-!!! tip "Annotations de schéma"
-    Ajoutez toujours `.annotations({ identifier: '...' })` aux schémas. L'identifiant apparaît dans les messages d'erreur de validation et les spans de traçage.
-
-### 2. Erreurs de domaine
-
-Définir des erreurs typées qui correspondent aux codes HTTP :
-
-```typescript
-// products.errors.ts
-import { NotFoundError, BadRequestError, InternalError } from "../platform/errors";
-
-export class ProductNotFound extends NotFoundError("ProductNotFound")<{
-  readonly productId: string;
-}> {}
-
-export class ProductSkuConflict extends BadRequestError("ProductSkuConflict")<{
-  readonly sku: string;
-}> {}
-```
-
-Chaque factory d'erreur définit automatiquement le code HTTP :
-
-| Factory | Status | Cas d'utilisation |
-|---------|--------|-------------------|
-| `NotFoundError` | 404 | Entité non trouvée |
-| `BadRequestError` | 400 | Validation, conflits |
-| `ConflictError` | 409 | Ressources dupliquées |
-| `ForbiddenError` | 403 | Permissions insuffisantes |
-| `UnauthorizedError` | 401 | Non authentifié |
-| `InternalError` | 500 | Erreurs d'infrastructure |
-
-### 3. Repository
-
-Les repositories gèrent l'accès aux données via Drizzle ORM :
-
-```typescript
-// repository.ts
-import { Effect } from "effect";
-import { DrizzleDatabase } from "../../platform/drizzle";
-
-export class ProductsRepository extends Effect.Service<ProductsRepository>()(
-  "ProductsRepository",
-  {
-    effect: Effect.gen(function* () {
-      const db = yield* DrizzleDatabase;
-
-      const tryAsync = makeTryAsync(
-        (error) => new ProductsInfrastructureError({ cause: error })
-      );
-
-      const findById = (id: string) =>
-        tryAsync(() =>
-          db.query.products.findFirst({
-            where: and(eq(products.id, id), isNull(products.deleted_at)),
-            with: { category: true },
-          })
-        );
-
-      return { findById /* ... */ };
-    }),
-    dependencies: [DrizzleDatabase.Default],
-  }
-) {}
-```
-
-### 4. Service
-
-Les services contiennent la logique métier :
-
-```typescript
-// service.ts
-export class ProductsService extends Effect.Service<ProductsService>()(
-  "ProductsService",
-  {
-    effect: Effect.gen(function* () {
-      const repo = yield* ProductsRepository;
-      const categoriesService = yield* CategoriesService;
-
-      const create = (dto: CreateProduct, userId: string) =>
-        Effect.gen(function* () {
-          if (dto.category_id) {
-            yield* categoriesService.existsById(dto.category_id);
-          }
-          const existing = yield* repo.findBySku(dto.sku);
-          if (existing) {
-            return yield* Effect.fail(
-              new ProductSkuConflict({ sku: dto.sku, messageKey: "products.skuConflict" })
-            );
-          }
-          return yield* repo.create({ ...dto, created_by: userId });
-        }).pipe(Effect.withSpan("ProductsService.create"));
-
-      return { create /* ... */ };
-    }),
-    dependencies: [ProductsRepository.Default, CategoriesService.Default],
-  }
-) {}
-```
-
-### 5. Router
-
-Les routers définissent les endpoints HTTP :
-
-```typescript
-// router.ts
-export const ProductsRouter = HttpRouter.empty.pipe(
-  HttpRouter.get("/products", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.READ);
-      const query = yield* searchParams(ProductsQuerySchema);
-      const service = yield* ProductsService;
-      return yield* service.findAllPaginated(query);
-    })
-  )),
-
-  HttpRouter.post("/products", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const body = yield* HttpServerRequest.schemaBodyJson(CreateProductSchema);
-      const session = yield* requireSession;
-      const service = yield* ProductsService;
-      const product = yield* service.create(body, session.user.id);
-
-      const audit = yield* AuditLogWriter;
-      yield* audit.log({
-        action: AuditAction.CREATE,
-        entityType: AuditEntityType.PRODUCT,
-        entityId: product.id,
-      });
-
-      return product;
-    }),
-    { status: 201 }
-  )),
+const main = Layer.launch(makeHttpServerLayer(port)).pipe(
+  Effect.provide(applicationLayer),
+  Effect.provide(runtimeLoggingLayer),
 );
+
+NodeRuntime.runMain(main);
 ```
 
-### Pattern des gestionnaires de routes
+`platformLayer` fournit la base de données, Better Auth et le stockage objet. Les services de fonctionnalités sont composés au-dessus, puis les services de modules et les workflows inter-modules. Ajoutez le nouveau câblage dans `application/layers.ts`, pas dans le point d'entrée.
 
-Chaque gestionnaire suit la même séquence :
+## Anatomie d'un module et contrats partagés
 
-1. **Autoriser** — `yield* requirePermission(Resource, Permission)`
-2. **Décoder** — Parser le corps, les paramètres de chemin ou de requête
-3. **Session** — `yield* requireSession` pour l'utilisateur courant
-4. **Service** — Logique métier et accès aux données
-5. **Audit** — Fire-and-forget via `AuditLogWriter.log()`
-6. **Répondre** — `respondJson()` enveloppe le résultat
+Les répertoires de modules se trouvent sous `src/effect/modules/<module>/`. Ils ne suivent pas un modèle de fichiers obligatoire. Un module contient généralement :
 
-### 6. Composition des couches
+```text
+router.ts              frontière HTTP
+service.ts             cas d'usage et règles métier
+repository.ts          persistance limitée au tenant
+types.ts               types internes
+mappers.ts             conversion base de données vers réponse
+write.ts               workflows d'écriture, si utile
+<module>.errors.ts     erreurs de domaine et d'infrastructure typées
+*.spec.ts              tests ciblés
+```
 
-Les modules sont câblés dans `main.ts` via les layers Effect :
+Les DTO publics, enums, identifiants, schémas de requête et schémas de corps appartiennent à `packages/types` et sont importés via l'export du domaine :
 
 ```typescript
-// main.ts (simplifié)
-const platformLayer = drizzleLayer.pipe(Layer.provideMerge(betterAuthLayer));
-const rolesLayer = RolesService.Default.pipe(Layer.provide(platformLayer));
-const productsLayer = ProductsService.Default.pipe(
-  Layer.provide(platformLayer),
-  Layer.provide(categoriesLayer)
-);
+import {
+  ClientIdSchema,
+  ClientQuerySchema,
+  CreateClientSchema,
+  UpdateClientSchema,
+} from '@stocket/types/clients';
 ```
 
-!!! tip "Direction des dépendances"
-    Les services n'exportent que leur layer `.Default`. L'accès inter-modules passe par la couche service — jamais importer un repository d'un autre module.
-
-### 7. Mise à jour des types partagés
+Conservez près du router les structures propres à une route, par exemple `{ id: ClientIdSchema }`. Conservez les lignes de base de données et les types internes aux workflows dans le module backend. Après l'ajout d'un fichier public au package partagé, régénérez ses barrels :
 
 ```bash
-pnpm --filter @stocket/types barrels
-pnpm --filter @stocket/types build
+pnpm --dir packages/types barrels
 ```
 
-## Authentification
+## Erreurs typées
 
-### Accès à la session
-
-L'authentification est gérée par Better Auth. Les sessions sont accessibles via le contexte Effect :
+Les erreurs de domaine utilisent les factories de `platform/effect/domain-errors.ts`. Chaque erreur applicative possède un tag unique, un statut HTTP, un `messageKey` et des arguments de message typés optionnels.
 
 ```typescript
-// Requiert l'authentification (échoue avec 401 si non connecté)
-const session = yield* requireSession;
-const userId = session.user.id;
+import {
+  ConflictError,
+  InternalError,
+  NotFoundError,
+} from '../../platform/effect/domain-errors';
 
-// Session optionnelle (retourne null si non connecté)
-const session = yield* getOptionalSession;
+export class ClientNotFound extends NotFoundError('ClientNotFound')<{
+  readonly id: string;
+}> {}
+
+export class ClientEmailAlreadyExists extends ConflictError(
+  'ClientEmailAlreadyExists',
+)<{ readonly email: string }> {}
+
+export class ClientsInfrastructureError extends InternalError(
+  'ClientsInfrastructureError',
+)<{ readonly action: string; readonly cause?: unknown }> {}
 ```
 
-## Autorisation
+Les factories disponibles correspondent aux statuts `400`, `401`, `403`, `404`, `409`, `500` et `501`. Les erreurs de parsing de schéma deviennent des `400` ; les erreurs inconnues deviennent des `500` et sont masquées en production. Les helpers de réponse standard localisent les messages depuis les catalogues anglais, français et allemand.
 
-Utiliser `requirePermission` au début de chaque route protégée :
+## Repositories limités au tenant et transactions
+
+Les données appartenant à un tenant doivent tirer leur tenant du contexte de requête, jamais d'un `tenant_id` fourni par le client. Préférez `makeTenantCrud()` pour le CRUD conventionnel. Il utilise `TenantQuery` pour ajouter le tenant aux insertions et limiter les lectures, mises à jour et suppressions.
 
 ```typescript
-yield* requirePermission(Resource.PRODUCTS, Permission.READ);
-yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
+export class ClientsRepository extends Effect.Service<ClientsRepository>()(
+  '@stocket/effect/clients/ClientsRepository',
+  {
+    effect: makeTenantCrud(clients, {
+      entity: 'client',
+      onError: (action, cause) =>
+        new ClientsInfrastructureError({
+          action,
+          cause,
+          messageKey: 'clients.repositoryFailed',
+        }),
+      list: {
+        filters: buildClientFilters,
+        orderBy: sql`"company_name" ASC`,
+      },
+    }),
+    dependencies: [TenantQuery.Default],
+  },
+) {}
 ```
 
-L'Effect `requirePermission` :
+Pour les requêtes spécifiques, utilisez les helpers limités au tenant exposés par `makeTenantCrud()` (`scopedWhere`, `scopedWhereId`, `scopedWhereIds`, `insertValues`) ou directement `TenantQuery`. Un identifiant d'un autre tenant doit se comporter comme un identifiant absent.
 
-1. Obtient la session courante (échoue avec 401 si non authentifié)
-2. Récupère les permissions via `PermissionProvider` (cache de 1 minute)
-3. Vérifie la permission requise
-4. Échoue avec `PermissionDenied` (403) si non autorisé
+Utilisez le helper de repository `withTransaction`, ou `withDrizzleTransaction`, lorsque plusieurs écritures en base forment un seul invariant. Gardez la validation et les écritures dans la même transaction lorsque la concurrence compte ; une vérification préalable applicative n'est pas une garantie d'unicité en base. Ne maintenez pas une transaction ouverte pendant un appel S3, email, LLM ou réseau. Les écritures d'audit sont également hors de la transaction métier.
 
-## Gestion des erreurs
+Convertissez les rejets de promesses en erreur d'infrastructure du module avec `makeTryAsync()` ou le wrapper fourni par `makeTenantCrud()`.
 
-Les erreurs sont des valeurs typées dans le canal d'échec Effect :
+## Services et frontières des modules
+
+Les services exposent les cas d'usage, convertissent les lignes en DTO publics et tracent leurs opérations. Les routers HTTP doivent appeler les services, pas les repositories.
+
+Pour une collaboration inter-module normale, dépendez du service de l'autre module. Pour un workflow inter-module réellement atomique, créez un orchestrateur explicite ou un repository coordinateur et injectez des capacités `Pick<...>` étroites. La propriété de la transaction reste ainsi visible sans disperser les imports de repositories dans les routers et services sans rapport.
+
+Déplacez un helper dans `platform/` seulement lorsqu'il est indépendant du domaine et réutilisé. Conservez les règles de produit, commande, inventaire et tenant dans leurs modules propriétaires. Ne dupliquez pas la validation d'un autre module uniquement pour éviter une dépendance de service.
+
+Le câblage des layers appartient à `application/layers.ts` ; le montage des routes à `modules/index.ts`.
+
+## Routes HTTP
+
+### `tenantRoute` et `tenantRouteContext`
+
+La plupart des routes d'API tenant utilisent les adaptateurs de `platform/http/tenant-route.ts` :
+
+- `tenantRoute()` autorise, applique un guard optionnel, décode l'entrée, résout le mode de session demandé, exécute le handler et renvoie une réponse JSON standard.
+- `tenantRouteContext()` effectue le même travail de frontière mais renvoie l'Effect du contexte décodé. Utilisez-le avec `respondAuditedMutation()`, un statut ou header personnalisé, ou une réponse vide.
+- `queryParams()`, `pathParams()`, `jsonBody()` et les décodeurs combinés gardent le parsing à la frontière.
+
+L'ordre de la frontière est : permissions, guard personnalisé, décodage, puis résolution explicite de la session. Une vérification de permission exige déjà une authentification. Définissez `session: 'required'` ou `'optional'` lorsque le handler a aussi besoin de `session` ou `userId` ; sinon la valeur par défaut est `'none'`.
 
 ```typescript
-// Échouer avec une erreur de domaine (inclut messageKey pour la localisation)
-yield* Effect.fail(
-  new ProductNotFound({
-    productId: id,
-    messageKey: "products.notFound",
-  })
+const ClientPathParams = Schema.Struct({ id: ClientIdSchema });
+
+export const clientsRouter = HttpRouter.empty.pipe(
+  HttpRouter.get(
+    '/',
+    tenantRoute({
+      permissions: [[Resource.CLIENTS, Permission.READ]],
+      decode: queryParams(ClientQuerySchema),
+      handler: ({ input: query }) =>
+        Effect.flatMap(ClientsService, (clients) =>
+          clients.findAllPaginated(query),
+        ),
+    }),
+  ),
+  HttpRouter.post(
+    '/',
+    tenantRouteContext({
+      permissions: [[Resource.CLIENTS, Permission.WRITE]],
+      decode: jsonBody(CreateClientSchema),
+    }).pipe(
+      Effect.flatMap(({ input: dto }) =>
+        respondAuditedMutation(
+          Effect.flatMap(ClientsService, (clients) => clients.create(dto)),
+          {
+            action: AuditAction.CREATE,
+            entityType: AuditEntityType.CLIENT,
+            entityId: (client) => client.id,
+            responseOptions: { status: 201 },
+          },
+        ),
+      ),
+    ),
+  ),
+  HttpRouter.prefixAll('/clients'),
 );
 ```
 
-### Messages localisés
+### Authentification, RBAC et guards de fonctionnalités
 
-Les messages sont résolus depuis les catalogues de langues (en, fr, de) selon l'en-tête `Accept-Language`.
+Better Auth sert `/api/auth/**`. Les routes tenant résolvent le hostname vérifié avant que les repositories n'utilisent le contexte du tenant. N'acceptez jamais un hostname ou un identifiant de tenant comme autorisation à lui seul : la session doit aussi avoir une adhésion à ce tenant.
 
-## Soft Delete
-
-Les produits utilisent la suppression logique via `deleted_at`, `deleted_by` :
+Déclarez les exigences RBAC sur la route :
 
 ```typescript
-// Repository — exclure les supprimés par défaut
-const findAll = () =>
-  tryAsync(() =>
-    db.query.products.findMany({
-      where: isNull(products.deleted_at),
-    })
-  );
-
-// Suppression logique
-const softDelete = (id: string, userId: string) =>
-  tryAsync(() =>
-    db.update(products)
-      .set({ deleted_at: new Date(), deleted_by: userId })
-      .where(eq(products.id, id))
-  );
+tenantRoute({
+  permissions: [[Resource.ORDERS, Permission.READ]],
+  guard: requireOrdersFeature,
+  decode: queryParams(OrderQuerySchema),
+  handler: ({ input }) =>
+    Effect.flatMap(OrdersService, (orders) =>
+      orders.findAllPaginated(input),
+    ),
+});
 ```
 
-## Formats de réponse
+Le RBAC indique si l'utilisateur peut effectuer une action. Un guard de fonctionnalité indique si le plan ou l'override du tenant active cette capacité produit. Ce sont deux vérifications distinctes. Les clés actuelles sont `orders` et `smartImport` ; Smart Import exige aussi les permissions d'écriture pour les produits, emplacements et inventaires.
 
-### Entité unique
+Les ressources RBAC exactes sont :
+
+| Ressource | Périmètre habituel |
+| --- | --- |
+| `DASHBOARD` | Accès au tableau de bord |
+| `ORDERS` | Commandes |
+| `CLIENTS` | Clients |
+| `SUPPLIERS` | Fournisseurs |
+| `STOCK_MOVEMENTS` | Registre des mouvements |
+| `PRODUCTS` | Catalogue de produits et photos |
+| `LOCATIONS` | Emplacements et zones |
+| `INVENTORY` | Lignes et ajustements d'inventaire |
+| `AUDIT_LOGS` | Lecture de l'audit tenant |
+| `USERS` | Utilisateurs du tenant |
+| `SETTINGS` | Paramètres et branding du tenant |
+| `ROLES` | Rôles et attributions |
+
+Les permissions sont `READ` et `WRITE`. Il n'existe pas de ressource `STOCK`. Les écritures de rôles et d'attributions invalident le cache des permissions ; les écritures de fonctionnalités invalident le cache des droits produit.
+
+## Contrats de réponse
+
+Les routes renvoient directement leur entité ou leur message. Il n'existe pas de layer HATEOAS et `_links` n'est pas garanti dans les réponses. Les statuts et corps de suppression dépendent de la route ; ne supposez pas que chaque suppression renvoie `204`.
+
+Les réponses paginées standard contiennent un objet `meta` imbriqué :
 
 ```json
 {
-  "id": "uuid",
-  "name": "Nom du produit",
-  "_links": {
-    "self": { "href": "/api/v1/products/uuid", "method": "GET" }
+  "data": [],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total": 0,
+    "total_pages": 0,
+    "has_next": false,
+    "has_previous": false
   }
 }
 ```
 
-### Liste paginée
+Les opérations en masse utilisent le contrat partagé `BulkOperationResult` :
 
 ```json
 {
-  "data": [...],
-  "page": 1,
-  "limit": 20,
-  "total": 100
-}
-```
-
-### Opération en masse
-
-```json
-{
-  "succeeded": ["id1", "id2"],
-  "failed": [
-    { "item": { "sku": "PROD-003" }, "error": "Le SKU existe déjà" }
+  "success_count": 2,
+  "failure_count": 1,
+  "succeeded": ["id-1", "id-2"],
+  "failures": [
+    { "id": "id-3", "error": "Produit introuvable" }
   ]
 }
 ```
 
+Utilisez `runBulkByIds()` depuis `platform/effect/run-bulk-by-ids.ts` pour les workflows en masse par identifiants, ou les builders de `@stocket/types/common` lorsqu'un workflow nécessite des identifiants personnalisés.
+
+`respondJson()` et `respondEmpty()` ajoutent `x-request-id`, localisent les descripteurs de message et convertissent les erreurs typées en enveloppe d'erreur standard. Les réponses Better Auth, Swagger, health typées et les preflights CORS ne passent pas toutes par ces helpers : ne promettez donc pas ce header sur toutes les réponses possibles.
+
 ## Journalisation d'audit
 
-La journalisation est fire-and-forget — elle s'exécute dans une fibre daemon en arrière-plan :
+Utilisez `respondAuditedMutation()` uniquement pour les mutations dont l'événement d'audit tenant fait partie du contrat actuel. Il produit la réponse après le succès de la mutation et demande à `AuditLogWriter` d'écrire un événement dans une fibre daemon.
+
+Les routers actuellement audités côté tenant couvrent les zones, catégories, clients, inventaires, emplacements, commandes, produits, rôles, mouvements de stock et fournisseurs. Cela ne signifie pas que chaque mutation du système est auditée. Les utilisateurs, le branding, les photos, les préférences de notification et les tâches sont des exemples hors de cette couverture ; les opérations superadmin utilisent un audit plateforme séparé.
+
+Les lignes d'audit tenant enregistrent actuellement l'action, le type et l'identifiant d'entité, l'identifiant utilisateur si disponible, l'adresse IP et l'horodatage. `changes` et `user_agent` valent actuellement `null`. L'écriture est best-effort, son échec est journalisé puis ignoré, et elle n'appartient pas à la transaction métier. N'utilisez pas ce journal comme historique exhaustif, source de rollback ou garantie réglementaire.
+
+## Observabilité
+
+### Traçage des services
+
+Créez un tracer une fois par service et enveloppez les opérations publiques avec `span()` ou `traced()` :
 
 ```typescript
-const audit = yield* AuditLogWriter;
-yield* audit.log({
-  action: AuditAction.CREATE,
-  entityType: AuditEntityType.PRODUCT,
-  entityId: product.id,
+const trace = makeServiceTracer({
+  serviceName: 'ClientsService',
+  module: 'clients',
+  layer: 'service',
+});
+
+const findOne = (id: string) =>
+  repository.findById(id).pipe(
+    trace.span('findOne', { attributes: { id } }),
+  );
+```
+
+`makeServiceTracer()` ajoute le module, le layer, l'opération, l'identifiant de requête, l'identifiant du tenant si disponible et une classification du résultat. Utilisez les attributs de traçage catalogués plutôt que des clés arbitraires.
+
+### Logs structurés et localisés
+
+`createLogger()` vient de `platform/observability/messages.ts`. Son scope préfixe la clé de message et ses arguments sont limités par `LogProperties` dans `platform/catalogs/log-properties.ts`.
+
+```typescript
+const logger = createLogger('tasks');
+
+yield* logger.info('settled', {
+  taskId,
+  taskType,
+  workerId,
+  status,
 });
 ```
 
-## Traçage
+Les catalogues de messages se trouvent dans `platform/catalogs/en.ts`, `fr.ts` et `de.ts`. Gardez leurs clés synchronisées ; l'anglais définit l'ensemble typé `MessageKey`. Évitez les logs console non structurés.
 
-Les méthodes de service utilisent `Effect.withSpan()` pour le traçage distribué :
+### Middlewares HTTP
 
-```typescript
-const create = (dto: CreateProduct, userId: string) =>
-  Effect.gen(function* () {
-    // ... logique métier
-  }).pipe(Effect.withSpan("ProductsService.create"));
+Pour une requête entrante, les middlewares enveloppent l'application dans cet ordre :
+
+1. journalisation de requête et contexte de requête ;
+2. headers de sécurité ;
+3. CORS, y compris les origines de tenants vérifiées ;
+4. limite de corps de requête à 10 Mio ;
+5. contexte du tenant ;
+6. router.
+
+Le contexte de requête standard contient l'identifiant de requête, le chemin, la méthode, l'IP, la locale et l'identifiant de tenant résolu.
+
+## Santé et découverte de l'API
+
+Les endpoints publics de santé sont :
+
+| Endpoint | Vérification | Échec |
+| --- | --- | --- |
+| `GET /health-check/live` | Vivacité du processus uniquement | Aucune dépendance vérifiée |
+| `GET /health-check/ready` | Connectivité PostgreSQL | `503` si la base est indisponible |
+| `GET /health-check` | PostgreSQL et secret Better Auth | `503` si l'un des deux est indisponible |
+
+Une réponse de santé réussie utilise `status`, `info`, `error` et `details` :
+
+```json
+{
+  "status": "ok",
+  "info": {
+    "database": { "status": "up" },
+    "better-auth": { "status": "up" }
+  },
+  "error": {},
+  "details": {
+    "database": { "status": "up" },
+    "better-auth": { "status": "up" }
+  }
+}
 ```
 
-## Middleware HTTP
+L'interface Swagger est montée sur `/docs`, mais elle ne décrit actuellement que le groupe health implémenté avec `HttpApiBuilder`. La plupart des modules `/api/v1` utilisent encore `HttpRouter` et n'apparaissent pas dans ce document OpenAPI. Considérez Swagger comme partiel jusqu'à leur migration.
 
-L'application HTTP applique les middlewares dans l'ordre :
+## Tâches durables et worker
 
-| Middleware | Objectif |
-|-----------|----------|
-| `corsMiddleware` | En-têtes CORS |
-| `securityHeadersMiddleware` | En-têtes de sécurité |
-| `requestLoggingMiddleware` | Journalisation requêtes/réponses |
-| `bodyLimitMiddleware` | Corps de requête max 10 Mo |
+Les traitements longs ou à réessayer doivent être placés dans une tâche durable au lieu de rester dans la fibre de requête. L'API et le worker sont des processus séparés :
 
-## Health Checks
-
-### Endpoints
-
-- `GET /health-check` — Vérification complète (base de données + auth). Retourne `503` si un check échoue.
-- `GET /health-check/live` — Sonde de vivacité. Retourne `200` si le processus tourne.
-- `GET /health-check/ready` — Sonde de disponibilité. Vérifie la base de données.
-
-### Configuration Kubernetes
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health-check/live
-    port: 8080
-  initialDelaySeconds: 30
-  periodSeconds: 10
-
-readinessProbe:
-  httpGet:
-    path: /health-check/ready
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 5
+```bash
+pnpm --filter @stocket/api start
+pnpm --filter @stocket/api start:worker
 ```
+
+Les tâches prennent les états `queued`, `running`, `succeeded`, `failed` et `canceled`, avec progression, tentatives, leases, heartbeats, retry différé, récupération et annulation coopérative. La lecture et l'annulation exigent une session et sont limitées au tenant et à l'utilisateur créateur :
+
+- `GET /api/v1/tasks`
+- `GET /api/v1/tasks/:id`
+- `POST /api/v1/tasks/:id/cancel`
+
+L'import produit est actuellement le seul type de tâche enregistré. `POST /api/v1/products/import` renvoie `202` avec la tâche et un header `Location: /api/v1/tasks/:id`. Son `Idempotency-Key` est limité au tenant, au créateur et au type de tâche.
+
+Pour ajouter un type de tâche, définissez et validez son payload, implémentez un `TaskHandler`, enregistrez-le dans le layer `TaskRegistry` du worker, ajoutez ses dépendances au layer applicatif du worker et exposez un service d'enqueue. Le processus HTTP peut créer les tâches ; seul le worker doit les exécuter.
+
+## Vérification rapide
+
+Pour les changements d'API backend, lancez d'abord les vérifications pertinentes les plus petites :
+
+```bash
+pnpm --filter @stocket/api type-check
+pnpm --filter @stocket/api lint
+pnpm --filter @stocket/api test -- clients
+```
+
+Utilisez le nom du module concerné comme filtre Vitest. Lancez les tests d'intégration lorsque la persistance, les transactions, le tenant ou la composition des routes changent.

--- a/docs/development/api-development.md
+++ b/docs/development/api-development.md
@@ -1,632 +1,378 @@
 # API Development
 
-This guide covers Effect.ts development patterns for the Stocket Inventory backend, which runs on Bun with Drizzle ORM and PostgreSQL.
+The Stocket backend runs on Node.js 22 with Effect, Drizzle ORM, and PostgreSQL. `tsx` runs the development entry points; esbuild produces Node 22 CommonJS bundles for production. Bun is not the backend runtime.
 
-## Module Structure
+## Runtime and application composition
 
-Each feature follows this structure:
+The entry points stay deliberately small:
 
-```
-modules/<feature>/
-├── router.ts              # HTTP route handlers
-├── service.ts             # Business logic (Effect service)
-├── repository.ts          # Data access (Drizzle queries)
-├── <feature>.schema.ts    # Validation schemas (Effect Schema)
-├── <feature>.errors.ts    # Domain error definitions
-└── <feature>.utils.ts     # Mappers, helpers (optional)
-```
+- `src/effect/main.ts` validates `NODE_ENV` and `PORT`, builds the application and HTTP layers, then calls `NodeRuntime.runMain()`.
+- `src/effect/task-worker.ts` builds the durable-task worker without starting an HTTP server.
+- `src/effect/application/layers.ts` owns service and platform layer composition.
+- `src/effect/application/startup.ts` owns startup migrations, default-role seeding, and the notification scanner.
+- `src/effect/modules/index.ts` mounts module routers under `/api/v1`.
+- `src/effect/http/app.ts` combines the routers, Better Auth, health API, Swagger, and middleware.
 
-## Creating a New Module
-
-### 1. Schema Definitions
-
-Schemas define validation for request bodies and query parameters using Effect Schema:
+The API entry point follows this shape:
 
 ```typescript
-// products.schema.ts
-import { Schema } from "effect";
+const applicationLayer = makeApplicationLayer({
+  nodeEnv,
+  runBetterAuthMigrations:
+    process.env.RUN_BETTER_AUTH_MIGRATIONS === 'true',
+});
 
-export const CreateProductSchema = Schema.Struct({
-  sku: Schema.Trim.pipe(Schema.minLength(1), Schema.maxLength(50)),
-  name: Schema.Trim.pipe(Schema.minLength(1), Schema.maxLength(200)),
-  category_id: Schema.optionalWith(Schema.NullOr(Schema.UUID), {
-    default: () => null,
-  }),
-  standard_cost: Schema.optionalWith(Schema.NullOr(Schema.Number), {
-    default: () => null,
-  }),
-}).annotations({ identifier: "CreateProduct" });
-
-export const ProductsQuerySchema = Schema.Struct({
-  page: Schema.optionalWith(Schema.NumberFromString, { default: () => 1 }),
-  limit: Schema.optionalWith(Schema.NumberFromString, { default: () => 20 }),
-  search: Schema.optionalWith(Schema.String, { default: () => "" }),
-  sortBy: Schema.optionalWith(Schema.String, { default: () => "created_at" }),
-  sortOrder: Schema.optionalWith(Schema.Literal("asc", "desc"), {
-    default: () => "desc" as const,
-  }),
-}).annotations({ identifier: "ProductsQuery" });
-```
-
-!!! tip "Schema Annotations"
-    Always add `.annotations({ identifier: '...' })` to schemas. The identifier appears in validation error messages and tracing spans, making debugging much easier.
-
-### 2. Domain Errors
-
-Define typed errors that map to HTTP status codes:
-
-```typescript
-// products.errors.ts
-import { NotFoundError, BadRequestError, InternalError } from "../platform/errors";
-
-export class ProductNotFound extends NotFoundError("ProductNotFound")<{
-  readonly productId: string;
-}> {}
-
-export class ProductSkuConflict extends BadRequestError("ProductSkuConflict")<{
-  readonly sku: string;
-}> {}
-
-export class ProductsInfrastructureError extends InternalError(
-  "ProductsInfrastructureError"
-)<{}> {}
-```
-
-Each error factory sets the HTTP status code automatically:
-
-| Factory | Status | Use Case |
-|---------|--------|----------|
-| `NotFoundError` | 404 | Entity not found |
-| `BadRequestError` | 400 | Validation, conflicts |
-| `ConflictError` | 409 | Duplicate resources |
-| `ForbiddenError` | 403 | Insufficient permissions |
-| `UnauthorizedError` | 401 | Not authenticated |
-| `InternalError` | 500 | Infrastructure failures |
-
-### 3. Repository
-
-Repositories handle data access using Drizzle ORM:
-
-```typescript
-// repository.ts
-import { Effect } from "effect";
-import { DrizzleDatabase } from "../../platform/drizzle";
-import { products, categories } from "../../platform/db/schema";
-import { eq, isNull, and } from "drizzle-orm";
-
-export class ProductsRepository extends Effect.Service<ProductsRepository>()(
-  "ProductsRepository",
-  {
-    effect: Effect.gen(function* () {
-      const db = yield* DrizzleDatabase;
-
-      const tryAsync = makeTryAsync(
-        (error) => new ProductsInfrastructureError({ cause: error })
-      );
-
-      const findById = (id: string) =>
-        tryAsync(() =>
-          db.query.products.findFirst({
-            where: and(eq(products.id, id), isNull(products.deleted_at)),
-            with: { category: true },
-          })
-        );
-
-      const create = (data: typeof products.$inferInsert) =>
-        tryAsync(() =>
-          db.insert(products).values(data).returning().then((r) => r[0]!)
-        );
-
-      return { findById, create /* ... */ };
-    }),
-    dependencies: [DrizzleDatabase.Default],
-  }
-) {}
-```
-
-!!! note "Error wrapping"
-    The `makeTryAsync()` helper converts async database calls into typed Effects. If a query fails, it wraps the error in the module's infrastructure error (e.g., `ProductsInfrastructureError`), keeping error types explicit in the return channel.
-
-### 4. Service
-
-Services contain business logic and depend on repositories and other services:
-
-```typescript
-// service.ts
-import { Effect } from "effect";
-
-export class ProductsService extends Effect.Service<ProductsService>()(
-  "ProductsService",
-  {
-    effect: Effect.gen(function* () {
-      const repo = yield* ProductsRepository;
-      const categoriesService = yield* CategoriesService;
-
-      const getProductOrFail = (id: string) =>
-        Effect.gen(function* () {
-          const product = yield* repo.findById(id);
-          if (!product) {
-            return yield* Effect.fail(
-              new ProductNotFound({ productId: id, messageKey: "products.notFound" })
-            );
-          }
-          return product;
-        });
-
-      const create = (dto: CreateProduct, userId: string) =>
-        Effect.gen(function* () {
-          // Validate category exists
-          if (dto.category_id) {
-            yield* categoriesService.existsById(dto.category_id);
-          }
-
-          // Check SKU uniqueness
-          const existing = yield* repo.findBySku(dto.sku);
-          if (existing) {
-            return yield* Effect.fail(
-              new ProductSkuConflict({ sku: dto.sku, messageKey: "products.skuConflict" })
-            );
-          }
-
-          return yield* repo.create({
-            ...dto,
-            created_by: userId,
-            updated_by: userId,
-          });
-        }).pipe(Effect.withSpan("ProductsService.create"));
-
-      return { create, getProductOrFail /* ... */ };
-    }),
-    dependencies: [ProductsRepository.Default, CategoriesService.Default],
-  }
-) {}
-```
-
-### 5. Router
-
-Routers define HTTP endpoints and wire together authorization, validation, and service calls:
-
-```typescript
-// router.ts
-import { HttpRouter, HttpServerRequest } from "@effect/platform";
-import { Effect } from "effect";
-
-export const ProductsRouter = HttpRouter.empty.pipe(
-  // GET /products — paginated list
-  HttpRouter.get("/products", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.READ);
-      const query = yield* searchParams(ProductsQuerySchema);
-      const service = yield* ProductsService;
-      return yield* service.findAllPaginated(query);
-    })
-  )),
-
-  // POST /products — create
-  HttpRouter.post("/products", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const body = yield* HttpServerRequest.schemaBodyJson(CreateProductSchema);
-      const session = yield* requireSession;
-      const service = yield* ProductsService;
-
-      const product = yield* service.create(body, session.user.id);
-
-      // Fire-and-forget audit log
-      const audit = yield* AuditLogWriter;
-      yield* audit.log({
-        action: AuditAction.CREATE,
-        entityType: AuditEntityType.PRODUCT,
-        entityId: product.id,
-      });
-
-      return product;
-    }),
-    { status: 201 }
-  )),
-
-  // PUT /products/:id — update
-  HttpRouter.put("/products/:id", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const { id } = yield* HttpRouter.schemaPathParams(
-        Schema.Struct({ id: Schema.UUID })
-      );
-      const body = yield* HttpServerRequest.schemaBodyJson(UpdateProductSchema);
-      const session = yield* requireSession;
-      const service = yield* ProductsService;
-      return yield* service.update(id, body, session.user.id);
-    })
-  )),
-
-  // DELETE /products/:id — soft delete
-  HttpRouter.delete("/products/:id", respondJson(
-    Effect.gen(function* () {
-      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const { id } = yield* HttpRouter.schemaPathParams(
-        Schema.Struct({ id: Schema.UUID })
-      );
-      const session = yield* requireSession;
-      const service = yield* ProductsService;
-      return yield* service.delete(id, session.user.id);
-    })
-  )),
+const main = Layer.launch(makeHttpServerLayer(port)).pipe(
+  Effect.provide(applicationLayer),
+  Effect.provide(runtimeLoggingLayer),
 );
+
+NodeRuntime.runMain(main);
 ```
 
-### Route Handler Pattern
+`platformLayer` provides database, Better Auth, and object storage services. Feature services are composed above that layer, followed by module services and cross-module workflows. Add new wiring in `application/layers.ts`, not in the entry point.
 
-Every route handler follows the same sequence:
+## Module anatomy and shared contracts
 
-1. **Authorize** — `yield* requirePermission(Resource, Permission)`
-2. **Decode** — Parse body, path params, or query params via schemas
-3. **Get session** — `yield* requireSession` for the current user
-4. **Call service** — Business logic and data access
-5. **Audit** — Fire-and-forget via `AuditLogWriter.log()`
-6. **Respond** — `respondJson()` wraps the result (or `respondEmpty()` for 204)
+Module directories are under `src/effect/modules/<module>/`. They do not follow a mandatory file template. A module commonly contains:
 
-### 6. Layer Composition
+```text
+router.ts              HTTP boundary
+service.ts             use cases and business rules
+repository.ts          tenant-scoped persistence
+types.ts               internal types
+mappers.ts             database-to-response mapping
+write.ts               write workflows, when useful
+<module>.errors.ts     typed domain and infrastructure errors
+*.spec.ts              focused tests
+```
 
-Modules are wired together in `main.ts` using Effect layers — no decorator-based DI container:
+Public DTOs, enums, IDs, query schemas, and request schemas belong in `packages/types` and are imported through a domain export:
 
 ```typescript
-// main.ts (simplified)
-const platformLayer = drizzleLayer.pipe(Layer.provideMerge(betterAuthLayer));
-
-const rolesLayer = RolesService.Default.pipe(Layer.provide(platformLayer));
-const permissionLayer = PermissionProvider.Default.pipe(Layer.provide(rolesLayer));
-
-const categoriesLayer = CategoriesService.Default.pipe(Layer.provide(platformLayer));
-const productsLayer = ProductsService.Default.pipe(
-  Layer.provide(platformLayer),
-  Layer.provide(categoriesLayer)
-);
+import {
+  ClientIdSchema,
+  ClientQuerySchema,
+  CreateClientSchema,
+  UpdateClientSchema,
+} from '@stocket/types/clients';
 ```
 
-!!! tip "Dependency direction"
-    Services export only their `.Default` layer. Cross-module access goes through the service layer — never import a repository from another module.
-
-### 7. Update Shared Types
-
-After changing DTOs or enums:
+Keep route-only structures, such as `{ id: ClientIdSchema }`, beside the router. Keep database rows and workflow-only types inside the backend module. When adding a public file to the shared package, regenerate its barrels:
 
 ```bash
-pnpm --filter @stocket/types barrels
-pnpm --filter @stocket/types build
+pnpm --dir packages/types barrels
 ```
 
-## Authentication
+## Typed errors
 
-### Session Access
-
-Authentication is handled by Better Auth. Sessions are accessed via Effect context:
+Domain errors use the factories in `platform/effect/domain-errors.ts`. Every application error has a unique tag, HTTP status, `messageKey`, and optional typed message arguments.
 
 ```typescript
-// Require authentication (fails with 401 if not logged in)
-const session = yield* requireSession;
-const userId = session.user.id;
+import {
+  ConflictError,
+  InternalError,
+  NotFoundError,
+} from '../../platform/effect/domain-errors';
 
-// Optional session (returns null if not logged in)
-const session = yield* getOptionalSession;
-const userId = session?.user.id;
-```
-
-## Authorization
-
-Use `requirePermission` at the start of every protected route handler:
-
-```typescript
-// Read access
-yield* requirePermission(Resource.PRODUCTS, Permission.READ);
-
-// Write access
-yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-```
-
-The `requirePermission` Effect:
-
-1. Gets the current session (fails with 401 if unauthenticated)
-2. Fetches the user's permissions via `PermissionProvider` (cached for 1 minute)
-3. Checks if the user has the required permission
-4. Fails with `PermissionDenied` (403) if not authorized
-
-### Resources and Permissions
-
-| Resource | Read | Write |
-|----------|------|-------|
-| `DASHBOARD` | View dashboard | — |
-| `STOCK` | View stock & movements | Create/edit stock |
-| `PRODUCTS` | View products | Create/edit/delete products |
-| `LOCATIONS` | View locations & areas | Create/edit/delete locations |
-| `INVENTORY` | View inventory | Adjust inventory |
-| `AUDIT_LOGS` | View audit logs | — |
-| `USERS` | View users | Manage users |
-| `SETTINGS` | View settings | Update settings |
-| `ROLES` | View roles | Manage roles |
-
-## Error Handling
-
-Errors are typed values in the Effect failure channel, not thrown exceptions:
-
-```typescript
-// Define a domain error
-export class ProductNotFound extends NotFoundError("ProductNotFound")<{
-  readonly productId: string;
+export class ClientNotFound extends NotFoundError('ClientNotFound')<{
+  readonly id: string;
 }> {}
 
-// Fail with a domain error (includes messageKey for localization)
-yield* Effect.fail(
-  new ProductNotFound({
-    productId: id,
-    messageKey: "products.notFound",
-  })
+export class ClientEmailAlreadyExists extends ConflictError(
+  'ClientEmailAlreadyExists',
+)<{ readonly email: string }> {}
+
+export class ClientsInfrastructureError extends InternalError(
+  'ClientsInfrastructureError',
+)<{ readonly action: string; readonly cause?: unknown }> {}
+```
+
+Available factories map to `400`, `401`, `403`, `404`, `409`, `500`, and `501`. Schema parse failures become `400`; unknown failures become `500` and are masked in production. Standard response helpers localize messages from the English, French, and German catalogs.
+
+## Tenant-scoped repositories and transactions
+
+Tenant-owned data must derive its tenant from request context, never from a client-supplied `tenant_id`. Prefer `makeTenantCrud()` for conventional CRUD. It uses `TenantQuery` to stamp inserts and scope reads, updates, and deletes.
+
+```typescript
+export class ClientsRepository extends Effect.Service<ClientsRepository>()(
+  '@stocket/effect/clients/ClientsRepository',
+  {
+    effect: makeTenantCrud(clients, {
+      entity: 'client',
+      onError: (action, cause) =>
+        new ClientsInfrastructureError({
+          action,
+          cause,
+          messageKey: 'clients.repositoryFailed',
+        }),
+      list: {
+        filters: buildClientFilters,
+        orderBy: sql`"company_name" ASC`,
+      },
+    }),
+    dependencies: [TenantQuery.Default],
+  },
+) {}
+```
+
+For bespoke queries, use the scoped helpers exposed by `makeTenantCrud()` (`scopedWhere`, `scopedWhereId`, `scopedWhereIds`, `insertValues`) or `TenantQuery` directly. A cross-tenant ID must behave like a missing ID.
+
+Use the provided `withTransaction` repository helper, or `withDrizzleTransaction`, when several database writes form one invariant. Keep validation and writes inside the same transaction when concurrency matters; an application preflight check is not a database uniqueness guarantee. Do not hold a database transaction open across S3, email, LLM, or other network calls. Audit writes are also outside the business transaction.
+
+Map promise failures into the module's infrastructure error with `makeTryAsync()` or the error wrapper supplied by `makeTenantCrud()`.
+
+## Services and module boundaries
+
+Services expose use cases, map rows to public DTOs, and trace their operations. HTTP routers must call services rather than repositories.
+
+For normal cross-module collaboration, depend on the other module's service. For a genuinely atomic cross-module workflow, create an explicit orchestrator or coordinating repository and inject narrow `Pick<...>` capabilities. This makes transaction ownership visible without spreading repository imports across routers and unrelated services.
+
+Move a helper into `platform/` only after it is domain-neutral and reused. Keep product, order, inventory, and tenant rules in their owning modules. Do not duplicate another module's validation just to avoid a service dependency.
+
+Layer wiring belongs in `application/layers.ts`; route mounting belongs in `modules/index.ts`.
+
+## HTTP routes
+
+### `tenantRoute` and `tenantRouteContext`
+
+Most tenant API routes use the adapters in `platform/http/tenant-route.ts`:
+
+- `tenantRoute()` authorizes, applies an optional guard, decodes input, resolves the requested session mode, runs the handler, and returns a standard JSON response.
+- `tenantRouteContext()` performs the same boundary work but returns the decoded context Effect. Use it when the route needs `respondAuditedMutation()`, a custom status/header, or an empty response.
+- `queryParams()`, `pathParams()`, `jsonBody()`, and the combined decoders keep parsing at the boundary.
+
+The boundary order is permissions, custom guard, decoding, then explicit session resolution. A permission check already requires authentication. Set `session: 'required'` or `'optional'` when the handler also needs `session` or `userId`; otherwise it defaults to `'none'`.
+
+```typescript
+const ClientPathParams = Schema.Struct({ id: ClientIdSchema });
+
+export const clientsRouter = HttpRouter.empty.pipe(
+  HttpRouter.get(
+    '/',
+    tenantRoute({
+      permissions: [[Resource.CLIENTS, Permission.READ]],
+      decode: queryParams(ClientQuerySchema),
+      handler: ({ input: query }) =>
+        Effect.flatMap(ClientsService, (clients) =>
+          clients.findAllPaginated(query),
+        ),
+    }),
+  ),
+  HttpRouter.post(
+    '/',
+    tenantRouteContext({
+      permissions: [[Resource.CLIENTS, Permission.WRITE]],
+      decode: jsonBody(CreateClientSchema),
+    }).pipe(
+      Effect.flatMap(({ input: dto }) =>
+        respondAuditedMutation(
+          Effect.flatMap(ClientsService, (clients) => clients.create(dto)),
+          {
+            action: AuditAction.CREATE,
+            entityType: AuditEntityType.CLIENT,
+            entityId: (client) => client.id,
+            responseOptions: { status: 201 },
+          },
+        ),
+      ),
+    ),
+  ),
+  HttpRouter.prefixAll('/clients'),
 );
 ```
 
-### Error Response Flow
+### Authentication, RBAC, and feature guards
 
-The `respondJson()` wrapper catches all errors and calls `respondCause()`, which:
+Better Auth serves `/api/auth/**`. Tenant routes resolve the verified hostname before repositories use tenant context. Never accept a hostname or tenant ID as authorization by itself: the session must also have a membership in that tenant.
 
-1. **Domain errors** → HTTP status from error factory + localized message via `messageKey`
-2. **Schema parse errors** → 400 with validation details
-3. **Unknown errors** → 500 (masked in production, detailed in development)
-
-All error responses include `x-request-id` for tracing.
-
-### Localized Messages
-
-Error messages are resolved from locale catalogs (en, fr, de) based on the `Accept-Language` header:
+Declare RBAC requirements on the route:
 
 ```typescript
-// English catalog
-"products.notFound": "Product not found",
-"products.skuConflict": "A product with this SKU already exists",
-
-// French catalog
-"products.notFound": "Produit non trouvé",
-"products.skuConflict": "Un produit avec ce SKU existe déjà",
+tenantRoute({
+  permissions: [[Resource.ORDERS, Permission.READ]],
+  guard: requireOrdersFeature,
+  decode: queryParams(OrderQuerySchema),
+  handler: ({ input }) =>
+    Effect.flatMap(OrdersService, (orders) =>
+      orders.findAllPaginated(input),
+    ),
+});
 ```
 
-## Soft Delete
+RBAC answers whether the user may perform an action. A feature guard answers whether the tenant's plan or override enables that product capability. They are separate checks. The current feature keys are `orders` and `smartImport`; Smart Import also requires write permissions for products, locations, and inventory.
 
-Products use soft delete via `deleted_at`, `deleted_by` columns:
+The exact RBAC resources are:
 
-```typescript
-// Repository — exclude deleted by default
-const findAll = () =>
-  tryAsync(() =>
-    db.query.products.findMany({
-      where: isNull(products.deleted_at),
-    })
-  );
+| Resource | Typical scope |
+| --- | --- |
+| `DASHBOARD` | Dashboard access |
+| `ORDERS` | Orders |
+| `CLIENTS` | Clients |
+| `SUPPLIERS` | Suppliers |
+| `STOCK_MOVEMENTS` | Movement ledger |
+| `PRODUCTS` | Product catalog and photos |
+| `LOCATIONS` | Locations and areas |
+| `INVENTORY` | Inventory records and adjustments |
+| `AUDIT_LOGS` | Tenant audit log reads |
+| `USERS` | Tenant users |
+| `SETTINGS` | Tenant settings and branding |
+| `ROLES` | Roles and assignments |
 
-// Include deleted (for admin views)
-const findAllIncludingDeleted = () =>
-  tryAsync(() => db.query.products.findMany());
+Permissions are `READ` and `WRITE`. There is no `STOCK` resource. Role and assignment writes invalidate the permission cache; feature writes invalidate the entitlement cache.
 
-// Soft delete
-const softDelete = (id: string, userId: string) =>
-  tryAsync(() =>
-    db.update(products)
-      .set({ deleted_at: new Date(), deleted_by: userId })
-      .where(eq(products.id, id))
-  );
+## Response contracts
 
-// Restore
-const restore = (id: string) =>
-  tryAsync(() =>
-    db.update(products)
-      .set({ deleted_at: null, deleted_by: null })
-      .where(eq(products.id, id))
-  );
-```
+Routes return their entity or message body directly. There is no HATEOAS layer and `_links` are not a response guarantee. Status codes and delete bodies are route-specific; do not assume every delete returns `204`.
 
-## Response Formats
-
-### Single Entity
+Standard paginated responses have a nested `meta` object:
 
 ```json
 {
-  "id": "uuid",
-  "name": "Product Name",
-  "_links": {
-    "self": { "href": "/api/v1/products/uuid", "method": "GET" }
+  "data": [],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total": 0,
+    "total_pages": 0,
+    "has_next": false,
+    "has_previous": false
   }
 }
 ```
 
-### Paginated List
+Bulk operations use the shared `BulkOperationResult` contract:
 
 ```json
 {
-  "data": [...],
-  "page": 1,
-  "limit": 20,
-  "total": 100
-}
-```
-
-### Bulk Operation
-
-```json
-{
-  "succeeded": ["id1", "id2"],
-  "failed": [
-    { "item": { "sku": "PROD-003" }, "error": "SKU already exists" }
+  "success_count": 2,
+  "failure_count": 1,
+  "succeeded": ["id-1", "id-2"],
+  "failures": [
+    { "id": "id-3", "error": "Product not found" }
   ]
 }
 ```
 
-Use `createBulkResultBuilder` from `platform/bulk-operation.utils.ts` to partition inputs into succeeded/failed, plus `findDuplicates` and `partitionByExistence` for common preflight checks.
+Use `runBulkByIds()` from `platform/effect/run-bulk-by-ids.ts` for ID-based bulk workflows, or the builders from `@stocket/types/common` when the workflow needs custom identifiers.
 
-### No Content (204)
+`respondJson()` and `respondEmpty()` attach `x-request-id`, localize message descriptors, and translate typed failures into the standard error envelope. Better Auth responses, Swagger, typed health responses, and CORS preflight do not all pass through those helpers, so do not promise that header on every possible response.
 
-For operations that return no body (e.g., soft deletes), use `respondEmpty` instead of `respondJson`:
+## Audit logging
+
+Use `respondAuditedMutation()` only for mutations whose tenant audit event is part of the current contract. It emits the response after the mutation succeeds and asks `AuditLogWriter` to write an event in a daemon fiber.
+
+Current tenant-audited routers cover areas, categories, clients, inventory, locations, orders, products, roles, stock movements, and suppliers. This does not imply that every mutation in the system is audited. Users, branding, photos, notification preferences, and tasks are examples outside that coverage; superadmin operations use a separate platform audit log.
+
+Tenant audit rows currently record action, entity type and ID, user ID when available, IP address, and timestamp. `changes` and `user_agent` are currently `null`. The write is best-effort, failure is logged and ignored, and it is not in the business transaction. Do not use this log as a complete change history, a rollback source, or a regulatory guarantee.
+
+## Observability
+
+### Service tracing
+
+Create a tracer once per service and wrap public operations with `span()` or `traced()`:
 
 ```typescript
-import { respondEmpty } from "../../platform/errors";
+const trace = makeServiceTracer({
+  serviceName: 'ClientsService',
+  module: 'clients',
+  layer: 'service',
+});
 
-HttpRouter.delete("/products/:id", respondEmpty(
-  Effect.gen(function* () {
-    yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-    const { id } = yield* HttpRouter.schemaPathParams(Schema.Struct({ id: Schema.UUID }));
-    const service = yield* ProductsService;
-    yield* service.delete(id);
-  }),
-  { status: 204 },
-));
+const findOne = (id: string) =>
+  repository.findById(id).pipe(
+    trace.span('findOne', { attributes: { id } }),
+  );
 ```
 
-## HATEOAS Links
+`makeServiceTracer()` adds module, layer, operation, request ID, tenant ID when available, and an outcome classification. Use catalogued trace attributes rather than arbitrary keys.
 
-HATEOAS links are added to responses via the `addHateoasLinks()` utility:
+### Structured and localized logging
 
-```typescript
-import { addHateoasLinks } from "../../platform/hateoas";
-
-const links = [
-  { rel: "self", href: `/products/${product.id}`, method: "GET" },
-  { rel: "update", href: `/products/${product.id}`, method: "PUT" },
-  { rel: "delete", href: `/products/${product.id}`, method: "DELETE" },
-];
-
-return addHateoasLinks(productDto, links);
-```
-
-The `getBaseUrl()` helper resolves the protocol from `x-forwarded-proto` for correct URLs behind reverse proxies.
-
-## Audit Logging
-
-Audit logging is fire-and-forget — it runs in a background daemon fiber and never blocks the response:
+`createLogger()` comes from `platform/observability/messages.ts`. Its scope prefixes the message key, and its arguments are limited by `LogProperties` in `platform/catalogs/log-properties.ts`.
 
 ```typescript
-const audit = yield* AuditLogWriter;
-yield* audit.log({
-  action: AuditAction.CREATE,
-  entityType: AuditEntityType.PRODUCT,
-  entityId: product.id,
+const logger = createLogger('tasks');
+
+yield* logger.info('settled', {
+  taskId,
+  taskType,
+  workerId,
+  status,
 });
 ```
 
-The audit writer automatically captures:
+Message catalogs live in `platform/catalogs/en.ts`, `fr.ts`, and `de.ts`. Keep their keys synchronized; English defines the typed `MessageKey` set. Avoid unstructured console logging.
 
-- **User ID** — from the current session
-- **IP address** — from request context
-- **User agent** — from request headers
-- **Timestamp** — current time
+### HTTP middleware
 
-### Audit Actions
+For an incoming request, middleware wraps the app in this order:
 
-| Action | When |
-|--------|------|
-| `CREATE` | Entity created |
-| `UPDATE` | Entity modified |
-| `DELETE` | Entity deleted |
-| `RESTORE` | Soft-deleted entity restored |
-| `ADJUST_QUANTITY` | Inventory quantity changed |
-| `ADD_PHOTO` | Photo uploaded |
-| `STATUS_CHANGE` | Status field changed (e.g., order status) |
+1. request logging and request context;
+2. security headers;
+3. CORS, including verified tenant origins;
+4. the 10 MiB request-body limit;
+5. tenant context;
+6. the router.
 
-## Tracing
+The standard request context carries request ID, path, method, IP, locale, and resolved tenant ID.
 
-The backend's chosen tracing abstraction is `makeServiceTracer` from `src/effect/platform/service-tracer.ts`. It wraps service methods with outcome classification (`not_found` / `validation_error` / `failure`) and request-context attributes.
+## Health and API discovery
 
-```typescript
-import { makeServiceTracer } from "../../platform/service-tracer";
+The public health endpoints are:
 
-const tracer = makeServiceTracer("ProductsService");
+| Endpoint | Check | Failure |
+| --- | --- | --- |
+| `GET /health-check/live` | Process liveness only | No dependency check |
+| `GET /health-check/ready` | PostgreSQL connectivity | `503` when the database is down |
+| `GET /health-check` | PostgreSQL and Better Auth secret | `503` when either is down |
 
-const create = tracer("create", (dto: CreateProduct, userId: string) =>
-  Effect.gen(function* () {
-    // ... business logic
-  }),
-);
-```
-
-!!! danger "Do not substitute `Effect.fn("span")`"
-    `Effect.fn` looks similar but does **not** emit the outcome classification or request-context attributes the tracer captures. Service methods must use `makeServiceTracer` — migrations to `Effect.fn` will be reverted.
-
-Legacy services may still use `Effect.withSpan("ServiceName.method")` directly; prefer `makeServiceTracer` for new code.
-
-## Structured Logging
-
-All structured logs must use the typed `LogProperties` vocabulary — arbitrary key/value pairs are rejected so every field can be indexed by Datadog / OpenSearch.
-
-```typescript
-import { createLogger } from "../../platform/console-logging";
-
-const log = createLogger("products");
-
-yield* log.info("products.created", { productId: product.id, sku: product.sku });
-```
-
-- `LogProperties` is defined in `src/effect/platform/messages.ts`. Every placeholder used in a message template must have a corresponding property with its exact type (`string` or `number`).
-- `MessageArgs = Partial<LogProperties>`.
-- Message catalogs live in `src/effect/platform/catalogs/` — one file per locale (`en.ts`, `fr.ts`, `de.ts`). **English (`en.ts`) is the source of truth for `MessageKey`**; French and German must stay in sync.
-- `createLogger(scope)` prepends the scope to every `MessageKey` automatically, so log sites can use short keys (`"created"` → `"products.created"`).
-- Raw `Effect.tryPromise` is acceptable **only** when each call site uses a distinct hand-typed `MessageKey`; otherwise use `makeTryAsync` from `platform/try-async.ts`.
-
-## HTTP Middleware
-
-The HTTP app applies middleware in order (innermost first):
-
-| Middleware | Purpose |
-|-----------|---------|
-| `corsMiddleware` | CORS headers for cross-origin requests |
-| `securityHeadersMiddleware` | Security headers (CSP, X-Frame-Options, etc.) |
-| `requestLoggingMiddleware` | Request/response logging with timing |
-| `bodyLimitMiddleware` | Max 10MB request body |
-
-All responses include `x-request-id` for request correlation.
-
-## Health Checks
-
-### Endpoints
-
-#### Full Health Check
-
-`GET /health-check`
-
-Checks database connectivity and auth configuration:
+A successful health response uses `status`, `info`, `error`, and `details`:
 
 ```json
 {
   "status": "ok",
-  "checks": {
-    "database": "up",
-    "auth": "configured"
+  "info": {
+    "database": { "status": "up" },
+    "better-auth": { "status": "up" }
+  },
+  "error": {},
+  "details": {
+    "database": { "status": "up" },
+    "better-auth": { "status": "up" }
   }
 }
 ```
 
-Returns `503` if any check fails.
+The Swagger UI is mounted at `/docs`, but it currently describes only the health group implemented with `HttpApiBuilder`. Most `/api/v1` modules still use `HttpRouter` and do not appear in that OpenAPI document. Treat Swagger as partial until those modules migrate.
 
-#### Liveness Probe
+## Durable tasks and the worker
 
-`GET /health-check/live`
+Long-running or retryable work must be enqueued as a durable task instead of remaining in the request fiber. The API and worker are separate processes:
 
-Returns `200` if the process is running.
-
-#### Readiness Probe
-
-`GET /health-check/ready`
-
-Checks database connectivity. Returns `503` if the database is unreachable.
-
-### Kubernetes Configuration
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health-check/live
-    port: 8080
-  initialDelaySeconds: 30
-  periodSeconds: 10
-
-readinessProbe:
-  httpGet:
-    path: /health-check/ready
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 5
+```bash
+pnpm --filter @stocket/api start
+pnpm --filter @stocket/api start:worker
 ```
+
+Tasks support `queued`, `running`, `succeeded`, `failed`, and `canceled` states, plus progress, retry attempts, leases, heartbeats, delayed retry, recovery, and cooperative cancellation. Task reads and cancellation require a session and are scoped by tenant and creating user:
+
+- `GET /api/v1/tasks`
+- `GET /api/v1/tasks/:id`
+- `POST /api/v1/tasks/:id/cancel`
+
+Product import is currently the only registered task type. `POST /api/v1/products/import` returns `202` with the task and a `Location: /api/v1/tasks/:id` header. Its `Idempotency-Key` is scoped to tenant, creator, and task type.
+
+To add a task type, define and validate its payload, implement a `TaskHandler`, register it in the worker's `TaskRegistry` layer, add the dependencies to the worker application layer, and expose an enqueueing service. The HTTP process may enqueue tasks; only the worker should execute them.
+
+## Fast verification
+
+For backend API changes, run the smallest relevant checks first:
+
+```bash
+pnpm --filter @stocket/api type-check
+pnpm --filter @stocket/api lint
+pnpm --filter @stocket/api test -- clients
+```
+
+Use the affected module name as the Vitest filter. Run integration tests when persistence, transactions, tenancy, or route composition changes.

--- a/docs/development/architecture.fr.md
+++ b/docs/development/architecture.fr.md
@@ -1,281 +1,270 @@
 # Architecture
 
-## Vue d'Ensemble du Systeme
+Stocket sépare des dépôts publiés indépendamment d'un workspace local
+coordonné. L'application est un système web/API multi-tenant complété par un
+worker de tâches durables.
+
+Pour l'inventaire exhaustif des dépôts et fonctionnalités, consultez la
+[carte des projets et modules](project-map.md).
+
+## Vue d'ensemble
 
 ```mermaid
-graph TB
-    subgraph "Frontend"
-        A[TanStack Start] --> B[React 19]
-        A --> E[TanStack Router]
-        B --> C[TanStack Query]
-        B --> D[TanStack Form]
+flowchart TB
+    subgraph Client
+        UI["React 19 + TanStack Start"]
+        SW["Service worker et page hors ligne"]
+        UI --- SW
     end
 
-    subgraph "Backend"
-        F[Effect.ts + Bun] --> G[Drizzle ORM]
-        G --> H[(PostgreSQL 16)]
+    subgraph Web
+        SSR["Processus SSR TanStack Start"]
+        Proxy["Proxy /api même origine"]
+        SSR --- Proxy
     end
 
-    subgraph "Auth"
-        I[Better Auth]
+    subgraph Backend
+        API["API Effect · Node.js 22"]
+        Worker["Worker durable · Node.js 22"]
+        Auth["Better Auth"]
     end
 
-    A -->|REST API| F
-    A --> I
-    F --> I
+    DB[("PostgreSQL 16")]
+    Storage["Stockage compatible S3"]
+    Mail["E-mail console ou Resend"]
+
+    UI --> SSR
+    Proxy --> API
+    API --- Auth
+    API --> DB
+    API --> Storage
+    API --> Mail
+    Worker --> DB
+    Worker --> Storage
 ```
 
-## Stack Technique
+Le service worker précharge repli/manifeste/ressources de marque, met en cache
+à l'exécution les ressources statiques récupérées et affiche le repli lorsque
+la navigation est hors ligne. Le HTML applicatif réussi et les données métier
+restent dépendants du réseau. Il n'existe ni base locale hors ligne ni
+synchronisation avec résolution de conflits.
+
+## Stack technique
 
 | Couche | Technologie |
 |--------|-------------|
-| Frontend | TanStack Start, React 19, TanStack Router, TanStack Query/Form, Tailwind CSS 4, Radix UI |
-| Backend | Effect.ts, Drizzle ORM, Bun, PostgreSQL 16 |
-| Auth | Better Auth |
-| Docs API | Effect HttpApi (OpenAPI) |
-| Outillage | pnpm workspaces, Nix flakes, TypeScript, Docker Compose |
-| i18n | i18next (en, de, fr) |
+| Web | TanStack Start, React 19, TanStack Router, TanStack Query/Form, Vite, Tailwind CSS 4, StyleX, Base UI/Radix |
+| API et worker | Effect, `@effect/platform-node`, Node.js 22, esbuild |
+| Persistance | PostgreSQL 16 et Drizzle ORM |
+| Authentification | Better Auth avec sessions par cookie |
+| Stockage objet | Client AWS S3 vers MinIO en local et un fournisseur compatible S3 en environnement hébergé |
+| E-mail | Modèles localisés `@stocketfr/emails`, transport console ou Resend |
+| Contrats | Package versionné `@stocketfr/types`, consommé via l'alias `@stocket/types` |
+| Outillage | pnpm 10, TypeScript, Oxlint, Prettier, Vitest, Playwright, flakes Nix |
+| Documentation | MkDocs Material avec localisation anglais/français par suffixe |
 
-## Structure des Repos
+## Frontières des dépôts et releases
 
-```
-stocket/
-├── backend/                # Backend Effect.ts (runtime Bun)
-│   ├── src/
-│   │   └── effect/
-│   │       ├── modules/    # Modules fonctionnels
-│   │       ├── platform/   # Concerns transversaux
-│   │       └── http/       # App HTTP & middleware
-│   └── flake.nix           # Environnement dev Nix
-├── frontend/               # Frontend TanStack Start
-│   ├── src/
-│   │   ├── routes/         # Routes basées sur les fichiers
-│   │   ├── components/     # Composants React
-│   │   └── lib/            # Utilitaires et hooks de données
-│   └── flake.nix           # Environnement dev Nix
-├── packages/
-│   ├── tsconfig/           # Configs TS partagées
-│   ├── eslint-config/      # Config ESLint partagée
-│   └── types/              # Interfaces/enums DTO partagés
-├── documentation/          # Documentation MkDocs
-└── meta/                   # Scripts d'orchestration, Docker Compose
-```
+Les dépôts peuvent être clonés indépendamment. `meta/repos.yaml` décrit le
+checkout assemblé par `meta/scripts/bootstrap` ; `meta/root/` fournit les
+fichiers du workspace pnpm racine.
 
-## Flux de Donnees
+Cette distinction est importante :
 
-```
-┌─────────────────────────────────────────┐
-│           Frontend TanStack Start       │
-│  React Query + clients écrits à la main │
-│  DTO partagés via @stocket/types     │
-│  Better Auth                            │
-└─────────────────────────────────────────┘
-                    ▼ HTTP/REST
-┌─────────────────────────────────────────┐
-│          Backend Effect.ts (Bun)        │
-│  Router → Service → Repository          │
-│  requireSession · requirePermission     │
-│  Drizzle ORM · HATEOAS · Audit Logging  │
-└─────────────────────────────────────────┘
-                    ▼
-┌─────────────────────────────────────────┐
-│             PostgreSQL                  │
-└─────────────────────────────────────────┘
-```
+- les filtres racine facilitent les vérifications locales coordonnées ;
+- chaque dépôt conserve son historique Git, sa CI et sa politique de release ;
+- le backend et le frontend consomment des packages publiés, pas les sources
+  sœurs modifiables ;
+- l'infrastructure est exploitée séparément et n'est pas dans `meta/repos.yaml` ;
+- la livraison backend/frontend est contrôlée par l'opérateur ; aucun
+  déploiement automatique persistant après merge ni workflow de rollback
+  autonome n'existe.
 
-## Flux d'Authentification
+Voir la [configuration de développement](setup.md) et le guide [CI/CD](ci-cd.md).
 
-```
-Utilisateur → Better Auth → Cookie de session
-                              ↓
-Frontend: Session basée sur les cookies
-                              ↓
-Backend: requireSession → vérifier → userId depuis la session
-```
-
-## Modules de Routes Backend
-
-Le backend possède les modules suivants dans `backend/src/effect/modules/` :
-
-| Module | Objectif |
-|--------|----------|
-| **areas** | Zones au sein des emplacements (étagères, bacs, etc.) |
-| **audit-logs** | Piste d'audit pour toutes les modifications d'entités |
-| **auth** | Endpoints d'authentification (Better Auth) |
-| **branding** | Paramètres de personnalisation/marque |
-| **categories** | Catégorisation hiérarchique des produits |
-| **clients** | Gestion des clients |
-| **health** | Endpoints de vérification de santé (liveness, readiness) |
-| **inventory** | Quantités de stock par emplacement/zone |
-| **locations** | Emplacements physiques (entrepôts, etc.) |
-| **orders** | Gestion des commandes |
-| **photos** | Gestion des photos/images pour les produits |
-| **products** | Catalogue de produits (SKU, nom, catégorie) |
-| **roles** | Gestion des rôles et permissions |
-| **stock-movements** | Suivi des mouvements de stock (transferts, ajustements) |
-| **suppliers** | Gestion des fournisseurs |
-| **users** | Gestion des utilisateurs |
-
-## Couche Plateforme du Backend
-
-Infrastructure partagée dans `backend/src/effect/platform/` :
-
-| Répertoire / Fichier | Objectif |
-|----------------------|----------|
-| **authorization.ts** | Effect `requirePermission(resource, permission)` |
-| **permission-provider.ts** | Recherche de permissions avec cache (TTL 1 min) |
-| **session.ts** | Effects `requireSession`, `getOptionalSession` |
-| **better-auth.ts** | Intégration Better Auth (APIs admin) |
-| **errors.ts** | Factories d'erreurs de domaine (`NotFoundError`, `BadRequestError`, etc.) |
-| **messages.ts** | Système de messages localisés (en, fr, de) |
-| **audit.ts** | Écriture d'audit fire-and-forget |
-| **drizzle.ts** | Couche Drizzle ORM avec pool de connexions |
-| **hateoas.ts** | Utilitaires de liens HATEOAS |
-| **request-context.ts** | ID de requête, chemin, méthode, IP, locale |
-| **db/** | Définitions de schéma, relations, migrations |
-
-## Workflow des Types Partagés
-
-Les interfaces/enums DTO partagés sont le contrat entre frontend et backend :
-
-```bash
-# 1. Générer les exports barrel
-pnpm --filter @stocket/types barrels
-
-# 2. Build des types partagés
-pnpm --filter @stocket/types build
-```
-
-!!! warning "Garder les types alignés"
-    Assurez-vous que les DTO backend et les hooks frontend correspondent à `packages/types`.
-
-## Modèle de Domaine
+## Flux des requêtes et des tenants
 
 ```mermaid
-classDiagram
-    class Product {
-        +uuid id
-        +string sku
-        +string name
-        +uuid category_id
-        +int reorder_point
-    }
+sequenceDiagram
+    participant Navigateur
+    participant Web as TanStack Start
+    participant API as API Effect
+    participant Auth as Better Auth
+    participant DB as PostgreSQL
 
-    class Location {
-        +uuid id
-        +string name
-        +LocationType type
-    }
-
-    class Area {
-        +uuid id
-        +uuid location_id
-        +uuid parent_id
-        +string name
-        +string code
-    }
-
-    class Inventory {
-        +uuid id
-        +uuid product_id
-        +uuid location_id
-        +uuid area_id
-        +int quantity
-    }
-
-    class Category {
-        +uuid id
-        +string name
-        +uuid parent_id
-    }
-
-    class Client {
-        +uuid id
-        +string name
-    }
-
-    class Supplier {
-        +uuid id
-        +string name
-    }
-
-    class Order {
-        +uuid id
-        +uuid client_id
-        +OrderStatus status
-    }
-
-    class StockMovement {
-        +uuid id
-        +uuid product_id
-        +uuid from_location_id
-        +uuid to_location_id
-        +int quantity
-    }
-
-    class Role {
-        +uuid id
-        +string name
-        +Permission[] permissions
-    }
-
-    class User {
-        +uuid id
-        +string email
-        +uuid role_id
-    }
-
-    Product --> Category : appartient à
-    Product --> Inventory : suivi dans
-    Location --> Inventory : stocke
-    Location --> Area : contient
-    Area --> Area : parent/enfants
-    Area --> Inventory : précise l'emplacement
-    Order --> Client : passée par
-    Supplier --> Product : fournit
-    StockMovement --> Product : déplace
-    StockMovement --> Location : de/vers
-    User --> Role : possède
+    Navigateur->>Web: Requête sur l'hôte plateforme ou tenant
+    Web->>API: Requête /api + hôte/protocole d'origine
+    API->>API: Résoudre le contexte plateforme ou tenant
+    API->>Auth: Résoudre la session cookie
+    Auth->>DB: Lire session/utilisateur
+    API->>API: Appliquer droits fonctionnels et permissions
+    API->>DB: Exécuter l'opération limitée au tenant
+    DB-->>API: Résultat
+    API-->>Navigateur: Réponse JSON
 ```
 
-### Entités Principales
+`PLATFORM_HOST` identifie l'hôte d'administration plateforme et
+`TENANT_BASE_DOMAIN` les sous-domaines tenant. Le processus web transmet l'hôte
+et le protocole d'origine via son proxy de confiance ; l'API rejette les hôtes
+inconnus avant tout accès aux données tenant.
 
-| Entité | Objectif |
-|--------|----------|
-| **Product** | Article du catalogue (quoi) - SKU, nom, catégorie, seuil de réapprovisionnement |
-| **Category** | Organisation hiérarchique des produits |
-| **Location** | Lieu physique (où) - entrepôt, fournisseur, client, en transit |
-| **Area** | Zone au sein d'un emplacement (où exactement) - étagère, bac, chambre froide |
-| **Inventory** | Quantité de stock (combien) d'un produit à un emplacement/zone |
-| **Client** | Client qui passe des commandes |
-| **Supplier** | Fournisseur externe approvisionnant en produits |
-| **Order** | Commande client pour des produits |
-| **StockMovement** | Enregistrement des transferts, ajustements et mouvements de stock |
-| **Role** | Ensemble nommé de permissions pour l'autorisation |
-| **User** | Utilisateur du système avec un rôle assigné |
-| **Photo** | Image associée à un produit |
-| **AuditLog** | Enregistrement des modifications d'entités pour la piste d'audit |
+## Couches backend
 
-### Décisions de Conception
+Les deux points d'entrée sont `src/effect/main.ts` et
+`src/effect/task-worker.ts`. Ils composent des layers Effect explicites depuis
+`src/effect/application/layers.ts`.
 
-1. **Séparation Product vs Inventory** - Les produits définissent ce qu'est un article. L'inventaire suit les quantités par emplacement.
-2. **Types d'emplacement** - `WAREHOUSE`, `SUPPLIER`, `IN_TRANSIT`, `CLIENT` décrivent la catégorie de lieu.
-3. **Les zones sont optionnelles** - L'inventaire peut référencer uniquement un emplacement, ou optionnellement une zone pour un suivi précis.
-4. **Hiérarchie des zones** - Les zones supportent les relations parent-enfant (Zone A -> Étagère A1 -> Bac A1-1).
-5. **Contrainte d'unicité** - Un seul enregistrement d'inventaire par combinaison (produit, emplacement, zone).
-6. **Auth basée sur les permissions** - Les rôles contiennent des permissions granulaires ; l'Effect `requirePermission` applique le contrôle d'accès par endpoint.
+```text
+Router HTTP
+  → garde tenant/session/fonctionnalité/permission
+  → décodage de la requête
+  → service du module
+  → repository ou adaptateur externe
+  → mapping des erreurs typées et réponse
+```
 
-## Patterns Clés
+Structure courante d'un module :
 
-| Pattern | Emplacement | Objectif |
-|---------|-------------|----------|
-| Repository | `backend/src/effect/modules/*/` | Accès aux données via Drizzle ORM |
-| Service | `backend/src/effect/modules/*/` | Logique métier comme services Effect |
-| Router | `backend/src/effect/modules/*/` | Gestionnaires de routes HTTP |
-| requireSession | `backend/src/effect/platform/` | Vérification de session Effect |
-| requirePermission | `backend/src/effect/platform/` | Autorisation basée sur les permissions |
-| AuditLogWriter | `backend/src/effect/platform/` | Journalisation d'audit fire-and-forget |
-| Erreurs de domaine | `backend/src/effect/platform/` | Factories d'erreurs HTTP typées |
-| HATEOAS | `backend/src/effect/platform/` | Liens hypermédia REST |
-| Composition de Layers | `backend/src/effect/main.ts` | Injection de dépendances via les layers Effect |
-| DTO partagés | `packages/types/src/` | Contrats backend/frontend |
+```text
+modules/<feature>/
+├── router.ts          # frontière HTTP si le module est routable
+├── service.ts         # opérations applicatives et métier
+├── repository.ts      # accès Drizzle
+├── mappers.ts         # conversion base → contrat
+├── write.ts           # coordination des mutations si utile
+├── types.ts           # types internes
+└── *.errors.ts        # erreurs de domaine/infrastructure
+```
+
+Les schémas de requête/réponse vivent généralement dans `@stocketfr/types`.
+Le code transversal est réparti par préoccupation dans
+`src/effect/platform/` : `auth/`, `db/`, `http/`, `observability/`, `tenancy/`
+et `storage.ts`.
+
+À chaque démarrage hors production, l'API exécute SQL commité, préparation des
+marqueurs, migration/réparation Better Auth, nettoyage des hôtes uniquement en
+développement, puis migrations superadmin en attente. En production, elle ne
+s'exécute que si `RUN_BETTER_AUTH_MIGRATIONS=true`. Le seed des rôles par défaut
+et le scan des notifications s'exécutent à chaque démarrage API indépendamment
+de cette garde.
+
+## Tâches durables et imports produit
+
+Les imports volumineux sont asynchrones :
+
+```mermaid
+sequenceDiagram
+    participant UI
+    participant API
+    participant Storage as Stockage
+    participant DB
+    participant Worker
+
+    UI->>API: Preview et proposition éventuelle
+    API-->>UI: Lignes, mappings, avertissements, plan proposé
+    UI->>API: Plan approuvé + CSV + clé d'idempotence
+    API->>Storage: Stocker le fichier d'entrée
+    API->>DB: Créer la tâche
+    API-->>UI: 202 + Location de la tâche
+    Worker->>DB: Louer la tâche en attente
+    Worker->>Storage: Lire l'entrée approuvée
+    loop Chaque ligne récupérable
+        Worker->>DB: Appliquer la ligne dans sa transaction
+        Worker->>Storage: Récupérer/stocker la photo après commit
+    end
+    Worker->>DB: Enregistrer progression et résultat terminal
+    UI->>API: Interroger l'état sans relancer l'import
+```
+
+Les leases PostgreSQL permettent plusieurs workers. Ceux-ci envoient des
+heartbeats, récupèrent les leases expirés, limitent les écritures de progression
+et réessaient selon la configuration. Une ligne en erreur est inscrite dans le
+résultat partiel sans annuler les lignes déjà commitées. Les photos distantes
+sont traitées après le commit de leur ligne ; leur échec n'annule donc pas le
+produit. Un observer supprime le fichier d'entrée après règlement du résultat ;
+une règle de cycle de vie objet reste recommandée comme filet de sécurité.
+
+## Workflow des contrats partagés
+
+Un changement inter-dépôts suit normalement cet ordre :
+
+1. modifier le package et ajouter un Changeset ;
+2. utiliser le snapshot immuable de la pull request pour les tests coordonnés ;
+3. fusionner le package puis la PR de version Changesets ;
+4. mettre à jour la version stable épinglée par les consommateurs ;
+5. exécuter les typechecks et tests inter-stack pertinents.
+
+Le package expose des sous-chemins comme `products`, `tasks`, `features` et
+`common`. Dans `packages/types`, exécutez `pnpm barrels` avant `pnpm build` lors
+de l'ajout de fichiers gérés par le générateur.
+
+## Authentification et autorisation
+
+Better Auth possède les endpoints compte/session sous `/api/auth`. Les handlers
+tenant ajoutent trois contrôles :
+
+1. résolution de l'hôte vers le tenant ;
+2. vérification des droits fonctionnels si nécessaire ;
+3. permissions `READ`/`WRITE` par ressource.
+
+Les utilisateurs Better Auth sont des comptes globaux. Un hôte vérifié choisit
+le tenant, puis une appartenance relie le compte à ce tenant ; un compte peut
+appartenir à plusieurs tenants. Les rôles tenant se combinent par union. Les
+fonctionnalités sont indépendantes du RBAC : une route peut exiger à la fois une
+permission et une fonctionnalité activée. Les superadmins plateforme utilisent
+`/platform` et `/api/v1/superadmin/*`. Être administrateur tenant ne donne pas
+l'accès plateforme.
+
+## Modèle de domaine
+
+```mermaid
+erDiagram
+    TENANT ||--o{ MEMBER : a
+    USER ||--o{ MEMBER : rejoint
+    MEMBER }o--o{ ROLE : possede
+    TENANT ||--o{ PRODUCT : possede
+    CATEGORY ||--o{ PRODUCT : classe
+    LOCATION ||--o{ AREA : contient
+    AREA ||--o{ AREA : imbrique
+    PRODUCT ||--o{ INVENTORY : stocke
+    LOCATION ||--o{ INVENTORY : conserve
+    AREA o|--o{ INVENTORY : precise
+    CLIENT ||--o{ ORDER : passe
+    ORDER ||--o{ ORDER_ITEM : contient
+    PRODUCT ||--o{ ORDER_ITEM : reference
+    PRODUCT ||--o{ STOCK_MOVEMENT : deplace
+    PRODUCT ||--o{ PHOTO : illustre
+    TENANT ||--o{ BACKGROUND_TASK : planifie
+```
+
+Invariants importants :
+
+- le produit décrit le catalogue, l'inventaire la quantité et le placement ;
+- une zone appartient à un emplacement et ne peut s'imbriquer que dans celui-ci ;
+- les chemins des zones respectent le tenant et les permissions ;
+- les mouvements sont des écritures de registre : leur création ne modifie pas
+  l'inventaire et un ajustement d'inventaire ne crée pas automatiquement de
+  mouvement actuellement ;
+- les commandes suivent une machine à états explicite ;
+- les écritures d'audit sont lancées en arrière-plan, au mieux, et ne font pas
+  partie de la transaction métier ;
+- les IDs tenant limitent les données et requêtes repository.
+
+## Documentation API
+
+L'API migre progressivement des modules `HttpRouter` écrits à la main vers des
+groupes Effect `HttpApiBuilder`. Swagger est servi sous `/docs`, mais ne décrit
+actuellement que les groupes migrés (la santé). Ce n'est pas encore un
+catalogue complet des endpoints.
+
+## Modèle de déploiement
+
+Le code prend en charge le développement local et une topologie hébergée gérée
+séparément. La CI backend/frontend ne déploie pas automatiquement après merge.
+Un chemin manuel temporaire a servi à un rollout de production audité en juillet
+2026, sans constituer un CD persistant ni un workflow autonome de rollback. Le
+dépôt infrastructure exploite le runtime sur un serveur. Son helper tente de
+restaurer l'image précédente lorsque ses propres contrôles Compose/readiness
+échouent après le début du remplacement ; les contrôles ultérieurs du workflow
+ne déclenchent pas cette récupération. Voir [CI/CD](ci-cd.md) pour la frontière
+exacte.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,304 +1,274 @@
 # Architecture
 
+Stocket separates independently released repositories from a coordinated local
+workspace. The application itself is a tenant-aware web/API system with a
+durable background worker.
+
+For the exhaustive repository and feature inventory, see the
+[Project and Module Map](project-map.md).
+
 ## System Overview
 
 ```mermaid
-graph TB
-    subgraph "Frontend"
-        A[TanStack Start] --> B[React 19]
-        A --> E[TanStack Router]
-        B --> C[TanStack Query]
-        B --> D[TanStack Form]
+flowchart TB
+    subgraph Client
+        UI["React 19 + TanStack Start"]
+        SW["Service worker and offline fallback"]
+        UI --- SW
     end
 
-    subgraph "Backend"
-        F[Effect.ts + Bun] --> G[Drizzle ORM]
-        G --> H[(PostgreSQL 16)]
+    subgraph Web
+        SSR["TanStack Start SSR process"]
+        Proxy["Same-origin /api proxy"]
+        SSR --- Proxy
     end
 
-    subgraph "Auth"
-        I[Better Auth]
+    subgraph Backend
+        API["Effect API · Node.js 22"]
+        Worker["Durable task worker · Node.js 22"]
+        Auth["Better Auth"]
     end
 
-    A -->|REST API| F
-    A --> I
-    F --> I
+    DB[("PostgreSQL 16")]
+    Storage["S3-compatible storage"]
+    Mail["Console or Resend email"]
+
+    UI --> SSR
+    Proxy --> API
+    API --- Auth
+    API --> DB
+    API --> Storage
+    API --> Mail
+    Worker --> DB
+    Worker --> Storage
 ```
 
-## Tech Stack
+The service worker precaches its fallback/manifest/brand assets, runtime-caches
+fetched static assets, and shows the fallback when navigation is offline.
+Successful application HTML and business data remain network-backed. There is
+no offline database or conflict-resolving synchronization layer.
+
+## Technology Stack
 
 | Layer | Technology |
 |-------|------------|
-| Frontend | TanStack Start, React 19, TanStack Router, TanStack Query/Form, Tailwind CSS 4, Radix UI |
-| Backend | Effect.ts, Drizzle ORM, Bun, PostgreSQL 16 |
-| Auth | Better Auth |
-| API Docs | Effect HttpApi (OpenAPI) |
-| Tooling | pnpm workspaces, Nix flakes, TypeScript, Docker Compose |
-| i18n | i18next (en, de, fr) |
+| Web | TanStack Start, React 19, TanStack Router, TanStack Query/Form, Vite, Tailwind CSS 4, StyleX, Base UI/Radix |
+| API and worker | Effect, `@effect/platform-node`, Node.js 22, esbuild |
+| Persistence | PostgreSQL 16 and Drizzle ORM |
+| Authentication | Better Auth with cookie sessions |
+| Object storage | AWS S3 client against MinIO locally and an S3-compatible provider in hosted environments |
+| Email | Localized `@stocketfr/emails` templates with console or Resend transport |
+| Contracts | Versioned `@stocketfr/types` package, consumed through the `@stocket/types` alias |
+| Tooling | pnpm 10, TypeScript, Oxlint, Prettier, Vitest, Playwright, Nix flakes |
+| Documentation | MkDocs Material with English/French suffix-based localization |
 
-## Repository Structure
+## Repository and Release Boundaries
 
-Stocket is a pnpm monorepo. All packages live under one workspace root with a single `pnpm-lock.yaml`.
+The repositories can be cloned independently. `meta/repos.yaml` describes the
+checkout assembled by `meta/scripts/bootstrap`; `meta/root/` supplies the root
+pnpm workspace files used in that checkout.
 
-```
-stocket/
-├── backend/                # Effect.ts API (Bun runtime, @stocket/api)
-│   ├── src/
-│   │   └── effect/
-│   │       ├── modules/    # Feature modules
-│   │       ├── platform/   # Cross-cutting concerns
-│   │       └── http/       # HTTP app & middleware
-│   └── flake.nix           # Per-package Nix dev shell (optional)
-├── frontend/               # TanStack Start SSR app (@stocket/web)
-│   ├── src/
-│   │   ├── routes/         # File-based routes (_authed/ for protected)
-│   │   ├── components/     # React components
-│   │   └── lib/            # Utilities and data hooks
-│   └── flake.nix           # Per-package Nix dev shell (optional)
-├── mobile-app/             # Expo React Native app (@stocket/mobile)
-├── landing/                # Static marketing site
-├── remote-desktop/         # Tauri 2 desktop app (@stocket/remote-desktop)
-├── packages/
-│   ├── tsconfig/           # Shared TS configs (base.json, nestjs.json)
-│   ├── eslint-config/      # Shared ESLint config (legacy; not consumed today)
-│   └── types/              # Shared DTO interfaces/enums (@stocket/types)
-├── documentation/          # MkDocs documentation site (this site)
-├── meta/                   # docker-compose.yml, legacy multi-repo scripts
-├── infrastructure/         # Terraform (Hetzner + Cloudflare; not a workspace member)
-├── pnpm-workspace.yaml     # Single workspace definition
-└── pnpm-lock.yaml          # Single lockfile for the whole monorepo
-```
+This distinction matters:
 
-## Data Flow
+- root filters are convenient for coordinated local checks;
+- each repository retains its own Git history, CI, and lock/release policy;
+- backend and frontend consume published shared packages, not mutable sibling
+  source;
+- infrastructure is operated separately and is not in `meta/repos.yaml`;
+- backend/frontend application delivery is operator-controlled; there is no
+  persistent automatic post-merge deploy or standalone rollback workflow.
 
-```
-┌─────────────────────────────────────────┐
-│           TanStack Start Frontend       │
-│  React Query + handwritten clients       │
-│  Shared DTOs from @stocket/types      │
-│  Better Auth                             │
-└─────────────────────────────────────────┘
-                    ▼ HTTP/REST
-┌─────────────────────────────────────────┐
-│          Effect.ts Backend (Bun)        │
-│  Router → Service → Repository          │
-│  requireSession · requirePermission     │
-│  Drizzle ORM · HATEOAS · Audit Logging  │
-└─────────────────────────────────────────┘
-                    ▼
-┌─────────────────────────────────────────┐
-│             PostgreSQL                  │
-└─────────────────────────────────────────┘
+See [Development Setup](setup.md) for the supported bootstrap flow and
+[CI/CD](ci-cd.md) for current lifecycle details.
+
+## Request and Tenant Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Web as TanStack Start
+    participant API as Effect API
+    participant Auth as Better Auth
+    participant DB as PostgreSQL
+
+    Browser->>Web: Request on platform or tenant hostname
+    Web->>API: /api request + original host/protocol
+    API->>API: Resolve platform or tenant context
+    API->>Auth: Resolve cookie session
+    Auth->>DB: Read session/user
+    API->>API: Apply feature and resource permission guards
+    API->>DB: Run tenant-scoped operation
+    DB-->>API: Result
+    API-->>Browser: JSON response
 ```
 
-## Authentication Flow
+`PLATFORM_HOST` identifies the platform administration host.
+`TENANT_BASE_DOMAIN` defines tenant subdomains. The web process forwards the
+original host and protocol only through its trusted same-origin proxy path;
+the API rejects unknown hosts before tenant data access.
 
-```
-User → Better Auth → Session Cookie
-                       ↓
-Frontend: Cookie-based session
-                       ↓
-Backend: requireSession → verify → userId from session
-```
+## Backend Layering
 
-## Backend Route Modules
+The two backend entrypoints are `src/effect/main.ts` and
+`src/effect/task-worker.ts`. Both compose explicit Effect layers from
+`src/effect/application/layers.ts`.
 
-The backend has the following modules in `backend/src/effect/modules/`:
-
-| Module | Purpose |
-|--------|---------|
-| **areas** | Zones within locations (shelves, bins, etc.) |
-| **audit-logs** | Audit trail for all entity changes |
-| **auth** | Authentication endpoints (Better Auth) |
-| **branding** | Branding/customization settings |
-| **categories** | Hierarchical product categorization |
-| **clients** | Client/customer management |
-| **fulfillment** | Order fulfillment, packing, and shipment tracking |
-| **health** | Health check endpoints (liveness, readiness) |
-| **inventory** | Stock quantities at locations/areas |
-| **locations** | Physical locations (warehouses, etc.) |
-| **orders** | Order management |
-| **photos** | Photo/image management for products |
-| **products** | Product catalog (SKU, name, category) |
-| **roles** | Role and permission management |
-| **stock-movements** | Stock movement tracking (transfers, adjustments) |
-| **suppliers** | Supplier management |
-| **users** | User management |
-
-## Backend Platform Layer
-
-Shared infrastructure in `backend/src/effect/platform/`:
-
-| Directory / File | Purpose |
-|------------------|---------|
-| **authorization.ts** | `requirePermission(resource, permission)` Effect |
-| **permission-provider.ts** | Cached permission lookups (1-min TTL) |
-| **session.ts** | `requireSession`, `getOptionalSession` Effects |
-| **better-auth.ts** | Better Auth integration (admin APIs) |
-| **errors.ts** | Domain error factories (`NotFoundError`, `BadRequestError`, etc.) + `respondJson` / `respondEmpty` |
-| **domain-errors.ts** | `isAppError` classification for typed error guards |
-| **messages.ts** | Localized message system + `LogProperties` type definitions |
-| **catalogs/** | Message catalogs per locale (`en.ts`, `fr.ts`, `de.ts`); `en.ts` is the source of truth for `MessageKey` |
-| **console-logging.ts** | Structured logging setup (`createLogger(scope)`) |
-| **audit.ts** | Fire-and-forget audit log writer |
-| **drizzle.ts** | Drizzle ORM database layer with connection pooling |
-| **drizzle-query.utils.ts** | Drizzle query helpers |
-| **drizzle-sort.utils.ts** | Sort-by utilities for list endpoints |
-| **hateoas.ts** | HATEOAS link utilities |
-| **pagination.utils.ts** | `toPaginatedResponse` and pagination helpers |
-| **bulk-operation.utils.ts** | `createBulkResultBuilder`, `findDuplicates`, `partitionByExistence` |
-| **service-tracer.ts** | `makeServiceTracer` — the project's chosen tracing abstraction |
-| **try-async.ts** | `makeTryAsync` — promise-to-Effect wrapper that maps to module infrastructure errors |
-| **from-null-or.ts** | Null coercion helper |
-| **request-context.ts** | Request ID, path, method, IP, locale |
-| **tracing.ts** | OpenTelemetry exporter wiring |
-| **db/** | Schema definitions, relations, migrations |
-
-!!! warning "Tracing abstraction is not `Effect.fn`"
-    `makeServiceTracer` captures outcome classification (`not_found` / `validation_error` / `failure`) and request-context attributes that `Effect.fn("span")` does not. **Do not migrate service methods to `Effect.fn`** — the service tracer was deliberately rebuilt for this purpose.
-
-## Shared-Types Workflow
-
-Shared DTO interfaces/enums are the contract between frontend and backend:
-
-```bash
-# 1. Generate barrel exports
-pnpm --filter @stocket/types barrels
-
-# 2. Build shared types
-pnpm --filter @stocket/types build
+```text
+HTTP router
+  → tenant/session/feature/permission guard
+  → request decoding
+  → module service
+  → repository or external adapter
+  → typed error mapping and response
 ```
 
-!!! warning "Keep shared types aligned"
-    Ensure backend DTOs and frontend hooks match `packages/types`.
+Most business modules contain some combination of:
+
+```text
+modules/<feature>/
+├── router.ts          # HTTP boundary, when the module is routable
+├── service.ts         # application/domain operations
+├── repository.ts      # Drizzle access
+├── mappers.ts         # database-to-contract mapping
+├── write.ts           # mutation coordination, when useful
+├── types.ts           # internal types
+└── *.errors.ts        # tagged domain/infrastructure failures
+```
+
+Request and response schemas generally live in `@stocketfr/types`; backend
+modules may keep internal schemas close to the implementation.
+
+Cross-cutting code is grouped by concern under `src/effect/platform/`:
+
+- `auth/` — session, permissions, and Better Auth adapter;
+- `db/` — Drizzle, committed SQL migrations, tenant helpers, transactions;
+- `http/` — tenant route wrappers, decoding, search params, and errors;
+- `observability/` — structured logging, localized catalogs, tracing;
+- `tenancy/` — host validation, tenant context, and feature access;
+- `storage.ts` — object-storage adapter.
+
+Every non-production API start runs committed SQL, data-marker preparation,
+Better Auth migration/repair, development-only hostname cleanup, then pending
+superadmin data migrations. Production runs that sequence only when
+`RUN_BETTER_AUTH_MIGRATIONS=true`. Default-role seeding and notification
+scanning run on every API startup regardless of that migration gate.
+
+## Durable Tasks and Product Imports
+
+Large product imports are asynchronous:
+
+```mermaid
+sequenceDiagram
+    participant UI
+    participant API
+    participant Storage
+    participant DB
+    participant Worker
+
+    UI->>API: Preview and optionally request a proposal
+    API-->>UI: Parsed rows, mappings, warnings, proposed plan
+    UI->>API: Approved plan + CSV + idempotency key
+    API->>Storage: Store input object
+    API->>DB: Enqueue task
+    API-->>UI: 202 + task Location
+    Worker->>DB: Lease queued task
+    Worker->>Storage: Read approved input
+    loop Each recoverable row
+        Worker->>DB: Apply row in its own transaction
+        Worker->>Storage: Fetch/store remote photo after row commit
+    end
+    Worker->>DB: Persist progress and terminal result
+    UI->>API: Poll task safely
+```
+
+PostgreSQL leases allow multiple workers to compete safely. Workers heartbeat,
+recover expired leases, throttle progress writes, and retry according to the
+environment configuration. A row failure is recorded in the partial result and
+does not roll back already committed rows. Remote-photo work happens after its
+row commit, so photo failure is also reported without undoing the product.
+Terminal observers clean up stored input after the database result settles; an
+object-storage lifecycle rule is still recommended as a crash fallback.
+
+## Shared Contract Workflow
+
+`packages/types` is not edited transitively from an application PR. A
+cross-repository contract change normally follows this order:
+
+1. change the package and add a Changeset;
+2. publish/use the pull request's immutable snapshot for coordinated testing;
+3. merge the package and its Changesets version PR;
+4. update the stable version pinned by backend/frontend;
+5. run consumer type checks and relevant cross-stack tests.
+
+The package exposes domain subpaths such as `products`, `tasks`, `features`,
+and `common`. Run `pnpm barrels` before `pnpm build` in `packages/types` when
+adding files matched by the barrel generator.
+
+## Authentication and Authorization
+
+Better Auth owns account/session endpoints at `/api/auth`. Tenant API handlers
+then apply three separate controls:
+
+1. host-to-tenant resolution;
+2. feature entitlement checks where applicable;
+3. resource `READ`/`WRITE` permission checks.
+
+Better Auth users are global accounts. A verified hostname selects a tenant,
+then a membership connects that account to the tenant; one account can belong
+to several tenants. Users may have multiple tenant roles and effective
+permissions are their union. Feature entitlements are independent of RBAC: a
+route can require both a resource permission and an enabled tenant feature.
+Platform superadmins use `/platform` and `/api/v1/superadmin/*`; being a tenant
+admin does not itself grant platform access.
 
 ## Domain Model
 
 ```mermaid
-classDiagram
-    class Product {
-        +uuid id
-        +string sku
-        +string name
-        +uuid category_id
-        +int reorder_point
-    }
-
-    class Location {
-        +uuid id
-        +string name
-        +LocationType type
-    }
-
-    class Area {
-        +uuid id
-        +uuid location_id
-        +uuid parent_id
-        +string name
-        +string code
-    }
-
-    class Inventory {
-        +uuid id
-        +uuid product_id
-        +uuid location_id
-        +uuid area_id
-        +int quantity
-    }
-
-    class Category {
-        +uuid id
-        +string name
-        +uuid parent_id
-    }
-
-    class Client {
-        +uuid id
-        +string name
-    }
-
-    class Supplier {
-        +uuid id
-        +string name
-    }
-
-    class Order {
-        +uuid id
-        +uuid client_id
-        +OrderStatus status
-    }
-
-    class StockMovement {
-        +uuid id
-        +uuid product_id
-        +uuid from_location_id
-        +uuid to_location_id
-        +int quantity
-    }
-
-    class Role {
-        +uuid id
-        +string name
-        +Permission[] permissions
-    }
-
-    class User {
-        +uuid id
-        +string email
-        +uuid role_id
-    }
-
-    Product --> Category : belongs to
-    Product --> Inventory : tracked in
-    Location --> Inventory : stores
-    Location --> Area : contains
-    Area --> Area : parent/children
-    Area --> Inventory : specifies placement
-    Order --> Client : placed by
-    Supplier --> Product : supplies
-    StockMovement --> Product : moves
-    StockMovement --> Location : from/to
-    User --> Role : has
+erDiagram
+    TENANT ||--o{ MEMBER : has
+    USER ||--o{ MEMBER : joins
+    MEMBER }o--o{ ROLE : assigned
+    TENANT ||--o{ PRODUCT : owns
+    CATEGORY ||--o{ PRODUCT : groups
+    LOCATION ||--o{ AREA : contains
+    AREA ||--o{ AREA : nests
+    PRODUCT ||--o{ INVENTORY : stocked_as
+    LOCATION ||--o{ INVENTORY : stores
+    AREA o|--o{ INVENTORY : pinpoints
+    CLIENT ||--o{ ORDER : places
+    ORDER ||--o{ ORDER_ITEM : contains
+    PRODUCT ||--o{ ORDER_ITEM : references
+    PRODUCT ||--o{ STOCK_MOVEMENT : moves
+    PRODUCT ||--o{ PHOTO : illustrates
+    TENANT ||--o{ BACKGROUND_TASK : queues
 ```
 
-### Core Entities
+Important invariants include:
 
-| Entity | Purpose |
-|--------|---------|
-| **Product** | Catalog item (what) - SKU, name, category, reorder point |
-| **Category** | Hierarchical product organization |
-| **Location** | Physical place (where) - warehouse, supplier, client, in-transit |
-| **Area** | Zone within a location (where exactly) - shelf, bin, cold storage |
-| **Inventory** | Stock quantity (how many) of a product at a location/area |
-| **Client** | Customer who places orders |
-| **Supplier** | External supplier providing products |
-| **Order** | Customer order for products |
-| **StockMovement** | Record of stock transfers, adjustments, and movements |
-| **Role** | Named set of permissions for authorization |
-| **User** | System user with assigned role |
-| **Photo** | Image associated with a product |
-| **AuditLog** | Record of entity changes for audit trail |
+- products describe catalog items; inventory describes quantity and placement;
+- an area belongs to one location and can nest within that location;
+- inventory area paths are tenant- and permission-filtered;
+- stock movements are ledger records; creating one does not mutate inventory,
+  and inventory adjustment does not currently create a movement automatically;
+- order transitions follow an explicit state machine;
+- audit writes are best-effort background inserts and are not part of the
+  business mutation transaction;
+- tenant IDs scope business data and repository queries.
 
-### Design Decisions
+## API Documentation
 
-1. **Product vs Inventory separation** - Products define what an item is. Inventory tracks quantities at locations.
-2. **Location types** - `WAREHOUSE`, `SUPPLIER`, `IN_TRANSIT`, `CLIENT` describe the category of place.
-3. **Areas are optional** - Inventory can reference just a Location, or optionally an Area for precise tracking.
-4. **Area hierarchy** - Areas support parent-child relationships (Zone A -> Shelf A1 -> Bin A1-1).
-5. **Unique constraint** - One inventory record per (product, location, area) combination.
-6. **Permission-based auth** - Roles contain granular permissions; `requirePermission` Effect enforces access per endpoint.
+The API is transitioning from hand-written `HttpRouter` modules to typed Effect
+`HttpApiBuilder` groups. Swagger is served at `/docs`, but currently documents
+only migrated groups (the health API). Do not treat it as a complete endpoint
+catalog until all legacy routers have migrated.
 
-## Key Patterns
+## Deployment Model
 
-| Pattern | Location | Purpose |
-|---------|----------|---------|
-| Repository | `backend/src/effect/modules/*/` | Data access via Drizzle ORM |
-| Service | `backend/src/effect/modules/*/` | Business logic as Effect services |
-| Router | `backend/src/effect/modules/*/` | HTTP route handlers |
-| requireSession | `backend/src/effect/platform/` | Session verification Effect |
-| requirePermission | `backend/src/effect/platform/` | Permission-based authorization |
-| AuditLogWriter | `backend/src/effect/platform/` | Fire-and-forget audit logging |
-| Domain Errors | `backend/src/effect/platform/` | Typed HTTP error factories |
-| HATEOAS | `backend/src/effect/platform/` | REST hypermedia links |
-| Layer Composition | `backend/src/effect/main.ts` | Dependency injection via Effect layers |
-| Shared DTOs | `packages/types/src/` | Backend/Frontend contracts |
+The source supports local development and a separately managed hosted
+topology. Backend and frontend CI does not automatically deploy after merge.
+A temporary manual-only path was used for an audited July 2026 production
+rollout, but it is not a persistent CD or standalone rollback surface. The
+infrastructure repository operates the single-box runtime. Its deploy helper
+can best-effort restore the previous image when its own Compose/readiness checks
+fail after replacement begins; later workflow checks do not trigger that
+recovery. See [CI/CD](ci-cd.md) for the exact boundary.

--- a/docs/development/ci-cd.fr.md
+++ b/docs/development/ci-cd.fr.md
@@ -1,145 +1,134 @@
-# CI/CD
+# CI, releases et déploiement
 
-Ce guide couvre les workflows GitHub Actions et les processus de déploiement pour Stocket Inventory.
+Les dépôts Stocket sont des unités de livraison indépendantes. Il n'existe pas
+de pipeline monorepo unique et tous les artefacts validés ne sont pas
+actuellement déployés.
 
-## Workflows
+## Inventaire des workflows et releases
 
-Les workflows CI sont **par repo**, pas au niveau racine du workspace.
+| Dépôt | Déclencheur | Jobs ou résultat |
+|-------|-------------|------------------|
+| `backend` | pull requests et pushes sur `main` | audit des dépendances, Oxlint, TypeScript, tests Vitest, intégration PostgreSQL et build Node 22/esbuild |
+| `frontend` | pull requests et pushes sur `main` | audit, Oxlint, Prettier, TypeScript, Vitest, build et Playwright full-stack avec backend épinglé, PostgreSQL et LocalStack S3 |
+| rollout backend/frontend (temporaire, juillet 2026) | dispatch manuel explicite | garde `main` courant/CI réussie, images SHA et `stocket-deploy` ; retrait après le rollout unique |
+| `packages` | pull requests et pushes sur `main` | build, publication de snapshots de PR, PR de version Changesets et publication stable sur GitHub Packages |
+| `documentation` | pull requests | audit EN/FR, navigation et liens relatifs, puis `mkdocs build --strict` |
+| `documentation` | pushes sur `main` | répétition de l'audit, puis déploiement MkDocs vers `gh-pages` |
+| `infrastructure` | pull requests | tests du destroy guard, Terraform fmt/init/validate/plan, syntaxe Ansible, tests Caddy/déploiement/sauvegarde et validation Compose |
+| `infrastructure` | dispatch manuel protégé | apply Terraform optionnel, configuration Ansible et vérification |
+| `remote-desktop` | tags/dispatch manuel/dispatch dépôt | release brouillon multi-plateforme prévue ; les noms de dépôts, flags frontend et chemins de sortie sont obsolètes, donc ce chemin n'est pas vérifié |
+| `landing` | aucun workflow dans le dépôt | contenu statique déployé indépendamment via les réglages GitHub Pages |
 
-### Pipeline CI Backend
+Le `mobile-ci.yml` stocké sous `meta/root/.github/workflows/` est un template
+inactif. Aucun dépôt mobile n'est actuellement géré par `meta/repos.yaml`.
 
-**Fichier :** `backend/.github/workflows/ci.yml`
+## État du déploiement applicatif
 
-S'exécute à chaque pull request et push sur main :
+Le backend et le frontend ne conservent ni CD automatique persistant après
+merge ni workflow autonome de rollback déclenché par l'opérateur. Pour un
+rollout de production audité en juillet 2026, chaque dépôt a temporairement
+porté un workflow manuel **Deploy Once**. Tant qu'il était présent, ce chemin :
 
-- Lint
-- Vérification des types
-- Exécution des tests unitaires
-- Exécution des tests E2E
-- Build
+- n'acceptait que le SHA du `main` courant après la réussite de la CI push ;
+- construisait et publiait une image GHCR taguée par SHA ;
+- appelait le helper infrastructure `stocket-deploy` via un SSH restreint. Le
+  helper attend jusqu'à 90 secondes la santé Compose des images
+  (`/health-check/live` pour l'API et `/` pour le web) ; pour le backend, il
+  exige aussi `/health-check/ready` depuis l'hôte et observe le même worker sans
+  redémarrage pendant 10 secondes ;
+- vérifiait éventuellement une URL publique après le retour du helper, puis
+  tentait de déplacer `:latest` vers l'image SHA.
 
-### Pipeline CI Frontend
+Ces workflows ont été retirés après le rollout unique ; aucun merge normal ne
+les déclenchait. Si un contrôle Compose, readiness backend
+ou stabilité du worker géré par le helper échoue après le début du remplacement,
+`stocket-deploy` tente de restaurer l'image précédente. Le contrôle public
+ultérieur se situe hors de cette frontière. Son échec ou celui de l'alias peut
+donc laisser le serveur sur l'image SHA et `:latest` inchangé ; l'image SHA reste
+aussi dans GHCR. Cette récupération limitée n'est ni un workflow général de
+rollback ni une surface de CD persistante.
 
-**Fichier :** `frontend/.github/workflows/ci.yml`
+Le dépôt infrastructure exploite la topologie hébergée sur un serveur et son
+helper de déploiement. Les changements d'image restent contrôlés par
+l'opérateur hors d'un rollout ponctuel explicitement audité.
 
-S'exécute à chaque pull request et push sur main :
+!!! warning "Terminologie hors ligne"
+    Le frontend possède un shell PWA installable et une page de repli, et un
+    shell Tauri existe. Les données et mutations d'inventaire exigent toujours
+    l'API. Ne présentez pas le produit comme offline-first ou synchronisé hors
+    ligne.
 
-- Lint
-- Vérification des types
-- Build
+## CI backend
 
-### Publication Docker
+`backend/.github/workflows/ci.yml` exécute quatre jobs sous Node.js 22 :
 
-Chaque repo possède son propre workflow de publication Docker :
+1. **lint** — installation figée depuis GitHub Packages, audit production,
+   Oxlint et TypeScript ;
+2. **test** — suite Vitest unitaire ;
+3. **integration-test** — PostgreSQL réel et configuration d'intégration ;
+4. **build** — bundle de `main.ts` et `task-worker.ts` avec esbuild.
 
-- **Backend :** `backend/.github/workflows/docker-publish.yml`
-- **Frontend :** `frontend/.github/workflows/docker-publish.yml`
+## CI frontend
 
-### Déploiement de la documentation
+`frontend/.github/workflows/ci.yml` exécute :
 
-**Fichier :** `documentation/.github/workflows/deploy-docs.yml`
+- lint, format, types, audit, tests unitaires et build depuis le lockfile
+  frontend autonome ;
+- un gate Playwright full-stack qui checkout un commit backend épinglé, lance
+  PostgreSQL et LocalStack S3, construit les applications, crée les tenants E2E,
+  vérifie la découverte des tests et publie les diagnostics en cas d'échec.
 
-Déploie la documentation via GitHub Pages lors d'un push sur main.
+Lorsqu'un changement frontend dépend d'un backend ou package non publié, ne
+mettez à jour les révisions explicites qu'après le test de la stack coordonnée.
 
-## Secrets GitHub Actions
+## Releases des packages partagés
 
-### Secrets requis
+Les packages sont publiés sur GitHub Packages sous `@stocketfr/*`.
 
-| Secret | Description |
-|--------|-------------|
-| `BETTER_AUTH_SECRET` | Secret Better Auth (CI backend uniquement) |
+1. Chaque changement publiable inclut un Changeset (`pnpm changeset`).
+2. Une PR contenant un Changeset publie des versions immuables sous un tag
+   propre à la PR pour les tests consommateur.
+3. Les merges sur `main` alimentent la pull request de version Changesets.
+4. La fusion de cette PR crée les versions stables et releases GitHub.
+5. Le backend/frontend mettent à jour leurs alias npm épinglés.
 
-!!! note "Secrets d'authentification"
-    `BETTER_AUTH_SECRET` n'est nécessaire que dans le CI du backend. Le frontend ne nécessite aucun secret d'authentification.
+Le code peut importer `@stocket/types`, mais le package registry est
+`@stocketfr/types`. GitHub Actions utilise `GITHUB_TOKEN` ; en local, un token
+classique `read:packages` est nécessaire.
 
-## Workflow Pull Request
+## Release de la documentation
 
-1. **Créer une branche** depuis `main`
-2. **Faire des modifications** et committer
-3. **Ouvrir une PR** - CI s'exécute automatiquement (par repo)
-4. **Review** - Attendre l'approbation
-5. **Merger** - Squash and merge vers main
+L'audit sans dépendance contrôle la couverture exacte de la navigation, les
+liens relatifs et la structure parallèle des pages anglaises/françaises. La CI
+installe ensuite MkDocs Material, l'i18n statique et les dates de révision
+localisées, puis exige un build strict. Un push sur `main` répète l'audit avant
+le déploiement avec `mkdocs gh-deploy --force`.
 
-### Template de PR
+L'anglais est la locale par défaut. Les fichiers français portent `.fr.md` ; le
+fallback anglais existe, mais les guides publics doivent rester à parité.
 
-Les PRs doivent inclure :
+## Apply de l'infrastructure
 
-- Résumé des changements
-- Plan de test
-- Éléments de checklist
+Le workflow de pull request planifie sans modifier la production. Le job apply
+exige un dispatch explicite avec `apply=true` et l'environnement protégé
+`production`. Il :
 
-## Vérifications CI locales
+1. applique Terraform avec l'état HCP Terraform ;
+2. écrit inventaire et variables Ansible dans des fichiers temporaires ;
+3. attend cloud-init ;
+4. configure l'hôte avec Ansible ;
+5. exécute le playbook de vérification ;
+6. supprime les fichiers sensibles temporaires.
 
-Exécuter les mêmes vérifications localement avant de pusher :
+Consultez le dépôt infrastructure pour les runbooks sauvegarde, destroy guard,
+Datadog, Caddy et reprise. Un apply infrastructure ne publie pas à lui seul une
+nouvelle version applicative.
 
-```bash
-# Backend
-cd backend
-pnpm install
-pnpm lint
-pnpm build
-pnpm test
+## Attentes pour les pull requests
 
-# Frontend
-cd frontend
-pnpm install
-pnpm lint
-pnpm build
-```
-
-## Déploiement
-
-### Documentation
-
-La documentation est automatiquement déployée via GitHub Pages quand des changements sont pushés sur main.
-
-Chemins déclencheurs :
-
-- `docs/**`
-- `mkdocs.yml`
-- `.github/workflows/deploy-docs.yml`
-
-### Application
-
-Les images Docker sont publiées via les workflows `docker-publish.yml` dans chaque repo.
-
-## Dépannage
-
-### Échecs CI
-
-**Erreurs de lint :**
-
-```bash
-pnpm lint --fix
-```
-
-**Erreurs de type :**
-
-```bash
-# Backend
-cd backend && pnpm build
-
-# Frontend
-cd frontend && pnpm build
-```
-
-**Échecs de tests :**
-
-```bash
-cd backend && pnpm test -- --verbose
-```
-
-### Problèmes de cache
-
-Vider le cache GitHub Actions :
-
-1. Aller dans l'onglet Actions
-2. Cliquer sur "Caches" dans la barre latérale
-3. Supprimer les caches concernés
-
-## Bonnes pratiques
-
-1. **Garder les PRs petites** - Plus faciles à review
-2. **Exécuter les vérifications localement** - Avant de pusher
-3. **Corriger la CI immédiatement** - Ne pas laisser les échecs s'accumuler
-4. **Mettre à jour les tests** - Quand on modifie les fonctionnalités
+- conserver les changements dans leur dépôt propriétaire ;
+- expliquer les révisions et snapshots inter-dépôts ;
+- exécuter les vérifications locales du dépôt ;
+- préserver la compatibilité lorsque l'ordre de rollout compte ;
+- mettre cette page à jour lors d'un changement de workflow ;
+- ne jamais conclure à un déploiement depuis des checks uniquement CI.

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -1,164 +1,141 @@
-# CI/CD
+# CI, Releases, and Deployment
 
-This guide covers the GitHub Actions workflows and deployment processes for Stocket Inventory.
+Stocket repositories are independent delivery units. There is no single
+monorepo pipeline, and not every validated artifact is currently deployed.
 
-## Workflows
+## Workflow and Release Inventory
 
-CI workflows live **per-package** for backend/frontend/documentation, and **at the monorepo root** for cross-package concerns (mobile-app, shared packages).
+| Repository | Trigger | Current jobs or outcome |
+|------------|---------|-------------------------|
+| `backend` | pull requests and pushes to `main` | production dependency audit, Oxlint, TypeScript, Vitest unit tests, PostgreSQL integration tests, and Node 22/esbuild build |
+| `frontend` | pull requests and pushes to `main` | production dependency audit, Oxlint, Prettier check, TypeScript, Vitest, build, and full-stack Playwright with a pinned backend revision, PostgreSQL, and LocalStack S3 |
+| backend/frontend rollout (temporary, July 2026) | explicit manual dispatch | current-`main`/successful-CI guard, SHA images, and `stocket-deploy`; removed after the one-time rollout |
+| `packages` | pull requests and pushes to `main` | package build; pull-request snapshot publication; Changesets version PR and stable publication to GitHub Packages |
+| `documentation` | pull requests | EN/FR, navigation, and relative-link audit, then `mkdocs build --strict` |
+| `documentation` | pushes to `main` | repeat the audit, then deploy MkDocs to the `gh-pages` branch |
+| `infrastructure` | pull requests | destroy-guard tests, Terraform formatting/init/validate/plan, Ansible syntax, Caddy/deploy/backup tests, and rendered Compose validation |
+| `infrastructure` | protected manual dispatch | optional Terraform apply, Ansible configuration, and verification |
+| `remote-desktop` | tags/manual dispatch/repository dispatch | intended multi-platform draft release; currently contains stale repository names, frontend build flags, and output paths and is not a verified release path |
+| `landing` | none in the repository | static content is owned and deployed independently through GitHub Pages settings |
 
-### Backend CI Pipeline
+The root `mobile-ci.yml` stored in `meta/root/.github/workflows/` is a dormant
+template. No mobile repository is currently managed by `meta/repos.yaml`.
 
-**File:** `backend/.github/workflows/ci.yml`
+## Application Deployment Status
 
-Runs on every pull request and push to main:
+Backend and frontend do not retain persistent automatic post-merge CD or a
+standalone operator-triggered rollback workflow. For an audited production
+rollout in July 2026, each repository temporarily carried a manual-only
+**Deploy Once** workflow. While present, that path:
 
-- Lint (oxlint)
-- Type check
-- Unit tests (Vitest)
-- Integration tests (against a real Postgres service)
-- Build (bun build)
+- accepted only the current `main` SHA after successful push CI;
+- built and published a SHA-tagged GHCR image;
+- invoked the infrastructure `stocket-deploy` helper over restricted SSH. The
+  helper waits up to 90 seconds for Compose image health (`/health-check/live`
+  for the API and `/` for the web image); for backend it also requires
+  host-local `/health-check/ready` and observes the same worker with zero
+  restarts for 10 seconds;
+- optionally checked a public URL after the helper returned, then attempted to
+  move `:latest` to the SHA image.
 
-### Frontend CI Pipeline
+Those workflows were removed after the one-time rollout; a normal merge never
+triggered them. If a helper-owned Compose, backend readiness,
+or worker-stability check fails after replacement starts, `stocket-deploy`
+best-effort restores the prior image. The later public check is outside that
+rollback boundary. A public-check or alias failure can therefore leave the
+server on the SHA image while `:latest` remains unchanged; the SHA image also
+remains in GHCR. This bounded failure recovery is not a general rollback
+workflow or persistent CD surface.
 
-**File:** `frontend/.github/workflows/ci.yml`
+The infrastructure repository operates the hosted single-box topology and its
+deploy helper. Application image changes remain operator-controlled outside an
+explicitly audited one-off rollout.
 
-Runs on every pull request and push to main:
+!!! warning "Offline terminology"
+    The frontend has an installable PWA shell and offline fallback, and a Tauri
+    shell exists. Inventory data and mutations still require the API. Do not
+    describe the product as offline-first or synchronized offline storage.
 
-- Lint (oxlint)
-- Type check
-- Build
+## Backend CI
 
-### Mobile CI Pipeline (Root-Level)
+`backend/.github/workflows/ci.yml` runs four independent jobs on Node.js 22:
 
-**File:** `.github/workflows/mobile-ci.yml`
+1. **lint** — frozen install from GitHub Packages, production audit, Oxlint,
+   and TypeScript;
+2. **test** — Vitest unit suite;
+3. **integration-test** — real PostgreSQL service and the integration config;
+4. **build** — bundles both `main.ts` and `task-worker.ts` with esbuild for
+   Node.js 22.
 
-Lives at the workspace root because it rebuilds shared types before testing `mobile-app/`. Triggers on changes to `mobile-app/**` or `packages/**`.
+The workflow does not require a production Better Auth secret because tests
+provide their own controlled configuration.
 
-### Docker Publish
+## Frontend CI
 
-Each application package has its own Docker publish workflow:
+`frontend/.github/workflows/ci.yml` runs:
 
-- **Backend:** `backend/.github/workflows/docker-publish.yml`
-- **Frontend:** `frontend/.github/workflows/docker-publish.yml`
+- lint, format, type, dependency-audit, unit-test, and build jobs against the
+  standalone frontend lockfile;
+- a full-stack Playwright gate that checks out a pinned backend commit, starts
+  PostgreSQL and LocalStack S3, builds both applications, seeds E2E tenants,
+  verifies test discovery, and uploads browser/service diagnostics on failure.
 
-### Documentation Deployment
+When a frontend change depends on an unreleased backend or package change,
+update the explicit revision pins only after testing the coordinated stack.
 
-**File:** `documentation/.github/workflows/deploy.yml`
+## Shared Package Releases
 
-Deploys the MkDocs site to GitHub Pages on push to main.
+Packages publish to GitHub Packages under `@stocketfr/*`.
 
-### Package Release (npm)
+1. Every publishable change includes a Changeset (`pnpm changeset`).
+2. A package pull request with a Changeset publishes immutable versions under
+   a PR-specific dist tag for consumer testing.
+3. Merges to `main` update or publish through the Changesets release pull
+   request.
+4. Merging that version PR creates stable package versions and GitHub releases.
+5. Backend/frontend update their pinned npm aliases to the stable release.
 
-Shared packages (`@stocket/types`, `@stocket/eslint-config`, `@stocket/tsconfig`) publish to npm via trusted publishing when their `package.json` version is bumped on `main`.
+Package source imports may use local names such as `@stocket/types`, while the
+registry package is `@stocketfr/types`. GitHub Actions authenticates with
+`GITHUB_TOKEN`; local users need a classic token with `read:packages`.
 
-- **Trigger:** merge to `main` with a version bump in `packages/<name>/package.json`
-- **Workflow:** `tag.yml` (at the monorepo root)
-- **Tag format:** `types@x.y.z`, `eslint-config@x.y.z`, `tsconfig@x.y.z`
+## Documentation Release
 
-!!! warning "Version-bump requirement"
-    If you edit `packages/types`, `packages/eslint-config`, or `packages/tsconfig`, bump that package's `package.json` version **in the same PR**. Skipping the bump means consumers won't pick up your change after merge.
+The dependency-free audit checks complete one-to-one navigation coverage,
+relative links, and matching English/French page structure. Docs CI then
+installs the three plugin families used by the site—MkDocs Material, static
+i18n, and localized Git revision dates—and requires a strict build. A push to
+`main` repeats the audit before deploying with `mkdocs gh-deploy --force`.
 
-## GitHub Actions Secrets
+English pages are the default locale. French pages use `.fr.md`; missing French
+translations fall back to English, but public user guides should be kept at
+feature parity.
 
-### Required Secrets
+## Infrastructure Apply
 
-| Secret | Description |
-|--------|-------------|
-| `BETTER_AUTH_SECRET` | Better Auth secret (backend CI only) |
+The infrastructure pull-request workflow plans but does not mutate production.
+The apply job requires an explicit manual dispatch with `apply=true` and the
+protected `production` environment. It then:
 
-!!! note "Auth secrets"
-    `BETTER_AUTH_SECRET` is only needed in the backend CI. The frontend does not require any auth secrets.
+1. applies Terraform using HCP Terraform state;
+2. writes the generated Ansible inventory and sensitive variables to temporary
+   files;
+3. waits for cloud-init readiness;
+4. configures the host with Ansible;
+5. runs the verification playbook;
+6. removes temporary sensitive files.
 
-## Pull Request Workflow
+See the infrastructure repository for its database backup, destroy guard,
+Datadog, Caddy, and operator recovery runbooks. Because application CD is
+disconnected, an infrastructure apply alone does not publish a new application
+version.
 
-1. **Create branch** from `main`
-2. **Make changes** and commit
-3. **Open PR** - CI runs automatically (per-repo)
-4. **Review** - Wait for approval
-5. **Merge** - Squash and merge to main
+## Pull Request Expectations
 
-### PR Template
-
-PRs should include:
-
-- Summary of changes
-- Test plan
-- Checklist items
-
-## Local CI Checks
-
-Run the same checks locally before pushing:
-
-```bash
-# One install at the monorepo root hydrates every package
-pnpm install
-
-# Backend
-pnpm --filter @stocket/api lint           # oxlint
-pnpm --filter @stocket/api type-check     # TypeScript
-pnpm --filter @stocket/api build          # bun build
-pnpm --filter @stocket/api test           # Vitest
-pnpm --filter @stocket/api test:integration
-
-# Frontend
-pnpm --filter @stocket/web lint           # oxlint
-pnpm --filter @stocket/web type-check
-pnpm --filter @stocket/web build
-```
-
-## Deployment
-
-### Documentation
-
-Documentation is automatically deployed via GitHub Pages when changes are pushed to main.
-
-Trigger paths:
-
-- `docs/**`
-- `mkdocs.yml`
-- `.github/workflows/deploy-docs.yml`
-
-### Application
-
-Docker images are published via `docker-publish.yml` workflows in each repo.
-
-## Troubleshooting
-
-### CI Failures
-
-**Lint errors:**
-
-```bash
-pnpm lint --fix
-```
-
-**Type errors:**
-
-```bash
-# Backend
-cd backend && pnpm build
-
-# Frontend
-cd frontend && pnpm build
-```
-
-**Test failures:**
-
-```bash
-cd backend && pnpm test
-```
-
-### Cache Issues
-
-Clear GitHub Actions cache:
-
-1. Go to Actions tab
-2. Click "Caches" in sidebar
-3. Delete relevant caches
-
-## Best Practices
-
-1. **Keep PRs small** - Easier to review
-2. **Run checks locally** - Before pushing
-3. **Fix CI immediately** - Don't let failures accumulate
-4. **Update tests** - When changing functionality
+- keep changes in the repository that owns them;
+- explain cross-repository revisions and package snapshots explicitly;
+- run the owning repository's local checks;
+- include migrations and backward-compatible contracts where rollout order
+  matters;
+- update this page when a workflow is added, removed, or reconnected;
+- never claim deployment success from CI-only checks.

--- a/docs/development/code-style.fr.md
+++ b/docs/development/code-style.fr.md
@@ -1,232 +1,105 @@
 # Style de code
 
-Ce guide couvre les standards et conventions de codage utilisés dans Stocket Inventory.
+Les dépôts Stocket partagent des contrats TypeScript mais gardent leurs propres outils. Suivez la configuration et le code voisin du dépôt modifié ; aucune commande racine ne couvre automatiquement tous les projets.
 
-## Outils
+## TypeScript général
 
-| Outil | Portée | Objectif |
-|-------|--------|----------|
-| oxlint | Backend | Linting rapide |
-| ESLint | Frontend | Linting |
-| Prettier | Les deux | Formatage |
-| TypeScript | Les deux | Vérification des types |
+- Conservez le typage strict et évitez `any`. Réduisez `unknown` à la frontière d'un adaptateur lorsque l'entrée externe ne peut être typée directement.
+- Préférez l'inférence pour les fonctions locales et des types publics explicites lorsqu'ils clarifient le contrat.
+- Utilisez `import type` pour les dépendances de type.
+- Préservez les champs snake_case des DTO API publiés ; les noms propres à l'UI restent à sa frontière.
+- Décodez les entrées externes avec les schémas partagés au lieu de caster.
+- Gardez les changements assez ciblés pour que les vérifications du dépôt propriétaire restent la référence.
 
-## Exécuter les vérifications
+## Contrats partagés
+
+Requêtes, réponses, enums et schémas communs vivent dans `packages/types` et sont publiés sous `@stocketfr/types`. Les consommateurs passent par l'alias et un sous-chemin :
+
+```ts
+import { Permission, Resource } from '@stocket/types/auth'
+import { CreateProductRequestSchema } from '@stocket/types/products'
+```
+
+Modifiez d'abord le contrat dans packages, ajoutez un Changeset, publiez ou utilisez le snapshot approuvé, puis mettez les consommateurs à jour. Ne dupliquez pas un schéma dans backend et frontend pour contourner ce cycle.
+
+## Conventions backend
+
+Le backend exécute Node 22 avec Effect et Drizzle. Un module courant sous `src/effect/modules/<nom>/` contient `router.ts`, `service.ts`, `repository.ts`, `mappers.ts`, `types.ts` et des erreurs typées. Les modules complexes séparent aussi écritures, requêtes, validations, états ou orchestration. Adaptez la structure au besoin réel.
+
+Responsabilités :
+
+- **router** — chemin/méthode, décodage par schéma partagé, permissions/fonctionnalités, réponse HTTP ;
+- **service/workflow** — règles métier et composition ;
+- **repository** — persistance tenant via `TenantQuery`/Drizzle ;
+- **mapper** — valeurs de base/domaine vers les DTO publiés ;
+- **errors** — erreurs métier/infrastructure typées.
+
+Utilisez `Effect.Service`, les erreurs taguées et le canal d'erreur Effect. Ne lancez pas d'exception pour une condition métier attendue. Réutilisez les helpers de `platform/effect`, `platform/db` et `platform/http`.
+
+Les routes tenant déclarent accès et décodage ensemble :
+
+```ts
+HttpRouter.post(
+  '/',
+  tenantRouteContext({
+    permissions: [[Resource.PRODUCTS, Permission.WRITE]],
+    decode: jsonBody(CreateProductRequestSchema),
+    session: 'optional',
+  }).pipe(
+    Effect.flatMap(({ input, userId }) =>
+      respondAuditedMutation(
+        Effect.flatMap(ProductsService, (service) =>
+          service.create(input, userId),
+        ),
+        {
+          action: AuditAction.CREATE,
+          entityType: AuditEntityType.PRODUCT,
+          entityId: (product) => product.id,
+          responseOptions: { status: 201 },
+        },
+      ),
+    ),
+  ),
+)
+```
+
+Utilisez `tenantRoute` pour une réponse JSON normale et `tenantRouteContext` lorsque réponse/audit exige le contexte décodé. Ajoutez un `guard` de fonctionnalité à côté des permissions. L'audit de `respondAuditedMutation` est une métadonnée au mieux après succès, hors transaction ; ne l'utilisez jamais pour orchestrer la transaction.
+
+Les services utilisent `makeServiceTracer` depuis `platform/observability/service-tracer`. Journalisez des clés/propriétés structurées, jamais secrets ou DTO entiers. Une transaction explicite transmet la surface de requête transactionnelle ; une composition inter-modules est valable si un orchestrateur possède le cas d'usage.
+
+## Conventions frontend
+
+Le frontend utilise React 19, TanStack Start/Router/Query/Form, StyleX, Tailwind 4 et shadcn/Radix.
+
+- Importez le code applicatif avec `@/`, pas l'ancien `~/`.
+- Les routes vivent sous `src/routes` ; ne modifiez jamais `routeTree.gen.ts` généré.
+- Placez les hooks API/query sous `src/lib/data` et utilisez le sous-chemin DTO partagé.
+- Protégez les routes avec `requireRouteAccess(currentUser, Resource, options)` en miroir du serveur.
+- Conservez les filtres partageables dans des paramètres de recherche URL validés.
+- Utilisez les clés/options de requête générées pour invalidation et chargement conditionnel.
+- Utilisez StyleX ou Tailwind/shadcn selon le modèle du composant voisin, sans migration incidente.
+- Traitez labels, clavier, focus, erreurs, chargement et vide comme partie de la fonctionnalité.
+
+N'utilisez pas de global navigateur lors du SSR. Loaders et fonctions serveur transmettent hôte, protocole et cookie via les adaptateurs API même origine existants.
+
+## Formatage et lint
+
+Backend et frontend utilisent Prettier et Oxlint. Le paquet `@stocketfr/eslint-config` est publié mais ne rend pas ESLint actif dans les applications.
 
 ```bash
-# Lint backend (oxlint)
-pnpm --filter @stocket/api lint
+# backend
+pnpm format
+pnpm lint
+pnpm type-check
 
-# Lint backend avec auto-correction
-pnpm --filter @stocket/api lint:fix
-
-# Vérification des types backend
-pnpm --filter @stocket/api type-check
-
-# Lint frontend (ESLint)
-pnpm --filter @stocket/web lint
-
-# Lint frontend avec auto-correction
-pnpm --filter @stocket/web lint:fix
-
-# Build des types partagés (inclut la vérification des types)
-pnpm --filter @stocket/types build
+# frontend (vérifications sans modification)
+pnpm format:check
+pnpm lint
+pnpm type-check
 ```
 
-## Conventions d'import
+Laissez le formateur décider ponctuation et retours. Ne mélangez pas un reformatage global à une évolution fonctionnelle.
 
-### Backend (Effect.ts)
+## Documentation
 
-```typescript
-// 1. Dépendances externes
-import { Effect, Layer, Schema } from "effect";
-import { HttpRouter, HttpServerRequest } from "@effect/platform";
-
-// 2. Imports de la plateforme
-import { requirePermission } from "../../platform/authorization";
-import { DrizzleDatabase } from "../../platform/drizzle";
-
-// 3. Imports locaux du module
-import { ProductsService } from "./service";
-import { CreateProductSchema } from "./products.schema";
-```
-
-### Frontend (React)
-
-```typescript
-// 1. Dépendances externes
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-
-// 2. Composants
-import { Button } from "~/components/ui/button";
-
-// 3. Utilitaires et types
-import { type ProductResponseDto } from "~/lib/data/products";
-```
-
-**Imports de types** — utiliser le mot-clé `type` inline :
-
-```typescript
-import { type ProductResponseDto } from "~/lib/data/products";
-```
-
-**Variables inutilisées** — préfixer avec underscore :
-
-```typescript
-const { data, error: _error } = useQuery();
-```
-
-## Configuration Prettier
-
-### Backend
-
-Utilise `.prettierrc` avec :
-
-```json
-{
-  "singleQuote": true,
-  "trailingComma": "all"
-}
-```
-
-### Frontend
-
-Utilise `prettier-plugin-tailwindcss` pour le tri automatique des classes Tailwind. Pas de `.prettierrc` personnalisé — défauts de Prettier.
-
-## TypeScript
-
-### Mode strict
-
-Tous les modules utilisent TypeScript strict :
-
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true
-  }
-}
-```
-
-### Alias de chemins
-
-| Module | Alias | Correspond à |
-|--------|-------|--------------|
-| Frontend | `~/*` | `./src/*` |
-
-## Conventions de nommage
-
-### Fichiers
-
-| Type | Convention | Exemple |
-|------|------------|---------|
-| Répertoire module backend | kebab-case | `stock-movements/` |
-| Router backend | `router.ts` | `router.ts` |
-| Service backend | `service.ts` | `service.ts` |
-| Schéma backend | `<feature>.schema.ts` | `products.schema.ts` |
-| Erreurs backend | `<feature>.errors.ts` | `products.errors.ts` |
-| Composant frontend | PascalCase | `ProductForm.tsx` |
-| UI frontend | kebab-case | `button.tsx` |
-
-### Code
-
-| Type | Convention | Exemple |
-|------|------------|---------|
-| Service Effect | PascalCase | `ProductsService` |
-| Interface | PascalCase (sans préfixe I) | `ProductResponse` |
-| Fonction | camelCase | `findAllProducts` |
-| Constante | UPPER_SNAKE | `MAX_PAGE_SIZE` |
-| Membre Enum | UPPER_SNAKE | `AuditAction.CREATE` |
-| Schéma | PascalCase | `CreateProductSchema` |
-| Classe d'erreur | PascalCase | `ProductNotFound` |
-
-### Structure d'un module Backend
-
-```
-modules/<feature>/
-├── router.ts              # Gestionnaires de routes HTTP
-├── service.ts             # Logique métier (service Effect)
-├── repository.ts          # Accès aux données (requêtes Drizzle)
-├── <feature>.schema.ts    # Schémas de validation (Effect Schema)
-├── <feature>.errors.ts    # Définitions d'erreurs de domaine
-└── <feature>.utils.ts     # Mappers, helpers (optionnel)
-```
-
-### Structure des composants Frontend
-
-```
-components/
-├── ui/                     # Composants de base (Radix/shadcn, kebab-case)
-│   ├── button.tsx
-│   └── input.tsx
-├── products/               # Composants par feature (PascalCase)
-│   ├── ProductForm.tsx
-│   └── ProductList.tsx
-└── common/                 # Composants partagés
-    └── Header.tsx
-```
-
-## Bonnes pratiques
-
-### Général
-
-- Utiliser `const` par défaut, `let` uniquement si réassignation nécessaire
-- Préférer les exports nommés aux exports par défaut
-- Toujours utiliser des accolades pour les structures de contrôle
-- Utiliser les retours anticipés pour réduire l'imbrication
-
-### TypeScript
-
-```typescript
-// Préférer les interfaces pour les formes d'objets
-interface ProductFormProps {
-  product?: Product;
-  onSubmit: (data: CreateProductDto) => void;
-}
-
-// Utiliser type pour les unions/intersections
-type ButtonVariant = "primary" | "secondary" | "danger";
-```
-
-### React
-
-```typescript
-// Composants fonction nommés
-export function ProductCard({ product }: ProductCardProps) {
-  return <div>...</div>;
-}
-```
-
-### Effect.ts
-
-```typescript
-// Les services yieldent leurs dépendances puis retournent les méthodes publiques
-export class ProductsService extends Effect.Service<ProductsService>()(
-  "ProductsService",
-  {
-    effect: Effect.gen(function* () {
-      const repo = yield* ProductsRepository;
-      return { findAll, create, update, delete: softDelete };
-    }),
-    dependencies: [ProductsRepository.Default],
-  }
-) {}
-```
-
-## Commentaires
-
-- Éviter les commentaires évidents
-- Documenter la logique métier complexe
-- Utiliser JSDoc pour les APIs publiques
-
-```typescript
-/**
- * Construit un arbre hiérarchique à partir d'une liste plate de catégories.
- * Les catégories sans parent deviennent des nœuds racines.
- */
-function buildTree(categories: Category[]): CategoryTreeNode[] {
-  // Implémentation
-}
-```
+Synchronisez la structure anglaise et `.fr.md`. Utilisez liens relatifs, blocs avec langage et avertissements pour les opérations destructrices/non atomiques. Ajoutez toute page navigable à `mkdocs.yml` et vérifiez liens/navigation. La CI exécute `mkdocs build --strict`.

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -1,266 +1,105 @@
 # Code Style
 
-This guide covers the coding standards and conventions used in Stocket Inventory.
+Stocket's repositories share TypeScript contracts but have independent toolchains. Follow the configuration and nearby code in the repository you are changing; do not assume a root-level formatter or lint command covers every project.
 
-## Tools
+## General TypeScript
 
-| Tool | Scope | Purpose |
-|------|-------|---------|
-| oxlint | Backend + Frontend | Fast Rust-based linting |
-| Prettier | Both | Formatting |
-| TypeScript | Both | Type checking |
+- Keep strict typing and avoid `any`. Narrow `unknown` at an adapter boundary when external input cannot be typed directly.
+- Prefer inferred return types for local functions and explicit public/domain types where they make the contract clearer.
+- Use `import type` for type-only dependencies.
+- Preserve the published snake_case API DTO fields; use local UI names only inside the frontend boundary.
+- Decode external input with the shared schemas instead of casting.
+- Keep changes small enough that the owning repository's checks remain the source of truth.
 
-!!! note "oxlint everywhere"
-    Both backend and frontend use [oxlint](https://oxc-project.github.io/docs/guide/usage/linter.html). The `packages/eslint-config/` package exists for the (legacy) shared ESLint config but is not currently consumed by backend or frontend.
+## Shared contracts
 
-## Running Checks
+Request, query, response, enum, and common schema definitions live in `packages/types` and publish as `@stocketfr/types`. Consumers import through the local alias and a module subpath:
+
+```ts
+import { Permission, Resource } from '@stocket/types/auth'
+import { CreateProductRequestSchema } from '@stocket/types/products'
+```
+
+Change a shared contract in the packages repository first, add a Changeset, publish or use the approved snapshot workflow, then update consumers. Do not copy a schema into backend and frontend to bypass that lifecycle.
+
+## Backend conventions
+
+The backend runs on Node 22 with Effect and Drizzle. A typical module below `src/effect/modules/<name>/` contains `router.ts`, `service.ts`, `repository.ts`, `mappers.ts`, `types.ts`, and a tagged error file. Larger modules also split `write.ts`, queries, validation, state transitions, or orchestration. Match the module's actual needs instead of forcing empty files.
+
+Responsibilities are:
+
+- **router** — route path/method, shared-schema decoding, permission/feature guards, HTTP response;
+- **service/workflow** — domain rules and composition;
+- **repository** — tenant-scoped persistence through `TenantQuery`/Drizzle;
+- **mapper** — database/domain values to published response DTOs;
+- **errors** — typed domain/infrastructure failures.
+
+Use `Effect.Service`, tagged errors, and Effect error channels. Do not throw for expected domain conditions. Use the helpers under `platform/effect`, `platform/db`, and `platform/http` instead of recreating decoding, existence, pagination, or PostgreSQL-error mapping.
+
+Tenant routes declare access and decoding together:
+
+```ts
+HttpRouter.post(
+  '/',
+  tenantRouteContext({
+    permissions: [[Resource.PRODUCTS, Permission.WRITE]],
+    decode: jsonBody(CreateProductRequestSchema),
+    session: 'optional',
+  }).pipe(
+    Effect.flatMap(({ input, userId }) =>
+      respondAuditedMutation(
+        Effect.flatMap(ProductsService, (service) =>
+          service.create(input, userId),
+        ),
+        {
+          action: AuditAction.CREATE,
+          entityType: AuditEntityType.PRODUCT,
+          entityId: (product) => product.id,
+          responseOptions: { status: 201 },
+        },
+      ),
+    ),
+  ),
+)
+```
+
+Use `tenantRoute` for a normal JSON handler and `tenantRouteContext` when the response/audit flow needs the decoded context. Add a feature `guard` beside permissions. Audit logging from `respondAuditedMutation` is best-effort metadata after success, not part of the domain transaction; never use it as transaction orchestration.
+
+Services use `makeServiceTracer` from `platform/observability/service-tracer`. Log structured message keys/properties rather than interpolated secrets or entire DTOs. Database transactions belong in an explicit workflow that passes the transaction-scoped query surface; cross-module composition is valid when an orchestrator owns the use case.
+
+## Frontend conventions
+
+The frontend uses React 19, TanStack Start/Router/Query/Form, StyleX, Tailwind 4, and shadcn/Radix components.
+
+- Import application code with `@/`; do not introduce the obsolete `~/` convention.
+- Route files live under `src/routes`; `routeTree.gen.ts` is generated and must not be edited.
+- Put API/query hooks under `src/lib/data` and use the shared DTO subpath.
+- Enforce route access with `requireRouteAccess(currentUser, Resource, options)` and mirror the server permission/feature requirement.
+- Keep filter state in validated URL search parameters when a list route is shareable.
+- Use generated query keys/options for invalidation and conditional fetches.
+- Use StyleX for feature/layout styles already following that model; use Tailwind/shadcn primitives where the surrounding component does. Avoid rewriting one system into the other incidentally.
+- Keep components accessible: labels, keyboard behavior, focus, error text, and loading/empty states are part of the feature.
+
+Do not assume browser-only globals during SSR. Route loaders/server functions should forward the request host, protocol, and cookie through the existing same-origin API adapters.
+
+## Formatting and linting
+
+Backend and frontend use Prettier for formatting and Oxlint for application linting. The packages repository also publishes `@stocketfr/eslint-config`, but its existence does not make ESLint the current application command.
 
 ```bash
-# Backend lint
-pnpm --filter @stocket/api lint
+# backend
+pnpm format
+pnpm lint
+pnpm type-check
 
-# Backend lint with auto-fix
-pnpm --filter @stocket/api lint:fix
-
-# Backend type check
-pnpm --filter @stocket/api type-check
-
-# Frontend lint
-pnpm --filter @stocket/web lint
-
-# Frontend lint with auto-fix
-pnpm --filter @stocket/web lint:fix
-
-# Build shared types — barrels first, then build
-pnpm --filter @stocket/types barrels
-pnpm --filter @stocket/types build
+# frontend (non-mutating checks)
+pnpm format:check
+pnpm lint
+pnpm type-check
 ```
 
-## Lint Configuration
+Let the repository formatter decide semicolons and wrapping. Do not combine broad formatting rewrites with a functional change.
 
-Both packages use [oxlint](https://oxc-project.github.io/docs/guide/usage/linter.html). The frontend config lives at `frontend/.oxlintrc.json`.
+## Documentation
 
-Key rules enforced in the frontend:
-
-- `unicorn/catch-error-name` — catch blocks must use `error`, not `e`
-- `@typescript-eslint/unbound-method` — don't destructure methods from objects (use `obj.method()`)
-- `prefer-destructuring` — use `const { x } = obj`, not `const x = obj.x`
-
-## Import Conventions
-
-### Backend (Effect.ts)
-
-```typescript
-// 1. External dependencies
-import { Effect, Layer, Schema } from "effect";
-import { HttpRouter, HttpServerRequest } from "@effect/platform";
-
-// 2. Platform imports
-import { requirePermission } from "../../platform/authorization";
-import { DrizzleDatabase } from "../../platform/drizzle";
-
-// 3. Local module imports
-import { ProductsService } from "./service";
-import { CreateProductSchema } from "./products.schema";
-```
-
-### Frontend (React)
-
-```typescript
-// 1. External dependencies
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-
-// 2. Components
-import { Button } from "~/components/ui/button";
-import { ProductCard } from "~/components/products/ProductCard";
-
-// 3. Utilities and types
-import { type ProductResponseDto } from "~/lib/data/products";
-```
-
-**Type imports** — use inline `type` keyword:
-
-```typescript
-import { type ProductResponseDto } from "~/lib/data/products";
-```
-
-**Unused variables** — prefix with underscore:
-
-```typescript
-const { data, error: _error } = useQuery();
-```
-
-## Prettier Configuration
-
-### Backend
-
-Uses `.prettierrc` with:
-
-```json
-{
-  "singleQuote": true,
-  "trailingComma": "all"
-}
-```
-
-All other values use Prettier defaults (printWidth: 80, semi: true, tabWidth: 2).
-
-### Frontend
-
-Uses `prettier-plugin-tailwindcss` for automatic Tailwind class sorting. No custom `.prettierrc` — Prettier defaults (double quotes, printWidth: 80, semi: true, trailingComma: "all").
-
-## TypeScript
-
-### Strict Mode
-
-All modules use strict TypeScript:
-
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true
-  }
-}
-```
-
-### Path Aliases
-
-| Module | Alias | Maps to |
-|--------|-------|---------|
-| Frontend | `~/*` | `./src/*` |
-| Frontend | `@/*` | `./src/*` (also available; used in e.g. `axios-client.ts`) |
-
-## Naming Conventions
-
-### Files
-
-| Type | Convention | Example |
-|------|------------|---------|
-| Backend module dir | kebab-case | `stock-movements/` |
-| Backend router | `router.ts` | `router.ts` |
-| Backend service | `service.ts` | `service.ts` |
-| Backend schema | `<feature>.schema.ts` | `products.schema.ts` |
-| Backend errors | `<feature>.errors.ts` | `products.errors.ts` |
-| Frontend Component | PascalCase | `ProductForm.tsx` |
-| Frontend UI | kebab-case | `button.tsx` |
-
-### Code
-
-| Type | Convention | Example |
-|------|------------|---------|
-| Effect Service | PascalCase | `ProductsService` |
-| Interface | PascalCase (no I prefix) | `ProductResponse` |
-| Function | camelCase | `findAllProducts` |
-| Constant | UPPER_SNAKE | `MAX_PAGE_SIZE` |
-| Enum Member | UPPER_SNAKE | `AuditAction.CREATE` |
-| Schema | PascalCase | `CreateProductSchema` |
-| Error class | PascalCase | `ProductNotFound` |
-
-### Backend Module Structure
-
-```
-modules/<feature>/
-├── router.ts              # HTTP route handlers
-├── service.ts             # Business logic (Effect service)
-├── repository.ts          # Data access (Drizzle queries)
-├── <feature>.schema.ts    # Validation schemas (Effect Schema)
-├── <feature>.errors.ts    # Domain error definitions
-└── <feature>.utils.ts     # Mappers, helpers (optional)
-```
-
-### Frontend Component Structure
-
-```
-components/
-├── ui/                     # Base components (Radix/shadcn, kebab-case)
-│   ├── button.tsx
-│   └── input.tsx
-├── products/               # Feature components (PascalCase)
-│   ├── ProductForm.tsx
-│   └── ProductList.tsx
-└── common/                 # Shared components
-    └── Header.tsx
-```
-
-## Best Practices
-
-### General
-
-- Use `const` by default, `let` only when reassignment is needed
-- Prefer named exports over default exports (only use default exports when required by tooling)
-- Always use braces for control statements
-- Use early returns to reduce nesting
-
-### TypeScript
-
-```typescript
-// Prefer interfaces for object shapes
-interface ProductFormProps {
-  product?: Product;
-  onSubmit: (data: CreateProductDto) => void;
-}
-
-// Use type for unions/intersections
-type ButtonVariant = "primary" | "secondary" | "danger";
-```
-
-### React
-
-```typescript
-// Named function components
-export function ProductCard({ product }: ProductCardProps) {
-  return <div>...</div>;
-}
-
-// Destructure props
-function Button({ variant = "primary", children, ...props }: ButtonProps) {
-  return <button {...props}>{children}</button>;
-}
-```
-
-### Effect.ts
-
-```typescript
-// Services yield dependencies, then return public methods
-export class ProductsService extends Effect.Service<ProductsService>()(
-  "ProductsService",
-  {
-    effect: Effect.gen(function* () {
-      const repo = yield* ProductsRepository;
-      // ... define methods
-      return { findAll, create, update, delete: softDelete };
-    }),
-    dependencies: [ProductsRepository.Default],
-  }
-) {}
-
-// Routers follow: authorize → decode → service → respond
-HttpRouter.post("/products", respondJson(
-  Effect.gen(function* () {
-    yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-    const body = yield* HttpServerRequest.schemaBodyJson(CreateProductSchema);
-    const service = yield* ProductsService;
-    return yield* service.create(body);
-  }),
-  { status: 201 }
-));
-```
-
-## Comments
-
-- Avoid obvious comments
-- Document complex business logic
-- Use JSDoc for public APIs
-
-```typescript
-/**
- * Builds a hierarchical tree from a flat list of categories.
- * Categories without a parent become root nodes.
- */
-function buildTree(categories: Category[]): CategoryTreeNode[] {
-  // Implementation
-}
-```
+Keep English and `.fr.md` pages structurally synchronized. Use relative links, fenced code with a language, and warnings for destructive or non-atomic behavior. Update `mkdocs.yml` for every navigable page and run link/navigation checks before a pull request. CI runs `mkdocs build --strict`.

--- a/docs/development/frontend-development.fr.md
+++ b/docs/development/frontend-development.fr.md
@@ -1,374 +1,281 @@
-# Développement Frontend
+# Développement frontend
 
-Ce guide couvre les patterns de développement TanStack Start pour le frontend Stocket Inventory.
+L'application web Stocket est une application React avec rendu serveur, construite avec TanStack Start. Ce guide décrit les conventions du frontend actuel.
 
 ## Stack technique
 
-- TanStack Start (TanStack Router + Vite)
-- React 19
-- TanStack Query (état serveur)
-- TanStack Form (gestion des formulaires)
-- Tailwind CSS 4
-- Radix UI / composants shadcn
-- Better Auth
-- i18next (en, de, fr)
+- React 19 et TanStack Start/Router
+- TanStack Query pour l'état serveur et l'hydratation SSR
+- TanStack Form avec validation Zod
+- Better Auth pour l'authentification par e-mail et mot de passe
+- StyleX pour les styles de fonctionnalités et de mise en page
+- Tailwind CSS 4 et shadcn/Radix pour les primitives d'interface
+- i18next pour l'anglais, l'allemand et le français
+- Vitest, Testing Library et Playwright
 
-## Structure du projet
+## Cartographie des sources
 
-```
-frontend/src/
-├── routes/                      # Routes basées sur les fichiers (TanStack Router)
-│   ├── __root.tsx               # Layout racine + providers
-│   ├── index.tsx                # Accueil (/)
-│   ├── products.tsx             # Produits (/products)
-│   ├── products.$id.tsx         # Détail produit (/products/:id)
-│   ├── locations.tsx            # Emplacements (/locations)
-│   ├── locations.$id.tsx        # Détail emplacement (/locations/:id)
-│   ├── inventory.tsx            # Inventaire (/inventory)
-│   ├── stock.tsx                # Stock (/stock)
-│   ├── stock-movements.tsx      # Mouvements de stock (/stock-movements)
-│   ├── orders.tsx               # Commandes (/orders)
-│   ├── clients.tsx              # Clients (/clients)
-│   ├── suppliers.tsx            # Fournisseurs (/suppliers)
-│   ├── audit-logs.tsx           # Journal d'audit (/audit-logs)
-│   ├── users.tsx                # Utilisateurs (/users)
-│   ├── roles.tsx                # Rôles (/roles)
-│   ├── settings.tsx             # Paramètres (/settings)
-│   ├── login.tsx                # Connexion
-│   └── signup.tsx               # Inscription
-├── components/
-│   ├── ui/                      # Composants de base (Radix/shadcn)
-│   ├── areas/                   # Fonctionnalités zones
-│   ├── audit-logs/              # Fonctionnalités journal d'audit
-│   ├── category/                # Fonctionnalités catégories
-│   ├── clients/                 # Fonctionnalités clients
-│   ├── common/                  # Header, dialogs, etc.
-│   ├── inventory/               # Fonctionnalités inventaire
-│   ├── items/                   # Fonctionnalités articles
-│   ├── locations/               # Fonctionnalités emplacements
-│   ├── orders/                  # Fonctionnalités commandes
-│   ├── products/                # Fonctionnalités produits
-│   ├── roles/                   # Fonctionnalités rôles
-│   ├── settings/                # Fonctionnalités paramètres
-│   ├── stock-movements/         # Fonctionnalités mouvements de stock
-│   ├── suppliers/               # Fonctionnalités fournisseurs
-│   ├── users/                   # Fonctionnalités utilisateurs
-│   ├── DefaultCatchBoundary.tsx # Limite d'erreur
-│   └── NotFound.tsx             # Composant 404
-├── hooks/providers/             # Contextes React
-├── lib/
-│   ├── data/
-│   │   ├── areas.ts             # Hooks API zones
-│   │   ├── audit-logs.ts        # Hooks API journal d'audit
-│   │   ├── auth.ts              # Hooks API auth
-│   │   ├── axios-client.ts      # Client API
-│   │   ├── branding.ts          # Hooks API branding
-│   │   ├── categories.ts        # Hooks API catégories
-│   │   ├── clients.ts           # Hooks API clients
-│   │   ├── inventory.ts         # Hooks API inventaire
-│   │   ├── locations.ts         # Hooks API emplacements
-│   │   ├── make-crud-hooks.ts   # Factory de hooks CRUD
-│   │   ├── orders.ts            # Hooks API commandes
-│   │   ├── photos.ts            # Hooks API photos
-│   │   ├── products.ts          # Hooks API produits
-│   │   ├── query-cache.ts       # Utilitaires cache de requêtes
-│   │   ├── roles.ts             # Hooks API rôles
-│   │   ├── stock-movements.ts   # Hooks API mouvements de stock
-│   │   ├── suppliers.ts         # Hooks API fournisseurs
-│   │   └── users.ts             # Hooks API utilisateurs
-│   └── utils.ts                 # Utilitaires
-├── locales/                     # i18n (en, de, fr)
-├── router.tsx                   # Configuration du router
-└── routeTree.gen.ts             # Routes générées
+```text
+frontend/
+├── public/                         # Manifeste, service worker, page hors ligne, icônes
+├── e2e/                            # Configuration, fixtures et tests Playwright
+└── src/
+    ├── routes/
+    │   ├── __root.tsx              # Document HTML et providers globaux
+    │   ├── _authed.tsx             # Hôte, session et layout authentifié
+    │   ├── _authed/                # Routes de l'application locataire
+    │   ├── login.tsx               # Routes publiques d'authentification
+    │   ├── signup.tsx
+    │   ├── forgot-password.tsx
+    │   ├── reset-password.tsx
+    │   └── platform.tsx            # Console de l'hôte plateforme
+    ├── components/
+    │   ├── ui/                     # Primitives shadcn/Radix partagées
+    │   ├── products/import-wizard/ # Revue et exécution de Smart Import
+    │   └── <module>/               # Composants fonctionnels
+    ├── hooks/                       # Orchestration et hooks de formulaires
+    ├── lib/
+    │   ├── data/                   # Hooks API/requête/mutation typés
+    │   ├── router/                 # Contexte, protections et schémas de recherche
+    │   ├── server/                 # Fonctions serveur et gestion de l'hôte
+    │   └── stylex/                 # Styles et marqueurs StyleX partagés
+    ├── locales/{en,de,fr}/
+    ├── router.tsx                  # Intégration QueryClient et Router
+    └── routeTree.gen.ts            # Généré ; ne jamais modifier à la main
 ```
 
-## Intégration API
+Le groupe authentifié contient actuellement le tableau de bord, les produits et leur détail, les emplacements et leur détail, l'inventaire, les clients, les fournisseurs, les commandes, les mouvements de stock, le journal d'audit, les utilisateurs, les rôles et les paramètres. Il n'existe pas de route `/stock` ni `/categories` ; la gestion des catégories fait partie de la page des produits.
 
-### Client écrit à la main + Types partagés
+## Architecture du rendu et des requêtes
 
-Les hooks API sont dans `src/lib/data/*.ts` et utilisent les interfaces/enums
-de `@stocket/types`. La factory `make-crud-hooks.ts` génère des hooks CRUD standards pour les ressources.
+`getRouter()` crée le routeur et son `QueryClient`. L'état des requêtes est déshydraté sur le serveur puis hydraté dans le navigateur : les loaders de route et les composants partagent donc le même cache. Le comportement par défaut comprend une durée de fraîcheur de 60 secondes, le préchargement à l'intention, la restauration du défilement et l'absence de nouvelle tentative pour les réponses 4xx.
 
-### Utilisation des requêtes
+`src/routes/__root.tsx` possède le document HTML et les providers globaux : branding, localisation, thème, info-bulles, notifications, outils de développement et enregistrement du service worker en production. Dans `beforeLoad`, `src/routes/_authed.tsx` choisit une branche selon l'hôte d'origine : la branche locataire résout l'utilisateur courant avant d'afficher son shell, tandis que la branche plateforme affiche l'accueil de la plateforme.
 
-```typescript
-import { useListProducts } from '~/lib/data/products';
+Le client API métier fonctionne de deux manières :
 
-function ProductList() {
-  const { data, isLoading, error } = useListProducts({
-    category_id: selectedCategory,
-    page: 1,
-    limit: 20,
-  });
+- Dans le navigateur, les requêtes utilisent `/api/v1` sur la même origine et incluent les identifiants.
+- Pendant le SSR, elles utilisent `INTERNAL_API_ORIGIN` et transmettent le cookie, l'hôte et le protocole d'origine afin que le backend puisse résoudre le locataire.
 
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorState error={error} />;
-  if (!data?.data?.length) return <EmptyState />;
+Les formulaires d'authentification utilisent le client Better Auth du navigateur sur `/api/auth` ; l'autorisation des routes provient du profil `/api/v1/auth/me` chargé côté serveur. `better-auth` est verrouillé sur une version exacte et doit être mis à niveau délibérément.
 
-  return (
-    <div>
-      {data.data.map(product => (
-        <ProductCard key={product.id} product={product} />
-      ))}
-    </div>
-  );
-}
-```
+N'autorisez `x-forwarded-host` et `x-forwarded-proto` que lorsque `TRUSTED_PROXY=1` et que le processus SSR se trouve derrière un proxy de confiance qui définit ces en-têtes. `VITE_CSP_NONCE` est facultatif et transmis à la configuration SSR du routeur.
 
-### Utilisation des mutations
-
-```typescript
-import { useCreateProduct, getListProductsQueryKey } from '~/lib/data/products';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-
-function CreateProductForm() {
-  const queryClient = useQueryClient();
-
-  const mutation = useCreateProduct({
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: getListProductsQueryKey() });
-      toast.success('Produit créé');
-    },
-    onError: () => {
-      toast.error('Échec de la création du produit');
-    },
-  });
-
-  const handleSubmit = async (data: CreateProductDto) => {
-    await mutation.mutateAsync(data);
-  };
-}
-```
-
-## Formulaires
-
-### TanStack Form + Zod
-
-```typescript
-import { useForm } from '@tanstack/react-form';
-import { z } from 'zod';
-
-const schema = z.object({
-  name: z.string().min(1, 'Requis').max(100),
-  sku: z.string().min(1, 'Requis').max(50),
-  category_id: z.string().uuid().optional(),
-});
-
-function ProductForm() {
-  const form = useForm({
-    defaultValues: { name: '', sku: '', category_id: '' },
-    validators: { onSubmit: schema },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  return (
-    <form onSubmit={(e) => { e.preventDefault(); form.handleSubmit(); }}>
-      <form.Field name="name">
-        {(field) => (
-          <Field>
-            <FieldLabel>Nom</FieldLabel>
-            <Input
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            <FieldError errors={field.state.meta.errors} />
-          </Field>
-        )}
-      </form.Field>
-
-      <Button type="submit" disabled={form.state.isSubmitting}>
-        Enregistrer
-      </Button>
-    </form>
-  );
-}
-```
+Le premier rendu s'exécutant sur le serveur, ne lisez pas `window`, `document`, `navigator`, `localStorage` ni les API de caméra au niveau du module. Utilisez un gestionnaire d'événement, `useEffect` ou une condition explicite `typeof window !== 'undefined'`.
 
 ## Routage
 
-Les routes sont définies avec `createFileRoute` dans `src/routes/` :
+TanStack Router déduit les chemins à partir des fichiers, y compris les groupes sans segment d'URL. Une route authentifiée doit donc déclarer son identifiant généré complet :
 
 ```typescript
-import { createFileRoute } from '@tanstack/react-router';
-import { ProductFilters } from '~/components/products/ProductFilters';
-import { ProductGrid } from '~/components/products/ProductGrid';
+import { createFileRoute } from '@tanstack/react-router'
+import { Resource } from '@stocket/types/auth'
+import { z } from 'zod'
+import { getListCategoriesQueryOptions } from '@/lib/data/categories'
+import { requireRouteAccess } from '@/lib/router/guards'
+import { pageSearchParam, stringSearchParam } from '@/lib/router/search'
 
-export const Route = createFileRoute('/products')({
+const searchSchema = z.object({
+  q: stringSearchParam,
+  page: pageSearchParam,
+})
+
+export const Route = createFileRoute('/_authed/products')({
+  validateSearch: (search) => searchSchema.parse(search),
+  beforeLoad: ({ context }) => {
+    requireRouteAccess(context.currentUser, Resource.PRODUCTS)
+  },
+  loader: async ({ context: { queryClient } }) => {
+    await queryClient.ensureQueryData(getListCategoriesQueryOptions())
+  },
   component: ProductsPage,
-});
+})
+```
 
-function ProductsPage() {
-  return (
-    <div className="page-container">
-      <h1>Produits</h1>
-      <ProductFilters />
-      <ProductGrid />
-    </div>
-  );
+Conservez les filtres partageables et la pagination dans des paramètres de recherche URL validés. Utilisez les loaders pour précharger les requêtes nécessaires au premier rendu, puis consommez les mêmes options de requête ou hooks dans le composant. `routeTree.gen.ts` est produit par le plugin TanStack Router et ne doit pas être modifié manuellement.
+
+### Protections d'hôte, de permission et de fonctionnalité
+
+La route parente `_authed` gère la détection de l'hôte plateforme et l'authentification. Les routes enfants ajoutent les contrôles de ressource et de fonctionnalité avec `requireRouteAccess` :
+
+```typescript
+import { Resource } from '@stocket/types/auth'
+import { FeatureKey } from '@stocket/types/features'
+import { requireRouteAccess } from '@/lib/router/guards'
+
+beforeLoad: ({ context }) => {
+  requireRouteAccess(context.currentUser, Resource.ORDERS, {
+    feature: FeatureKey.ORDERS,
+  })
 }
 ```
 
-### Liste des routes
+Utilisez le profil utilisateur déjà présent dans le contexte de route ; ne rechargez pas les permissions dans `beforeLoad`. Une route autonome réservée à la plateforme utilise `getServerIsPlatformHost()` et redirige les hôtes locataires.
 
-| Fichier | Route |
-|---------|-------|
-| `__root.tsx` | Layout racine |
-| `index.tsx` | `/` (Accueil) |
-| `products.tsx` | `/products` |
-| `products.$id.tsx` | `/products/:id` |
-| `locations.tsx` | `/locations` |
-| `locations.$id.tsx` | `/locations/:id` |
-| `inventory.tsx` | `/inventory` |
-| `stock.tsx` | `/stock` |
-| `stock-movements.tsx` | `/stock-movements` |
-| `orders.tsx` | `/orders` |
-| `clients.tsx` | `/clients` |
-| `suppliers.tsx` | `/suppliers` |
-| `audit-logs.tsx` | `/audit-logs` |
-| `users.tsx` | `/users` |
-| `roles.tsx` | `/roles` |
-| `settings.tsx` | `/settings` |
-| `login.tsx` | `/login` |
-| `signup.tsx` | `/signup` |
-
-## Sécurité SSR
-
-TanStack Start rend côté serveur au premier chargement. Éviter les APIs
-navigateur au niveau module ; utiliser `useEffect` ou
-`typeof window !== 'undefined'` si nécessaire.
-
-## Composants
-
-### Template de composant
+Dans les composants, protégez séparément les actions d'écriture, car les permissions de lecture et d'écriture diffèrent :
 
 ```typescript
-import { useTranslation } from 'react-i18next';
-import { cn } from '~/lib/utils';
-import { type ProductResponseDto } from '~/lib/data/products';
+import { Permission, Resource } from '@stocket/types/auth'
+import { FeatureKey } from '@stocket/types/features'
+import { useFeatures } from '@/lib/features'
+import { usePermissions } from '@/lib/permissions'
 
-interface ProductCardProps {
-  product: ProductResponseDto;
-  className?: string;
-}
-
-export function ProductCard({ product, className }: ProductCardProps) {
-  const { t } = useTranslation();
-
-  return (
-    <div className={cn('p-4 border rounded', className)}>
-      <h3>{product.name}</h3>
-      <p>{product.sku}</p>
-    </div>
-  );
-}
+const { can } = usePermissions()
+const features = useFeatures()
+const canCreate = can(Permission.WRITE, Resource.PRODUCTS)
+const canImport = canCreate && features.has(FeatureKey.SMART_IMPORT)
 ```
 
-## Styles
+Les protections de route constituent la frontière de navigation du frontend ; les endpoints backend restent l'autorité de sécurité. Masquer la navigation ou les boutons est une protection UX supplémentaire, pas une autorisation. Lors de l'ajout d'une page, alignez sa protection de route avec les métadonnées `resource`/`feature` de la barre latérale.
 
-### Tailwind CSS
+## Conventions API et Query
 
-Utiliser l'utilitaire `cn()` pour les classes conditionnelles :
+Utilisez `@/` pour les imports depuis `src`. Bien que la configuration TypeScript résolve encore `~/`, le nouveau code suit la convention `@/`. Importez les DTO et enums depuis leur point d'entrée métier, par exemple `@stocket/types/products` ou `@stocket/types/auth`.
+
+Les hooks API typés se trouvent dans `src/lib/data`. Les ressources standard utilisent `makeCrudHooks` ; les opérations spécifiques utilisent `makeQueryHook`, `makeParamQueryHook` ou `makeMutationHook`. Les utilitaires Axios ajoutent les en-têtes transmis pendant le SSR, extraient les données de réponse, acceptent un signal d'annulation pour les requêtes GET et redirigent les réponses 401 du navigateur vers `/login`.
 
 ```typescript
-import { cn } from '~/lib/utils';
+import { useListProducts } from '@/lib/data/products'
 
-<div className={cn('p-4', isActive && 'bg-primary', className)} />
+const products = useListProducts(
+  { search: searchText || undefined, page, limit: 20 },
+  { query: { enabled: isReady } },
+)
+
+if (products.isLoading) return <LoadingState />
+if (products.error) return <ErrorState error={products.error} />
+if (!products.data?.data.length) return <EmptyState />
 ```
 
-### Variables CSS
-
-Les couleurs du thème sont définies dans `globals.css` :
-
-```css
-:root {
-  --primary: 220 90% 56%;
-  --background: 0 0% 100%;
-}
-
-.dark {
-  --primary: 220 90% 60%;
-  --background: 0 0% 10%;
-}
-```
-
-## Internationalisation
-
-### Ajouter des traductions
-
-```json
-// locales/fr/common.json
-{
-  "navigation": {
-    "products": "Produits",
-    "categories": "Catégories"
-  }
-}
-```
-
-### Utiliser les traductions
+Les options propres aux requêtes sont imbriquées sous `query`. Les callbacks de mutation sont imbriqués sous `mutation`, et les mutations CRUD générées reçoivent des variables de forme `{ data }`, `{ id, data }` ou `{ id }` :
 
 ```typescript
-import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  getListProductsQueryKey,
+  useCreateProduct,
+} from '@/lib/data/products'
 
-function Header() {
-  const { t, i18n } = useTranslation();
+const queryClient = useQueryClient()
+const createProduct = useCreateProduct({
+  mutation: {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: getListProductsQueryKey(),
+      })
+    },
+  },
+})
 
-  return (
-    <nav>
-      <a href="/products">{t('navigation.products')}</a>
-      <button onClick={() => i18n.changeLanguage('fr')}>FR</button>
-    </nav>
-  );
-}
+createProduct.mutate({ data: values })
 ```
 
-## Alias de chemin
+Préférez les factories d'options de requête exportées dans les loaders et les clés de requête exportées pour une invalidation ciblée. Préservez l'`AbortSignal` lors de l'ajout d'opérations GET.
 
-Le frontend utilise `~/*` comme alias de chemin correspondant à `src/*` :
+## Formulaires et internationalisation
+
+Les formulaires métier utilisent TanStack Form et Zod, généralement via un hook dans `src/hooks/forms`. Conservez la conversion des DTO et l'orchestration des mutations dans le hook ou la couche fonctionnelle, plutôt que dans les composants UI de base. La validation serveur reste l'autorité ; mappez les erreurs API vers une bannière de formulaire ou des erreurs de champ.
+
+Toute chaîne visible par l'utilisateur nécessite des clés correspondantes dans `src/locales/en`, `de` et `fr`. Utilisez `useTranslation()` dans les composants et séparez les valeurs stables d'enum/statut de leurs libellés traduits.
+
+Nettoyez les URL fournies par l'API avec `sanitizeUrl()` depuis `@/lib/utils`. Validez les URL saisies par l'utilisateur avec le schéma d'URL sûre partagé avant de les stocker.
+
+## Styles et composants
+
+Utilisez les couches de style existantes selon leur rôle :
+
+- StyleX (`stylex.create` et `stylex.props`) pour les mises en page fonctionnelles et les styles locaux.
+- Les primitives StyleX partagées de `@/lib/stylex` pour les motifs de mise en page répétés.
+- Les composants shadcn/Radix de `@/components/ui` pour les contrôles et superpositions accessibles.
+- Les utilitaires Tailwind et `cn()` lorsqu'un composant shadcn expose `className` ou qu'une petite composition d'utilitaires est plus claire.
+- Les propriétés CSS personnalisées de `routes/globals.css` pour les couleurs, la sémantique d'espacement et les valeurs dépendantes du thème.
 
 ```typescript
-// Au lieu de chemins relatifs :
-import { Button } from '../../../components/ui/button';
+import * as stylex from '@stylexjs/stylex'
+import { Button } from '@/components/ui/button'
+import { stylexBase } from '@/lib/stylex/base'
 
-// Utiliser l'alias :
-import { Button } from '~/components/ui/button';
+const styles = stylex.create({
+  actions: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: '0.75rem',
+  },
+})
+
+<div {...stylex.props(stylexBase.panelColumn, styles.actions)}>
+  <Button type="button">{t('common.save')}</Button>
+</div>
 ```
 
-## Patterns courants
+Ne codez pas en dur les couleurs du thème clair. Le document peut utiliser les thèmes Stocket clair, Stocket sombre, neutre clair ou neutre sombre ; tous sont résolus par les variables CSS.
 
-### États de chargement
+## Tâches en arrière-plan et Smart Import
+
+L'import de produits est une requête multipart qui met en file une tâche backend durable. `importProductsCsv` exige une clé d'idempotence, puis `waitForTask` interroge `/tasks/:id` chaque seconde jusqu'à `SUCCEEDED`, `FAILED` ou `CANCELED`. Le délai d'attente côté navigateur est de 30 minutes ; les erreurs réseau et certaines erreurs HTTP réessayables n'abandonnent pas immédiatement la tâche.
 
 ```typescript
-if (isLoading) return <Spinner />;
-if (error) return <ErrorState error={error} />;
-if (!data?.length) return <EmptyState />;
+import type { TaskResponseDto } from '@stocket/types/tasks'
+import { useState } from 'react'
+import { useBulkCsvImport } from '@/hooks/products'
+
+const [task, setTask] = useState<TaskResponseDto | null>(null)
+const importProducts = useBulkCsvImport(handleResult, handleFailure)
+
+importProducts.mutate({
+  file,
+  approvedPlan,
+  idempotencyKey,
+  onTaskUpdate: setTask,
+})
 ```
 
-### Invalidation de requêtes
+Gardez l'identifiant et la progression de la tâche visibles afin que l'utilisateur puisse vérifier son état après un délai d'attente du navigateur. Réutilisez la même clé d'idempotence pour réessayer la même soumission. Ne lancez pas plusieurs boucles d'interrogation en parallèle : chaque requête dépend de l'état précédent. L'interface Smart Import doit rester protégée à la fois par `PRODUCTS.WRITE` et `FeatureKey.SMART_IMPORT`.
 
-```typescript
-queryClient.invalidateQueries({ queryKey: getListProductsQueryKey() });
+## Limites de la PWA
+
+La racine de production enregistre `public/sw.js` ; ce n'est pas le cas en développement. Le manifeste démarre l'application installée sur `/login?source=pwa`. Le service worker précharge la page hors ligne et les ressources de marque, utilise une stratégie réseau d'abord pour la navigation avec repli hors ligne, et une stratégie stale-while-revalidate pour les ressources statiques.
+
+Les requêtes API sont explicitement exclues du cache du service worker. L'application ne fournit ni données hors ligne, ni mutations en attente, ni synchronisation en arrière-plan. Les fonctionnalités doivent considérer l'accès API comme disponible uniquement en ligne et afficher les erreurs réseau normales en cas de déconnexion.
+
+## Tests et vérifications
+
+Les tests unitaires et de composants sont colocalisés sous `src/**/*.test.ts(x)` et s'exécutent dans l'environnement JSDOM de Vitest avec Testing Library et le plugin de test StyleX. Placez les comportements purs de requête, protection, reducer et tâche dans des tests unitaires ciblés ; testez le comportement visible des composants avec des rôles et libellés accessibles.
+
+Les spécifications Playwright se trouvent dans `e2e/tests`. Le projet de préparation crée l'état de stockage authentifié pour les tests locataires ; les tests d'authentification utilisent le projet non authentifié. L'origine cible provient de `E2E_FRONTEND_ORIGIN`.
+
+Depuis `frontend/`, utilisez :
+
+```bash
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+pnpm test:e2e
+pnpm validate       # type-check + lint + format:check
 ```
 
-### Récupération conditionnelle
+Exécutez le plus petit test unitaire ou E2E pertinent pendant l'itération, puis `pnpm validate` avant la livraison.
 
-```typescript
-const query = useListProducts(params, { enabled: !!categoryId });
-```
+## Ajouter une page fonctionnelle
 
-## Bonnes pratiques
+1. Ajoutez la route sous `src/routes/_authed` et utilisez son identifiant généré complet.
+2. Définissez et validez les paramètres de recherche URL lorsque l'état doit être partageable.
+3. Ajoutez les contrôles de ressource et, si nécessaire, de fonctionnalité avec `requireRouteAccess`.
+4. Préchargez l'état serveur initial avec les options de requête exportées lorsque cela améliore le SSR.
+5. Placez les opérations API dans `src/lib/data` et l'orchestration dans un hook ou composant fonctionnel.
+6. Protégez les contrôles d'écriture avec `usePermissions` et les droits de plan avec `useFeatures`.
+7. Ajoutez les métadonnées correspondantes dans la barre latérale et les traductions en anglais, allemand et français.
+8. Ajoutez une couverture unitaire/composant ciblée et le scénario Playwright pertinent.
 
-1. **Colocaliser la récupération de données** - Récupérer où les données sont utilisées
-2. **Utiliser l'UI pending des routes** - Définir `pendingComponent` ou des limites de suspense
-3. **Lazy load les composants lourds** - Utiliser `React.lazy` ou le code splitting des routes
-4. **Garder les bundles petits** - Ne pas importer de bibliothèques lourdes inutilement
+## Erreurs courantes
 
-### Erreurs courantes à éviter
-
-- Utiliser des APIs navigateur au niveau module pendant le SSR
-- Invalider trop largement les requêtes au lieu de clés ciblées
-- Mettre tout l'état au niveau de la page et faire du prop-drilling
-- Récupérer sans clés de requête stables ou paramètres mémorisés
+- Déclarer une route authentifiée comme `/products` au lieu de `/_authed/products`.
+- Modifier `routeTree.gen.ts` manuellement.
+- Ajouter des imports `~/` au lieu de l'alias standard du projet `@/`.
+- Passer directement `{ enabled }` au lieu de `{ query: { enabled } }` aux hooks de données.
+- Passer directement un DTO à une mutation générée au lieu de `{ data: dto }`.
+- Lire les objets globaux du navigateur ou des variables réservées au navigateur pendant le SSR.
+- Transmettre les en-têtes proxy sans respecter la frontière de proxy de confiance.
+- Masquer un lien sans appliquer les mêmes permission et fonctionnalité sur la route.
+- Supposer que la PWA met les données API en cache ou qu'un délai d'attente navigateur a annulé une tâche backend.

--- a/docs/development/frontend-development.md
+++ b/docs/development/frontend-development.md
@@ -1,445 +1,281 @@
 # Frontend Development
 
-This guide covers TanStack Start development patterns for the Stocket Inventory frontend.
+The Stocket web application is a server-rendered React application built with TanStack Start. This guide describes the conventions used by the current frontend.
 
-## Tech Stack
+## Stack
 
-- TanStack Start (TanStack Router + Vite)
-- React 19
-- TanStack Query (server state)
-- TanStack Form (form management)
-- Tailwind CSS 4
-- Radix UI / shadcn components
-- Better Auth
-- i18next (en, de, fr)
+- React 19 and TanStack Start/Router
+- TanStack Query for server state and SSR hydration
+- TanStack Form with Zod validation
+- Better Auth for email/password authentication
+- StyleX for feature and layout styles
+- Tailwind CSS 4 and shadcn/Radix for UI primitives
+- i18next for English, German, and French
+- Vitest, Testing Library, and Playwright
 
-## Project Structure
+## Source Map
 
-```
-frontend/src/
-├── routes/                      # File-based routes (TanStack Router)
-│   ├── __root.tsx               # Root layout + providers
-│   ├── login.tsx                # Login (/login)
-│   ├── signup.tsx               # Signup (/signup)
-│   ├── _authed.tsx              # Auth guard layout — beforeLoad redirects to /login
-│   └── _authed/                 # Authenticated route group
-│       ├── index.tsx            # Home (/)
-│       ├── products.tsx         # Products (/products)
-│       ├── products.$id.tsx     # Product detail (/products/:id)
-│       ├── locations.tsx        # Locations (/locations)
-│       ├── locations.$id.tsx    # Location detail (/locations/:id)
-│       ├── inventory.tsx        # Inventory (/inventory)
-│       ├── stock.tsx            # Stock (/stock)
-│       ├── stock-movements.tsx  # Stock Movements (/stock-movements)
-│       ├── orders.tsx           # Orders (/orders)
-│       ├── clients.tsx          # Clients (/clients)
-│       ├── suppliers.tsx        # Suppliers (/suppliers)
-│       ├── audit-logs.tsx       # Audit logs (/audit-logs)
-│       ├── users.tsx            # Users (/users)
-│       ├── roles.tsx            # Roles (/roles)
-│       └── settings.tsx         # Settings (/settings)
-├── components/
-│   ├── ui/                      # Base components (Radix/shadcn)
-│   ├── areas/                   # Area features
-│   ├── audit-logs/              # Audit log features
-│   ├── category/                # Category features
-│   ├── clients/                 # Client features
-│   ├── common/                  # Header, dialogs, etc.
-│   ├── inventory/               # Inventory features
-│   ├── items/                   # Item features
-│   ├── locations/               # Location features
-│   ├── orders/                  # Order features
-│   ├── products/                # Product features
-│   ├── roles/                   # Role features
-│   ├── settings/                # Settings features
-│   ├── stock-movements/         # Stock movement features
-│   ├── suppliers/               # Supplier features
-│   ├── users/                   # User features
-│   ├── DefaultCatchBoundary.tsx # Error boundary
-│   └── NotFound.tsx             # 404 component
-├── hooks/providers/             # React context
-├── lib/
-│   ├── data/
-│   │   ├── areas.ts             # Area API hooks
-│   │   ├── audit-logs.ts        # Audit log API hooks
-│   │   ├── auth.ts              # Auth API hooks
-│   │   ├── axios-client.ts      # API client
-│   │   ├── branding.ts          # Branding API hooks
-│   │   ├── categories.ts        # Category API hooks
-│   │   ├── clients.ts           # Client API hooks
-│   │   ├── inventory.ts         # Inventory API hooks
-│   │   ├── locations.ts         # Location API hooks
-│   │   ├── make-crud-hooks.ts   # CRUD hook factory
-│   │   ├── orders.ts            # Order API hooks
-│   │   ├── photos.ts            # Photo API hooks
-│   │   ├── products.ts          # Product API hooks
-│   │   ├── query-cache.ts       # Query cache utilities
-│   │   ├── roles.ts             # Role API hooks
-│   │   ├── stock-movements.ts   # Stock movement API hooks
-│   │   ├── suppliers.ts         # Supplier API hooks
-│   │   └── users.ts             # User API hooks
-│   └── utils.ts                 # Utilities
-├── locales/                     # i18n (en, de, fr)
-├── router.tsx                   # Router setup
-└── routeTree.gen.ts             # Generated routes
+```text
+frontend/
+├── public/                         # Manifest, service worker, offline page, icons
+├── e2e/                            # Playwright setup, fixtures, and tests
+└── src/
+    ├── routes/
+    │   ├── __root.tsx              # Document shell and global providers
+    │   ├── _authed.tsx             # Host, session, and authenticated layout
+    │   ├── _authed/                # Tenant application routes
+    │   ├── login.tsx               # Public authentication routes
+    │   ├── signup.tsx
+    │   ├── forgot-password.tsx
+    │   ├── reset-password.tsx
+    │   └── platform.tsx            # Platform-host console
+    ├── components/
+    │   ├── ui/                     # Shared shadcn/Radix primitives
+    │   ├── products/import-wizard/ # Smart Import review and execution
+    │   └── <module>/               # Feature components
+    ├── hooks/                       # Feature orchestration and form hooks
+    ├── lib/
+    │   ├── data/                   # Typed API/query/mutation hooks
+    │   ├── router/                 # Context, guards, and search schemas
+    │   ├── server/                 # Server functions and request-host handling
+    │   └── stylex/                 # Shared StyleX styles and markers
+    ├── locales/{en,de,fr}/
+    ├── router.tsx                  # QueryClient and Router integration
+    └── routeTree.gen.ts            # Generated; never edit by hand
 ```
 
-## API Integration
+The authenticated route group currently contains the dashboard, products and product detail, locations and location detail, inventory, clients, suppliers, orders, stock movements, audit logs, users, roles, and settings. There is no `/stock` or `/categories` route; category management is part of the products page.
 
-### Handwritten Client + Shared Types
+## Rendering and Request Architecture
 
-API hooks live in `src/lib/data/*.ts` and use DTO interfaces/enums from
-`@stocket/types`. The `make-crud-hooks.ts` factory generates standard CRUD hooks for resources.
+`getRouter()` creates the router and its `QueryClient`. Query state is dehydrated on the server and hydrated in the browser, so route loaders and components share the same cache. Default query behavior includes a 60-second stale time, intent preloading, scroll restoration, and no retry for 4xx responses.
 
-### Using Queries
+`src/routes/__root.tsx` owns the HTML document and global providers: branding, localization, theme, tooltips, toasts, development tools, and production service-worker registration. In `beforeLoad`, `src/routes/_authed.tsx` branches on the original request host; the tenant branch resolves the current user before rendering the tenant shell, while the platform branch renders the platform home.
 
-```typescript
-import { useListProducts } from '~/lib/data/products';
+The domain API client has two modes:
 
-function ProductList() {
-  const { data, isLoading, error } = useListProducts({
-    category_id: selectedCategory,
-    page: 1,
-    limit: 20,
-  });
+- In the browser, requests use same-origin `/api/v1` and include credentials.
+- During SSR, requests use `INTERNAL_API_ORIGIN` and forward the cookie plus the original host and protocol so the backend can resolve the tenant.
 
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorState error={error} />;
-  if (!data?.data?.length) return <EmptyState />;
+Authentication forms use the Better Auth browser client at `/api/auth`; route authorization comes from the server-fetched `/api/v1/auth/me` payload. `better-auth` is pinned to an exact version and should be upgraded deliberately.
 
-  return (
-    <div>
-      {data.data.map(product => (
-        <ProductCard key={product.id} product={product} />
-      ))}
-    </div>
-  );
-}
-```
+Only trust `x-forwarded-host` and `x-forwarded-proto` when `TRUSTED_PROXY=1` and the SSR process is behind a trusted proxy that sets them. `VITE_CSP_NONCE` is optional and is passed to the router's SSR configuration.
 
-### Using Mutations
-
-```typescript
-import { useCreateProduct, getListProductsQueryKey } from '~/lib/data/products';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-
-function CreateProductForm() {
-  const queryClient = useQueryClient();
-
-  const mutation = useCreateProduct({
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: getListProductsQueryKey() });
-      toast.success('Product created');
-    },
-    onError: () => {
-      toast.error('Failed to create product');
-    },
-  });
-
-  const handleSubmit = async (data: CreateProductDto) => {
-    await mutation.mutateAsync(data);
-  };
-}
-```
-
-## Forms
-
-### TanStack Form + Zod
-
-```typescript
-import { useForm } from '@tanstack/react-form';
-import { z } from 'zod';
-
-const schema = z.object({
-  name: z.string().min(1, 'Required').max(100),
-  sku: z.string().min(1, 'Required').max(50),
-  category_id: z.string().uuid().optional(),
-});
-
-function ProductForm() {
-  const form = useForm({
-    defaultValues: { name: '', sku: '', category_id: '' },
-    validators: { onSubmit: schema },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  return (
-    <form onSubmit={(e) => { e.preventDefault(); form.handleSubmit(); }}>
-      <form.Field name="name">
-        {(field) => (
-          <Field>
-            <FieldLabel>Name</FieldLabel>
-            <Input
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            <FieldError errors={field.state.meta.errors} />
-          </Field>
-        )}
-      </form.Field>
-
-      <Button type="submit" disabled={form.state.isSubmitting}>
-        Save
-      </Button>
-    </form>
-  );
-}
-```
+Because the first render runs on the server, do not read `window`, `document`, `navigator`, `localStorage`, or camera APIs at module scope. Use an event handler, `useEffect`, or an explicit `typeof window !== 'undefined'` guard.
 
 ## Routing
 
-Routes are defined with `createFileRoute` in `src/routes/`:
+TanStack Router derives paths from files, including pathless groups. An authenticated route must therefore declare the full generated route ID:
 
 ```typescript
-import { createFileRoute } from '@tanstack/react-router';
-import { ProductFilters } from '~/components/products/ProductFilters';
-import { ProductGrid } from '~/components/products/ProductGrid';
+import { createFileRoute } from '@tanstack/react-router'
+import { Resource } from '@stocket/types/auth'
+import { z } from 'zod'
+import { getListCategoriesQueryOptions } from '@/lib/data/categories'
+import { requireRouteAccess } from '@/lib/router/guards'
+import { pageSearchParam, stringSearchParam } from '@/lib/router/search'
 
-export const Route = createFileRoute('/products')({
-  component: ProductsPage,
-});
+const searchSchema = z.object({
+  q: stringSearchParam,
+  page: pageSearchParam,
+})
 
-function ProductsPage() {
-  return (
-    <div className="page-container">
-      <h1>Products</h1>
-      <ProductFilters />
-      <ProductGrid />
-    </div>
-  );
-}
-```
-
-### Route List
-
-| File | Route |
-|------|-------|
-| `__root.tsx` | Root layout |
-| `login.tsx` | `/login` |
-| `signup.tsx` | `/signup` |
-| `_authed.tsx` | Auth guard layout (redirects unauthenticated users to `/login`) |
-| `_authed/index.tsx` | `/` (Home) |
-| `_authed/products.tsx` | `/products` |
-| `_authed/products.$id.tsx` | `/products/:id` |
-| `_authed/locations.tsx` | `/locations` |
-| `_authed/locations.$id.tsx` | `/locations/:id` |
-| `_authed/inventory.tsx` | `/inventory` |
-| `_authed/stock.tsx` | `/stock` |
-| `_authed/stock-movements.tsx` | `/stock-movements` |
-| `_authed/orders.tsx` | `/orders` |
-| `_authed/clients.tsx` | `/clients` |
-| `_authed/suppliers.tsx` | `/suppliers` |
-| `_authed/audit-logs.tsx` | `/audit-logs` |
-| `_authed/users.tsx` | `/users` |
-| `_authed/roles.tsx` | `/roles` |
-| `_authed/settings.tsx` | `/settings` |
-
-!!! warning "`routeTree.gen.ts` only regenerates when dev is running"
-    The generated route tree at `src/routeTree.gen.ts` is only updated by the TanStack Router Vite plugin while `pnpm dev` is running. If dev isn't running, update it manually.
-
-## Authentication & Authorization
-
-### Route Guarding
-
-Protected routes live under the `_authed/` group. The parent `_authed.tsx` registers a `beforeLoad` that redirects to `/login` if there is no session.
-
-**`beforeLoad` cannot call React hooks.** Use the pure helpers from `~/lib/permissions.ts` — `resolvePermissions()` and `canAccess()` — not the `usePermissions()` hook.
-
-```typescript
-// _authed/roles.tsx
-import { createFileRoute, redirect } from '@tanstack/react-router';
-import { canAccess, resolvePermissions } from '~/lib/permissions';
-import { Permission, Resource } from '@stocket/types';
-
-export const Route = createFileRoute('/_authed/roles')({
-  beforeLoad: async ({ context }) => {
-    const permissions = await resolvePermissions(context);
-    if (!canAccess(permissions, Permission.READ, Resource.ROLES)) {
-      throw redirect({ to: '/' });
-    }
+export const Route = createFileRoute('/_authed/products')({
+  validateSearch: (search) => searchSchema.parse(search),
+  beforeLoad: ({ context }) => {
+    requireRouteAccess(context.currentUser, Resource.PRODUCTS)
   },
-  component: RolesPage,
-});
+  loader: async ({ context: { queryClient } }) => {
+    await queryClient.ensureQueryData(getListCategoriesQueryOptions())
+  },
+  component: ProductsPage,
+})
 ```
 
-### Write-Gating in Components
+Keep shareable filters and pagination in validated URL search parameters. Use loaders to warm queries needed for the initial render, then consume the same query options or hooks in the component. `routeTree.gen.ts` is an output of the TanStack Router plugin and must not be edited manually.
 
-Inside components, use the `usePermissions()` hook and `can(Permission.WRITE, resource)` to hide or disable actions for read-only users:
+### Host, Permission, and Feature Guards
+
+The parent `_authed` route handles platform-host detection and authentication. Child routes add resource and feature checks with `requireRouteAccess`:
 
 ```typescript
-import { usePermissions } from '~/hooks/providers/permissions';
-import { Permission, Resource } from '@stocket/types';
+import { Resource } from '@stocket/types/auth'
+import { FeatureKey } from '@stocket/types/features'
+import { requireRouteAccess } from '@/lib/router/guards'
 
-function ProductActions() {
-  const { can } = usePermissions();
-  if (!can(Permission.WRITE, Resource.PRODUCTS)) return null;
-  return <CreateProductButton />;
+beforeLoad: ({ context }) => {
+  requireRouteAccess(context.currentUser, Resource.ORDERS, {
+    feature: FeatureKey.ORDERS,
+  })
 }
 ```
 
-### Adding a New Authenticated Page
+Use the current-user payload already present in route context; do not fetch permissions again in `beforeLoad`. A platform-only standalone route uses `getServerIsPlatformHost()` and redirects tenant hosts.
 
-1. Create the route file under `src/routes/_authed/`.
-2. Add a sidebar nav entry in `components/common/Header.tsx` (with `resource: Resource`).
-3. Add translation keys to **all three** locales: `locales/{en,de,fr}/common.json`.
-4. For role-guarded routes, add `beforeLoad` using `resolvePermissions()` + `canAccess()` (pure functions, not hooks).
-
-### URL Sanitization
-
-Always wrap URLs from API data (branding logo, favicon, external links) in `sanitizeUrl()` from `~/lib/utils`. Validate user-submitted URLs in forms with `safeUrlSchema`.
-
-## SSR Safety
-
-TanStack Start renders on the server for the initial HTML. Avoid browser-only
-APIs at module scope; use `useEffect` or guard with
-`typeof window !== 'undefined'` when needed.
-
-## Components
-
-### Component Template
+Inside components, gate write actions independently because read and write permissions differ:
 
 ```typescript
-import { useTranslation } from 'react-i18next';
-import { cn } from '~/lib/utils';
-import { type ProductResponseDto } from '~/lib/data/products';
+import { Permission, Resource } from '@stocket/types/auth'
+import { FeatureKey } from '@stocket/types/features'
+import { useFeatures } from '@/lib/features'
+import { usePermissions } from '@/lib/permissions'
 
-interface ProductCardProps {
-  product: ProductResponseDto;
-  className?: string;
-}
-
-export function ProductCard({ product, className }: ProductCardProps) {
-  const { t } = useTranslation();
-
-  return (
-    <div className={cn('p-4 border rounded', className)}>
-      <h3>{product.name}</h3>
-      <p>{product.sku}</p>
-    </div>
-  );
-}
+const { can } = usePermissions()
+const features = useFeatures()
+const canCreate = can(Permission.WRITE, Resource.PRODUCTS)
+const canImport = canCreate && features.has(FeatureKey.SMART_IMPORT)
 ```
 
-## Styling
+Route guards are the frontend navigation boundary; backend endpoints remain the security authority. Hiding navigation or buttons is additional UX protection, not authorization. When adding a page, keep its route guard and sidebar `resource`/`feature` metadata aligned.
 
-### Tailwind CSS
+## API and Query Conventions
 
-Use the `cn()` utility for conditional classes:
+Use `@/` for imports from `src`. Although the TypeScript configuration still resolves `~/`, new code follows the `@/` convention. Import DTOs and enums from their domain entry point, such as `@stocket/types/products` or `@stocket/types/auth`.
+
+Typed API hooks live in `src/lib/data`. Standard resources use `makeCrudHooks`; custom operations use `makeQueryHook`, `makeParamQueryHook`, or `makeMutationHook`. The Axios helpers attach SSR forwarding headers, unwrap response data, accept abort signals for GET requests, and send browser 401 responses to `/login`.
 
 ```typescript
-import { cn } from '~/lib/utils';
+import { useListProducts } from '@/lib/data/products'
 
-<div className={cn('p-4', isActive && 'bg-primary', className)} />
+const products = useListProducts(
+  { search: searchText || undefined, page, limit: 20 },
+  { query: { enabled: isReady } },
+)
+
+if (products.isLoading) return <LoadingState />
+if (products.error) return <ErrorState error={products.error} />
+if (!products.data?.data.length) return <EmptyState />
 ```
 
-### CSS Variables
-
-Theme colors are defined in `globals.css`:
-
-```css
-:root {
-  --primary: 220 90% 56%;
-  --background: 0 0% 100%;
-}
-
-.dark {
-  --primary: 220 90% 60%;
-  --background: 0 0% 10%;
-}
-```
-
-## Internationalization
-
-### Adding Translations
-
-```json
-// locales/en/common.json
-{
-  "navigation": {
-    "products": "Products",
-    "categories": "Categories"
-  }
-}
-
-// locales/fr/common.json
-{
-  "navigation": {
-    "products": "Produits",
-    "categories": "Catégories"
-  }
-}
-```
-
-### Using Translations
+Query-specific options are nested under `query`. Mutation callbacks are nested under `mutation`, and generated CRUD mutations receive variables shaped as `{ data }`, `{ id, data }`, or `{ id }`:
 
 ```typescript
-import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  getListProductsQueryKey,
+  useCreateProduct,
+} from '@/lib/data/products'
 
-function Header() {
-  const { t, i18n } = useTranslation();
+const queryClient = useQueryClient()
+const createProduct = useCreateProduct({
+  mutation: {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: getListProductsQueryKey(),
+      })
+    },
+  },
+})
 
-  return (
-    <nav>
-      <a href="/products">{t('navigation.products')}</a>
-      <button onClick={() => i18n.changeLanguage('fr')}>FR</button>
-    </nav>
-  );
-}
+createProduct.mutate({ data: values })
 ```
 
-## Path Aliases
+Prefer exported query-option factories in loaders and exported query keys for targeted invalidation. Preserve the `AbortSignal` when adding GET operations.
 
-The frontend supports two path aliases, both mapping to `src/*`:
+## Forms and Internationalization
 
-- `~/*` — the primary convention used across components and hooks
-- `@/*` — equivalent; used in a handful of files (e.g. `axios-client.ts` references `@/lib/url-config`)
+Feature forms use TanStack Form and Zod, usually through a hook in `src/hooks/forms`. Keep DTO conversion and mutation orchestration in the hook or feature layer rather than in base UI components. Server validation remains authoritative; map API errors to a form banner or field errors.
+
+All user-visible strings require matching keys in `src/locales/en`, `de`, and `fr`. Use `useTranslation()` in components and keep stable enum/status values separate from translated labels.
+
+Sanitize API-provided URLs with `sanitizeUrl()` from `@/lib/utils`. Validate user-entered URLs with the shared safe URL schema before storing them.
+
+## Styling and Components
+
+Use the existing styling layers according to their role:
+
+- StyleX (`stylex.create` and `stylex.props`) for feature layouts and local component styles.
+- Shared StyleX primitives from `@/lib/stylex` for repeated layout patterns.
+- shadcn/Radix components from `@/components/ui` for accessible controls and overlays.
+- Tailwind utilities and `cn()` where a shadcn component exposes `className` or a small utility composition is clearer.
+- CSS custom properties from `routes/globals.css` for colors, spacing semantics, and theme-aware values.
 
 ```typescript
-// Instead of relative paths:
-import { Button } from '../../../components/ui/button';
+import * as stylex from '@stylexjs/stylex'
+import { Button } from '@/components/ui/button'
+import { stylexBase } from '@/lib/stylex/base'
 
-// Use the alias:
-import { Button } from '~/components/ui/button';
+const styles = stylex.create({
+  actions: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: '0.75rem',
+  },
+})
+
+<div {...stylex.props(stylexBase.panelColumn, styles.actions)}>
+  <Button type="button">{t('common.save')}</Button>
+</div>
 ```
 
-!!! note "Better Auth is pinned"
-    `better-auth` is pinned to an exact version in `package.json` (not `"latest"`). Upgrade intentionally — breaking changes can break session handling.
+Do not hard-code light-theme colors. The document can use Stocket light, Stocket dark, neutral light, or neutral dark themes, and all themes resolve through CSS variables.
 
-## Common Patterns
+## Background Tasks and Smart Import
 
-### Loading States
+Product import is a multipart request that queues a durable backend task. `importProductsCsv` requires an idempotency key, then `waitForTask` polls `/tasks/:id` every second until `SUCCEEDED`, `FAILED`, or `CANCELED`. The browser-side timeout is 30 minutes; retryable network and selected HTTP failures do not immediately abandon the task.
 
 ```typescript
-if (isLoading) return <Spinner />;
-if (error) return <ErrorState error={error} />;
-if (!data?.length) return <EmptyState />;
+import type { TaskResponseDto } from '@stocket/types/tasks'
+import { useState } from 'react'
+import { useBulkCsvImport } from '@/hooks/products'
+
+const [task, setTask] = useState<TaskResponseDto | null>(null)
+const importProducts = useBulkCsvImport(handleResult, handleFailure)
+
+importProducts.mutate({
+  file,
+  approvedPlan,
+  idempotencyKey,
+  onTaskUpdate: setTask,
+})
 ```
 
-### Query Invalidation
+Keep the task ID and progress visible so a user can check status after a browser timeout. Reuse the same idempotency key when retrying the same submission. Do not start parallel polling loops; each poll depends on the preceding task state. Smart Import UI must remain gated by both `PRODUCTS.WRITE` and `FeatureKey.SMART_IMPORT`.
 
-```typescript
-queryClient.invalidateQueries({ queryKey: getListProductsQueryKey() });
+## PWA Boundaries
+
+The production root registers `public/sw.js`; development does not. The manifest starts the installed application at `/login?source=pwa`. The service worker precaches the offline page and brand assets, uses network-first navigation with an offline fallback, and uses stale-while-revalidate for static assets.
+
+API requests are explicitly excluded from service-worker caching. The application does not provide offline data, queued mutations, or background synchronization. Features must treat API access as online-only and display normal network errors when disconnected.
+
+## Tests and Checks
+
+Unit and component tests are colocated as `src/**/*.test.ts(x)` and run in Vitest's JSDOM environment with Testing Library and the StyleX test plugin. Put pure query, guard, reducer, and task behavior in focused unit tests; test user-visible component behavior with accessible roles and labels.
+
+Playwright specifications live in `e2e/tests`. The setup project creates authenticated storage state for tenant tests; authentication tests use the unauthenticated project. The target origin comes from `E2E_FRONTEND_ORIGIN`.
+
+From `frontend/`, use:
+
+```bash
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+pnpm test:e2e
+pnpm validate       # type-check + lint + format:check
 ```
 
-### Conditional Fetching
+Run the smallest relevant unit or E2E test while iterating, then run `pnpm validate` before handoff.
 
-```typescript
-const query = useListProducts(params, { enabled: !!categoryId });
-```
+## Adding a Feature Page
 
-## Best Practices
+1. Add the route under `src/routes/_authed` and use its full generated route ID.
+2. Define and validate URL search parameters when state should be shareable.
+3. Add resource and optional feature checks with `requireRouteAccess`.
+4. Prefetch initial server state with exported query options when useful for SSR.
+5. Put API operations in `src/lib/data` and orchestration in a feature hook or component.
+6. Gate write controls with `usePermissions` and entitlements with `useFeatures`.
+7. Add matching sidebar metadata and translations in English, German, and French.
+8. Add focused unit/component coverage and the relevant Playwright flow.
 
-1. **Colocate data fetching** - Fetch where data is used
-2. **Use route pending UI** - Set `pendingComponent` or suspense boundaries
-3. **Lazy load heavy components** - Use `React.lazy` or route-level code splitting
-4. **Keep bundles small** - Don't import heavy libraries unnecessarily
+## Common Mistakes
 
-### Common Mistakes to Avoid
-
-- Using browser-only APIs at module scope during SSR
-- Over-invalidation of queries instead of scoped keys
-- Putting all state at page level and prop-drilling
-- Fetching without memoized query keys or stable params
+- Declaring an authenticated route as `/products` instead of `/_authed/products`.
+- Editing `routeTree.gen.ts` manually.
+- Adding new `~/` imports instead of the project-standard `@/` alias.
+- Passing `{ enabled }` directly instead of `{ query: { enabled } }` to data hooks.
+- Passing a DTO directly to a generated mutation instead of `{ data: dto }`.
+- Reading browser globals or browser-only environment values during SSR.
+- Forwarding proxy headers without the trusted-proxy boundary.
+- Hiding a link without enforcing the same permission and feature at the route.
+- Assuming the PWA caches API data or that a browser timeout canceled a backend task.

--- a/docs/development/index.fr.md
+++ b/docs/development/index.fr.md
@@ -1,52 +1,85 @@
 # Développement
 
-Cette section couvre tout ce dont vous avez besoin pour contribuer à la base de code Stocket Inventory.
+Stocket se développe dans un checkout coordonné de dépôts indépendants.
+Commencez par `meta`, qui clone les projets gérés et assemble le workspace pnpm
+local.
 
-## Aperçu
+## Pour commencer
 
-Stocket Inventory est un workspace multi-repo contenant :
+- [Carte des projets et modules](project-map.md) — propriétaires, modules,
+  routes frontend, packages et état des déploiements
+- [Architecture](architecture.md) — topologie, tenancy, couches et tâches durables
+- [Configuration de développement](setup.md) — bootstrap, services et identifiants
+- [Style de code](code-style.md) — TypeScript, Effect, React, Oxlint et formatage
+- [Tests](testing.md) — tests unitaires, intégration, full-stack et documentation
+- [Développement API](api-development.md) — modules backend et patterns HTTP
+- [Développement frontend](frontend-development.md) — TanStack Start, données,
+  permissions, routes et styles
+- [CI/CD](ci-cd.md) — workflows actuels et frontières de release
 
-- **backend/** - Backend Effect.ts (runtime Bun)
-- **frontend/** - Frontend TanStack Start
-- **packages/** - Types partagés, configs
-- **meta/** - Scripts d'orchestration, Docker Compose
+## Propriété des changements
 
-## Liens Rapides
+| Changement | Dépôt |
+|------------|-------|
+| API, base, worker, adaptateur auth | `backend` |
+| Routes web, UI, serveur SSR, client navigateur | `frontend` |
+| DTO/schéma inter-dépôts ou modèle d'e-mail | `packages` |
+| Checkout, bootstrap, services locaux | `meta` |
+| Terraform, Ansible, opérations de l'hôte | `infrastructure` |
+| Shell natif | `remote-desktop` |
+| Documentation publique | `documentation` |
+| Site marketing | `landing` |
 
-- [Architecture](architecture.md) - Conception du système et stack technique
-- [Configuration](setup.md) - Configuration de l'environnement de développement
-- [Style de Code](code-style.md) - ESLint, Prettier et conventions
-- [Tests](testing.md) - Patterns de tests Vitest
-- [Développement API](api-development.md) - Patterns Effect.ts
-- [Développement Frontend](frontend-development.md) - Patterns TanStack Start
-- [CI/CD](ci-cd.md) - Workflows GitHub Actions
+Une fonctionnalité peut nécessiter plusieurs pull requests coordonnées. Les
+contrats partagés passent par le workflow snapshot/release stable avant la mise
+à jour des versions épinglées par les consommateurs.
 
-## Flux de Travail de Développement
+## Workflow local courant
 
-1. **Démarrer l'environnement**
+```bash
+# Depuis le dossier qui contiendra tous les dépôts
+git clone https://github.com/stocketfr/meta.git
+./meta/scripts/bootstrap
 
-    ```bash
-    # Démarrer les services (PostgreSQL, etc.)
-    cd meta && docker compose up -d
+# Démarrer PostgreSQL, MinIO, l'API et le web
+./meta/scripts/dev
+```
 
-    # Entrer dans le shell de développement (Nix flakes par repo)
-    cd backend && nix develop
-    cd frontend && nix develop
-    ```
+Le script choisit Loggle s'il est installé, sinon son runner direct. Le graphe
+Loggle commité appelle actuellement le script frontend `dev:workspace` absent :
+utilisez le [lancement séparé](setup.md#lancer-les-projets-separement) jusqu'à
+correction. `--include-desktop`/`--include-docs` passent par le runner direct et
+ajoutent ces processus. PostgreSQL et MinIO sont tentés automatiquement ;
+`--with-docker` n'est pas un mode actuel.
 
-2. **Effectuer les modifications** dans la base de code
+Pour un changement ciblé, utilisez les scripts du dépôt propriétaire :
 
-3. **Mettre à jour les types partagés** (si les DTO ont changé)
+```bash
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+```
 
-    ```bash
-    pnpm --filter @stocket/types build
-    ```
+Les filtres racine restent disponibles après bootstrap, par exemple
+`pnpm --filter @stocket/api type-check`, mais les commandes locales reflètent
+le plus directement la CI de chaque dépôt.
 
-4. **Exécuter les tests et le lint**
+## Changements de contrats inter-dépôts
 
-    ```bash
-    pnpm test
-    pnpm lint
-    ```
+1. Modifier `packages/<package>` et ajouter un Changeset.
+2. Utiliser le snapshot de la PR dans les branches backend/frontend coordonnées.
+3. Fusionner le changement et la PR de version Changesets.
+4. Mettre à jour la version publiée dans chaque consommateur.
+5. Exécuter les vérifications consommateur et le gate Playwright full-stack si
+   le contrat ou le comportement API change.
 
-5. **Soumettre une pull request**
+Le package publié s'appelle `@stocketfr/types`. Le code applicatif l'importe
+via l'alias `@stocket/types` ; cet alias ne doit pas servir de filtre pnpm.
+
+## Avant une pull request
+
+Exécutez les plus petites vérifications prouvant le changement, puis le lint et
+le typecheck du dépôt. Ajoutez une couverture d'intégration ou E2E pour les
+comportements traversant la base, HTTP ou le navigateur. Mettez à jour ensemble
+les documentations anglaise et française lorsqu'un comportement public change.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,68 +1,91 @@
 # Development
 
-This section covers everything you need to contribute to the Stocket Inventory codebase.
+Stocket is developed as a coordinated checkout of independent repositories.
+Start with `meta`, which clones the managed projects and assembles the local
+pnpm workspace overlay.
 
-## Overview
+## Start Here
 
-Stocket Inventory is a **pnpm monorepo** containing:
+- [Project and Module Map](project-map.md) — repository ownership, runtime
+  modules, frontend routes, packages, and deployment status
+- [Architecture](architecture.md) — runtime topology, tenancy, layering, and
+  durable tasks
+- [Development Setup](setup.md) — bootstrap, services, credentials, and local
+  workflow
+- [Code Style](code-style.md) — TypeScript, Effect, React, Oxlint, and formatting
+- [Testing](testing.md) — unit, integration, full-stack, and docs checks
+- [API Development](api-development.md) — backend module and HTTP patterns
+- [Frontend Development](frontend-development.md) — TanStack Start, data,
+  permissions, routing, and styling
+- [CI/CD](ci-cd.md) — current repository workflows and release boundaries
 
-- **backend/** — Effect.ts backend (Bun runtime, `@stocket/api`)
-- **frontend/** — TanStack Start SSR app (`@stocket/web`)
-- **mobile-app/** — Expo React Native app (`@stocket/mobile`)
-- **landing/** — Static marketing site
-- **remote-desktop/** — Tauri 2 desktop app (`@stocket/remote-desktop`)
-- **packages/** — Shared `types`, `eslint-config`, `tsconfig`
-- **meta/** — Workspace tooling: Docker Compose, legacy multi-repo scripts
-- **infrastructure/** — Terraform (Hetzner + Cloudflare); not a pnpm workspace member
+## Repository Ownership
 
-## Quick Links
+Use the repository that owns a change:
 
-- [Architecture](architecture.md) — System design and tech stack
-- [Setup](setup.md) — Development environment configuration
-- [Code Style](code-style.md) — oxlint, Prettier, and conventions
-- [Testing](testing.md) — Vitest + Playwright patterns
-- [API Development](api-development.md) — Effect.ts patterns
-- [Frontend Development](frontend-development.md) — TanStack Start patterns
-- [CI/CD](ci-cd.md) — GitHub Actions workflows
+| Change | Repository |
+|--------|------------|
+| API, database, task worker, auth adapter | `backend` |
+| Web routes, UI, SSR server, browser client | `frontend` |
+| DTO/schema shared across repositories or email templates | `packages` |
+| Checkout/bootstrap/local services | `meta` |
+| Terraform/Ansible/host operations | `infrastructure` |
+| Native shell | `remote-desktop` |
+| Public docs | `documentation` |
+| Marketing site | `landing` |
 
-## Development Workflow
+A feature can require coordinated pull requests. Shared contracts should land
+through the package snapshot/stable-release workflow before consumers update
+their pinned package versions.
 
-1. **Install once from the monorepo root**
+## Typical Local Workflow
 
-    ```bash
-    pnpm install
-    ```
+```bash
+# From a directory that will contain all project repositories
+git clone https://github.com/stocketfr/meta.git
+./meta/scripts/bootstrap
 
-2. **Start services**
+# Start PostgreSQL, MinIO, API, and web processes
+./meta/scripts/dev
+```
 
-    ```bash
-    cd meta && docker compose up -d
-    ```
+The dev script selects Loggle when available; otherwise it uses its direct
+runner. The checked-in Loggle graph currently calls the missing frontend
+`dev:workspace` script, so Loggle users should use the manual process startup in
+[Development Setup](setup.md#run-projects-individually) until it is fixed.
+`--include-desktop`/`--include-docs` use the direct runner and add those
+processes. Docker-backed PostgreSQL and MinIO are attempted automatically;
+`--with-docker` is not a current mode switch.
 
-3. **Run dev servers (separate terminals)**
+For a focused change, enter the owning repository and use its scripts:
 
-    ```bash
-    pnpm --filter @stocket/api start
-    pnpm --filter @stocket/web dev
-    ```
+```bash
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+```
 
-    Per-package Nix shells (`cd backend && nix develop`) are optional for isolated environments; there is **no root flake.nix**.
+Root filters are also available after bootstrap, for example
+`pnpm --filter @stocket/api type-check`, but repository-local commands match
+each project's CI most directly.
 
-4. **Make changes** to the codebase
+## Cross-Repository Contract Changes
 
-5. **Update shared types** (if DTO shapes changed) — **barrels must run before build**
+1. Modify `packages/<package>` and add a Changeset.
+2. Use the package PR snapshot in coordinated backend/frontend branches.
+3. Merge the package change and Changesets version PR.
+4. Update the released version in each consumer.
+5. Run consumer checks and the frontend full-stack Playwright gate when the API
+   contract or behavior changed.
 
-    ```bash
-    pnpm --filter @stocket/types barrels
-    pnpm --filter @stocket/types build
-    ```
+The published package is `@stocketfr/types`. Application source imports it
+through the alias `@stocket/types`; do not use that alias as a pnpm workspace
+filter.
 
-6. **Run tests and lint**
+## Before Opening a Pull Request
 
-    ```bash
-    pnpm --filter @stocket/api test
-    pnpm --filter @stocket/api lint      # oxlint
-    pnpm --filter @stocket/web lint      # oxlint (frontend too)
-    ```
-
-7. **Submit a pull request**
+Run the smallest checks that prove your change, then the repository's standard
+lint/type check. Add integration or E2E coverage for behavior crossing a
+database, HTTP, or browser boundary. Update English and French documentation
+together when public behavior changes.

--- a/docs/development/project-map.fr.md
+++ b/docs/development/project-map.fr.md
@@ -1,0 +1,173 @@
+# Carte des projets et modules
+
+Cette page est la carte de référence de la base de code Stocket. Stocket est un
+**projet fédéré en plusieurs dépôts** : chaque dépôt possède son historique, sa
+CI, son lockfile et son cycle de publication. Le dépôt `meta` peut réunir ces
+dépôts dans un workspace pnpm local pour le développement coordonné.
+
+## Carte des dépôts
+
+| Dépôt | Responsabilité | Utilisation |
+|-------|----------------|-------------|
+| [`meta`](https://github.com/stocketfr/meta) | Manifeste du workspace, orchestration du bootstrap et du développement, fichiers pnpm racine, services Compose PostgreSQL et MinIO | À cloner en premier pour obtenir le checkout complet. `repos.yaml` est le manifeste des dépôts gérés. |
+| [`backend`](https://github.com/stocketfr/backend) | API Effect sous Node.js 22, Better Auth, PostgreSQL, stockage objet, e-mails et workers | Exécute l'API HTTP et un processus worker séparé. Consomme des versions publiées de `@stocketfr/*`. |
+| [`frontend`](https://github.com/stocketfr/frontend) | Application React 19 et TanStack Start | S'exécute en SSR en développement ou en mode hébergé. Le navigateur utilise `/api` sur la même origine ; le serveur relaie vers `INTERNAL_API_ORIGIN`. |
+| [`packages`](https://github.com/stocketfr/packages) | Contrats API, modèles d'e-mail, configuration TypeScript et configuration de lint partagés | Publie des versions immuables sur GitHub Packages avec Changesets. Le backend et le frontend épinglent les versions publiées. |
+| [`remote-desktop`](https://github.com/stocketfr/remote-desktop) | Shell desktop Tauri 2 expérimental | Le code actuel fournit un écran mémorisant l'URL du serveur. Le workflow vise à embarquer un build frontend, mais contient des hypothèses de dépôt/build obsolètes et doit être réparé et vérifié avant une release. Ce n'est pas un moteur de synchronisation hors ligne. |
+| [`documentation`](https://github.com/stocketfr/documentation) | Ce site MkDocs bilingue | Les pull requests auditent locales/navigation/liens et exécutent un build MkDocs strict ; `main` répète l'audit puis déploie vers GitHub Pages. |
+| [`landing`](https://github.com/stocketfr/landing) | Site marketing statique et domaine personnalisé | Déployé indépendamment avec GitHub Pages. Ce n'est pas un runtime applicatif. |
+| [`infrastructure`](https://github.com/stocketfr/infrastructure) | Automatisation Hetzner, Cloudflare, Terraform, Ansible, Caddy, Postgres, sauvegardes R2 et Datadog | Exploité séparément de `meta`. Il gère la topologie hébergée sur un serveur et le helper de déploiement, mais aucun CD backend/frontend automatique et persistant après merge. |
+
+!!! note "Workspace local et frontières des dépôts"
+    Le bootstrap lie les fichiers racine depuis `meta/root/` et exécute pnpm
+    sur le checkout. Cette commodité ne transforme pas les projets en une
+    unité de publication. Modifiez et publiez dans le dépôt propriétaire.
+
+Le workspace racine contient une entrée réservée `mobile-app`, mais
+`meta/repos.yaml` ne gère ni ne clone actuellement d'application mobile. Elle
+ne doit pas être présentée comme un projet actif tant qu'elle n'est pas ajoutée
+au manifeste.
+
+## Topologie d'exécution
+
+```mermaid
+flowchart LR
+    B["Navigateur ou webview desktop"] -->|"/api sur la même origine"| W["Processus web TanStack Start"]
+    W -->|"INTERNAL_API_ORIGIN"| A["Processus API Effect"]
+    A --> P[("PostgreSQL 16")]
+    A --> S["Stockage objet compatible S3"]
+    A --> E["Transport d'e-mail"]
+    Q["Processus worker"] --> P
+    Q --> S
+    A -->|"crée une tâche durable"| P
+```
+
+L'API et le worker sont deux processus Node.js distincts construits depuis le
+même dépôt backend. Les imports de produits sont mis en file dans PostgreSQL,
+loués par un worker et utilisent un stockage compatible S3 pour le fichier
+d'entrée et les photos. Au moins un worker doit être actif lorsque les imports
+en arrière-plan sont disponibles.
+
+Stocket est multi-tenant. L'hôte plateforme sert aux opérations superadmin ;
+les hôtes tenant sélectionnent une organisation et limitent les données. En
+développement local, `localhost:3000` est l'hôte plateforme et les tenants
+utilisent `<slug>.localhost:3000`.
+
+## Modules backend
+
+Les modules de production résident dans `backend/src/effect/modules/`. La
+plupart suivent router → service → repository, avec les préoccupations
+partagées fournies par des layers Effect.
+
+| Module | Responsabilité et surface |
+|--------|---------------------------|
+| `areas` | Étagères, bacs et sous-emplacements hiérarchiques ; API tenant et détail d'un emplacement. |
+| `audit-logs` | Métadonnées partielles des mutations, écrites au mieux ; API tenant et UI admin. Les écritures sont asynchrones et hors transaction. |
+| `auth` | Utilisateur courant, profil et claims de session autour de Better Auth, monté sous `/api/auth`. |
+| `branding` | Lecture publique et mise à jour protégée de la marque ; écran Paramètres. |
+| `categories` | Catégories hiérarchiques utilisées par Produits et le planificateur d'import. |
+| `clients` | Clients utilisés par la création et le filtrage des commandes. |
+| `features` | Plans, droits et overrides tenant pour `smartImport` et `orders`. |
+| `fulfillment` | Prototype de domaine non monté pour confirmation et picking. Il n'est relié ni au layer applicatif ni au router HTTP ; packing et expédition renvoient explicitement « non implémenté ». |
+| `health` | Endpoints publics de liveness, readiness et santé complète ; premier module migré vers Effect `HttpApiBuilder`. |
+| `inventory` | Quantités, lots, dates d'expiration, requêtes de stock faible/expiration et chemins complets des zones. |
+| `locations` | Entrepôts, fournisseurs, clients et emplacements en transit. |
+| `notifications` | API de préférences e-mail et scan planifié. Seul le stock faible émet actuellement un événement ; le cycle des commandes n'est pas livré et aucune page frontend dédiée n'existe. |
+| `orders` | CRUD, lignes à la création puis en lecture seule, donnée d'affectation et transitions. Aucune route ne modifie ensuite les lignes et fulfillment n'est pas monté. |
+| `photos` | Upload, lecture et suppression des photos produit via stockage compatible S3. |
+| `platform` | Endpoint opérationnel public utilisé par le TLS à la demande de Caddy pour autoriser les domaines plateforme et tenant. |
+| `products` | Catalogue, actions groupées, suppression/restauration, preview CSV, propositions et import guidé durable. |
+| `roles` | Rôles système/personnalisés et permissions lecture/écriture par ressource. |
+| `stock-movements` | Registre immuable des mouvements. Créer un mouvement ne modifie pas l'inventaire et les ajustements n'en émettent pas actuellement. |
+| `superadmin` | Identité plateforme, création/import/suppression de tenants, plans, overrides et audit plateforme séparé. La suppression ne nettoie pas actuellement tout le préfixe S3 ni tous les artefacts globaux/auth. |
+| `suppliers` | Contacts fournisseurs et références depuis les produits. |
+| `tasks` | État, progression, annulation, lease, reprise et registre des workers. L'import produit est le type de tâche actuel. |
+| `users` | Création d'utilisateur/appartenance et rôles. Ban/révocation agissent globalement sur tous les tenants ; supprimer retire cette appartenance et le compte seulement après la dernière. |
+
+`e2e` est un router de support toujours désactivé en production. Dans les autres
+environnements, un secret E2E configuré le protège ; en développement sans
+secret configuré, la route locale de seed est permise. Ce n'est pas un module
+métier.
+La route authentifiée `/api/v1/_migration` est un diagnostic interne du runtime
+et des modules, pas une fonctionnalité produit.
+
+### Couches plateforme et application
+
+| Zone | Responsabilité |
+|------|----------------|
+| `src/effect/application/` | Validation de l'environnement, composition des layers, migrations de démarrage et câblage API/worker. |
+| `src/effect/http/` | Composition des routers, résolution tenant, CORS, sécurité, logs de requête et erreurs. |
+| `src/effect/platform/auth/` | Sessions, permissions, adaptateur Better Auth et gardes d'autorisation. |
+| `src/effect/platform/db/` | Drizzle, helpers tenant, migrations SQL commitées et migrations de données. |
+| `src/effect/platform/observability/` | Logs structurés localisés, tracing et service tracer. |
+| `src/effect/platform/tenancy/` | Hôtes, contexte tenant, requêtes tenant et droits fonctionnels. |
+| `src/effect/platform/storage.ts` | Adaptateur de stockage compatible S3. |
+| `src/email/` | Transports console, mémoire et Resend. |
+| `src/scripts/` | Administration superadmin/tenant, données de démo et import. |
+
+## Modules frontend
+
+Les routes authentifiées résident sous `src/routes/_authed/` et sont protégées
+par la session et les permissions de ressource.
+
+| Route | Module utilisateur |
+|-------|--------------------|
+| `/` | Totaux du tableau de bord, stock faible et activité récente. |
+| `/products` et `/products/:id` | Recherche/pagination, actions groupées, import CSV guidé, détail, édition et photos. Les catégories sont gérées ici. |
+| `/locations` et `/locations/:id` | Recherche/filtrage, détail et zones hiérarchiques. |
+| `/inventory` | Inventaire avec filtres emplacement/zone, stock faible, lot et expiration. |
+| `/clients` | Recherche, filtre de statut et CRUD des clients. |
+| `/suppliers` | Recherche par nom, filtre actif/inactif et CRUD des contacts. L'état actif se modifie dans le formulaire. |
+| `/orders` | Recherche/statuts, lignes à la création, modifications limitées des Brouillons/Confirmées et transitions. Le prototype `fulfillment` non monté n'est pas un workflow UI actif. |
+| `/stock-movements` | Historique et filtres motif/produit/emplacement, mouvements manuels. |
+| `/audit-logs` | Filtres action/entité et métadonnées de mutation, sans détail avant/après. |
+| `/users` | Cycle de vie des utilisateurs et affectation des rôles. |
+| `/roles` | Gestion des rôles et permissions. |
+| `/settings` | Marque, apparence, langue et déconnexion. |
+| `/platform` | Administration des tenants, plans, overrides et imports, uniquement sur l'hôte plateforme. |
+
+Les routes publiques couvrent la connexion, l'inscription, le mot de passe
+oublié, sa réinitialisation et les erreurs. Les dossiers de
+`src/components/` reflètent les fonctionnalités ; les accès API et clés de
+cache résident dans `src/lib/data/`.
+
+## Packages partagés
+
+| Package | Contenu |
+|---------|---------|
+| `@stocketfr/types` | Schémas Effect, DTO, IDs, enums, pagination, droits, tâches et contrats de tous les domaines publics. Les consommateurs utilisent des sous-chemins comme `@stocket/types/products`. |
+| `@stocketfr/emails` | Modèles React Email localisés pour vérification, mot de passe, bienvenue et stock faible. |
+| `@stocketfr/tsconfig` | Configuration TypeScript stricte partagée. |
+| `@stocketfr/eslint-config` | Configuration de lint publiée ; le backend et le frontend exécutent actuellement Oxlint directement. |
+
+Les changements de packages utilisent Changesets. Les pull requests peuvent
+publier des snapshots immuables pour les tests inter-dépôts ; la fusion de la
+PR de version Changesets publie les versions stables sur GitHub Packages. Le
+backend et le frontend mettent ensuite à jour leurs alias épinglés.
+
+## État des déploiements
+
+- Le backend et le frontend exécutent la CI sur les pushes et pull requests,
+  sans déploiement automatique persistant après merge ni workflow autonome de
+  rollback.
+- Des workflows manuels temporaires ont servi à un rollout audité en juillet
+  2026. Tant qu'ils étaient présents, ils n'acceptaient que le `main` courant
+  avec une CI push réussie, publiaient des images taguées par SHA et appelaient
+  le helper infrastructure ; tous deux ont été retirés après ce rollout unique.
+- La documentation reste déployée automatiquement sur GitHub Pages depuis
+  `main`.
+- Les packages restent publiés via Changesets et GitHub Packages.
+- Le site marketing est un projet GitHub Pages indépendant.
+- L'infrastructure provisionne et configure la topologie hébergée. Son helper
+  tente de restaurer l'image précédente uniquement si ses propres contrôles
+  Compose/readiness échouent après le début du remplacement. Les contrôles
+  ultérieurs du workflow ne déclenchent pas cette récupération, qui n'est ni un
+  CD persistant ni un workflow de rollback déclenché par l'opérateur.
+- Le workflow desktop vise à créer des releases natives en brouillon, mais ses
+  noms de dépôts, flags de build frontend et chemins de sortie sont obsolètes.
+  Ce chemin reste non vérifié jusqu'à sa correction. Un build desktop
+  n'implique ni base de données hors ligne ni synchronisation avec résolution
+  de conflits.
+
+Lorsque ces choix changent, mettez à jour ensemble cette page, le guide
+[CI/CD](ci-cd.md) et la [feuille de route](../roadmap.md).

--- a/docs/development/project-map.md
+++ b/docs/development/project-map.md
@@ -1,0 +1,166 @@
+# Project and Module Map
+
+This page is the source-of-truth map for the Stocket codebase. Stocket is a
+**federated multi-repository project**: each repository has its own history,
+CI, lockfile, and release lifecycle. The `meta` repository can assemble those
+repositories into one local pnpm workspace for coordinated development.
+
+## Repository Map
+
+| Repository | Responsibility | How it is used |
+|------------|----------------|----------------|
+| [`meta`](https://github.com/stocketfr/meta) | Workspace manifest, bootstrap/dev orchestration, root pnpm files, PostgreSQL and MinIO Compose services | Clone this first for a complete local checkout. `repos.yaml` is the managed-repository manifest. |
+| [`backend`](https://github.com/stocketfr/backend) | Node.js 22 Effect API, Better Auth, PostgreSQL persistence, object storage, email, and background workers | Runs the HTTP API and a separate task-worker process. Consumes versioned `@stocketfr/*` packages. |
+| [`frontend`](https://github.com/stocketfr/frontend) | React 19 and TanStack Start application | Runs as an SSR web process in development/hosted mode. Browser API calls use same-origin `/api`; the server proxies to `INTERNAL_API_ORIGIN`. |
+| [`packages`](https://github.com/stocketfr/packages) | Shared API contracts, email templates, TypeScript config, and lint config | Publishes immutable versions to GitHub Packages with Changesets. Backend and frontend pin released versions. |
+| [`remote-desktop`](https://github.com/stocketfr/remote-desktop) | Experimental Tauri 2 desktop shell | Current source provides a saved server-URL connection screen. Its release workflow intends to bundle a frontend build, but currently contains stale repository/build assumptions and must be repaired and verified before release. This is not an offline data-sync engine. |
+| [`documentation`](https://github.com/stocketfr/documentation) | This bilingual MkDocs site | Pull requests audit locale/navigation/link consistency and run a strict MkDocs build; `main` repeats the audit and deploys to GitHub Pages. |
+| [`landing`](https://github.com/stocketfr/landing) | Static marketing site and custom domain | Deployed independently through GitHub Pages. It is not an application runtime. |
+| [`infrastructure`](https://github.com/stocketfr/infrastructure) | Hetzner, Cloudflare, Terraform, Ansible, Caddy, Postgres, R2 backups, and Datadog automation | Operated separately from `meta`. It runs the single-box hosted topology and deploy helper, but backend/frontend have no persistent automatic post-merge CD. |
+
+!!! note "Local workspace versus repository boundaries"
+    Bootstrap links the root workspace files from `meta/root/` and runs pnpm
+    across the checkout. That convenience does not turn the projects into one
+    release unit. Make and publish changes in the repository that owns them.
+
+The root workspace file contains a reserved `mobile-app` entry, but
+`meta/repos.yaml` does not currently manage or clone a mobile application. Do
+not treat it as an active project until it is added to the manifest.
+
+## Runtime Topology
+
+```mermaid
+flowchart LR
+    B["Browser or desktop webview"] -->|"same-origin /api"| W["TanStack Start web process"]
+    W -->|"INTERNAL_API_ORIGIN"| A["Effect API process"]
+    A --> P[("PostgreSQL 16")]
+    A --> S["S3-compatible object storage"]
+    A --> E["Email transport"]
+    Q["Task worker process"] --> P
+    Q --> S
+    A -->|"enqueue durable task"| P
+```
+
+The API and task worker are separate Node.js processes built from the same
+backend repository. Product imports are queued in PostgreSQL, leased by a
+worker, and use S3-compatible storage for uploaded input and product photos.
+Run at least one worker anywhere background imports are enabled.
+
+Stocket is tenant-aware. The platform host is used for superadmin operations;
+tenant hosts select an organization and scope data access. In local
+development, `localhost:3000` is the platform host and tenant URLs use
+`<slug>.localhost:3000`.
+
+## Backend Modules
+
+Production modules live under `backend/src/effect/modules/`. Most HTTP modules
+follow router → service → repository, with shared concerns supplied by Effect
+layers.
+
+| Module | Responsibility and surface |
+|--------|----------------------------|
+| `areas` | Hierarchical shelves, bins, and other sub-locations; tenant API and location-detail UI. |
+| `audit-logs` | Partial, best-effort mutation metadata with tenant API and admin UI. Writes are asynchronous and not transactional. |
+| `auth` | Current-user/profile/session claims around Better Auth. Better Auth itself is mounted at `/api/auth`. |
+| `branding` | Public branding reads and permission-gated updates; Settings UI. |
+| `categories` | Hierarchical product categories used in the Products UI and import planner. |
+| `clients` | Client records used by order creation and filtering. |
+| `features` | Tenant plans, entitlements, and overrides for `smartImport` and `orders`; exposed through platform/superadmin operations and frontend feature gates. |
+| `fulfillment` | Unmounted domain prototype for confirmation and picking. It is not wired into the application layer or HTTP router; packing and shipping explicitly return not-implemented failures. |
+| `health` | Public liveness, readiness, and full health endpoints; the first module migrated to Effect `HttpApiBuilder`. |
+| `inventory` | Quantities, batches, expiry dates, low-stock/expiry queries, and full area paths. |
+| `locations` | Warehouse, supplier, client, and in-transit locations. |
+| `notifications` | User email-preference API and scheduled scanning. Low-stock email is the only emitted event today; order-lifecycle delivery is not implemented and no dedicated frontend page exists. |
+| `orders` | Order CRUD, create-time/read-only line items, assignment data, and status transitions. There is no later line-item mutation route, and it does not mount fulfillment. |
+| `photos` | Product photo upload/read/delete backed by S3-compatible storage. |
+| `platform` | Public operational endpoint used by Caddy on-demand TLS to authorize platform and tenant domains. |
+| `products` | Product catalog, bulk actions, soft-delete/restore, CSV preview/proposals, and durable guided import execution. |
+| `roles` | Custom/system roles and resource-level read/write permissions. |
+| `stock-movements` | Immutable movement ledger records. Creating a movement does not change inventory, and inventory adjustments do not currently emit movements. |
+| `superadmin` | Platform identity, tenant creation/import/deletion, plan selection, feature overrides, and separate platform audit. Tenant deletion does not currently clean the full S3 prefix or every global/auth artifact. |
+| `suppliers` | Supplier contact records and product references. |
+| `tasks` | Durable task state, progress, cancellation, leasing, recovery, and worker registry. Product import is the current registered task type. |
+| `users` | Tenant user/membership creation and roles. Ban/unban and session revocation affect the global account across memberships; delete removes this membership and deletes the account only after its last membership. |
+
+`e2e` is a test-support router and is always disabled in production. In other
+environments, a configured E2E seed secret protects it; development without a
+configured secret permits the local seed route. It is not a business module.
+The authenticated `/api/v1/_migration` route is an internal runtime/module
+diagnostic, not a product feature.
+
+### Backend Platform and Application Layers
+
+| Area | Responsibility |
+|------|----------------|
+| `src/effect/application/` | Environment validation, layer composition, startup migrations, and API/worker entrypoint wiring. |
+| `src/effect/http/` | Router composition, tenant resolution, CORS, security headers, request logging, and error responses. |
+| `src/effect/platform/auth/` | Session resolution, permission provider, Better Auth adapter, and authorization guards. |
+| `src/effect/platform/db/` | Drizzle database, tenant-aware helpers, committed SQL migrations, and startup data migrations. |
+| `src/effect/platform/observability/` | Localized structured logs, tracing, and the service tracer. |
+| `src/effect/platform/tenancy/` | Host parsing, tenant context, tenant queries, and feature access. |
+| `src/effect/platform/storage.ts` | S3-compatible storage adapter. |
+| `src/email/` | Console, in-memory, and Resend transports. |
+| `src/scripts/` | Superadmin/tenant administration, seed data, and import utilities. |
+
+## Frontend Modules
+
+Authenticated routes live below `src/routes/_authed/` and are protected by
+session and resource-permission guards.
+
+| Route | User-facing module |
+|-------|--------------------|
+| `/` | Dashboard totals, low-stock summary, and recent activity. |
+| `/products` and `/products/:id` | Product search/pagination, bulk actions, guided CSV import, details, editing, and photos. Categories are managed in this surface. |
+| `/locations` and `/locations/:id` | Location search/filtering, details, and hierarchical area management. |
+| `/inventory` | Searchable inventory with location/area, low-stock, batch, and expiry filters. |
+| `/clients` | Client search, status filters, and CRUD. |
+| `/suppliers` | Supplier-name search, active-state filter, and contact CRUD. Active state changes through edit. |
+| `/orders` | Order search/status filters, create-time line items, limited Draft/Confirmed edits, and status transitions. The unmounted `fulfillment` prototype is not a live UI workflow. |
+| `/stock-movements` | Movement history, reason/product/location filters, and manual movements. |
+| `/audit-logs` | Action/entity filters and mutation metadata. No before/after detail is displayed. |
+| `/users` | User lifecycle and role assignments. |
+| `/roles` | Role and permission management. |
+| `/settings` | Branding, appearance, language, and account sign-out. |
+| `/platform` | Platform-host-only tenant, plan, feature-override, and tenant-import administration. |
+
+Public routes cover login, signup, forgotten passwords, password reset, and
+not-found/error handling. Frontend feature folders mirror these routes under
+`src/components/`; API access and cache keys live in `src/lib/data/`.
+
+## Shared Packages
+
+| Package | Contents |
+|---------|----------|
+| `@stocketfr/types` | Effect schemas, DTOs, entity IDs, enums, pagination helpers, feature entitlements, tasks, and contracts for every public domain. Consumers import through subpaths such as `@stocket/types/products`. |
+| `@stocketfr/emails` | Localized React Email templates for verification, password reset, welcome, and low-stock messages. |
+| `@stocketfr/tsconfig` | Shared strict TypeScript base configuration. |
+| `@stocketfr/eslint-config` | Published shared lint configuration; backend and frontend currently execute Oxlint directly. |
+
+Shared-package changes use Changesets. Pull requests can publish immutable
+snapshot versions for cross-repository testing; merging the Changesets version
+PR publishes stable GitHub Packages releases. Backend and frontend then update
+their pinned package aliases.
+
+## Deployment Status
+
+- Backend and frontend run CI on pushes and pull requests, with no persistent
+  automatic post-merge deploy or standalone rollback workflow.
+- Temporary manual-only workflows were used for an audited July 2026 rollout.
+  While present, they accepted only current `main` with successful push CI,
+  published SHA-tagged images, and invoked the infrastructure deploy helper;
+  both were removed after that one-time rollout.
+- Documentation still deploys automatically to GitHub Pages from `main`.
+- Packages still publish through Changesets and GitHub Packages.
+- The landing site is an independent GitHub Pages project.
+- Infrastructure provisions and configures the hosted topology. Its deploy
+  helper best-effort restores the prior image only when helper-owned
+  Compose/readiness checks fail after replacement begins. Later workflow checks
+  do not trigger that recovery, which is not a persistent CD or
+  operator-triggered rollback workflow.
+- The desktop workflow is intended to create draft native releases, but its
+  repository names, frontend build flags, and output paths are currently stale.
+  Treat that path as unverified until it is repaired. A desktop build does not
+  imply offline database operation or conflict-resolving sync.
+
+When these lifecycle decisions change, update this page, the
+[CI/CD guide](ci-cd.md), and the [roadmap](../roadmap.md) together.

--- a/docs/development/setup.fr.md
+++ b/docs/development/setup.fr.md
@@ -1,148 +1,213 @@
-# Configuration de l'environnement
+# Configuration du développement
 
-Ce guide vous accompagne dans la configuration de votre environnement de développement local.
+Ce guide crée le checkout multi-dépôts coordonné utilisé pour développer
+Stocket.
 
 ## Prérequis
 
-- **Node.js** >= 20 (géré par Nix)
-- **pnpm** >= 10 (géré par Nix)
-- **PostgreSQL** 16 (via Docker Compose)
-- **Nix** avec flakes activés
-- **Infisical CLI** (pour la configuration des variables d'environnement)
-- **just** command runner (pour la configuration des variables d'environnement)
+- Git ; `jj` est optionnel et utilisé automatiquement pour les nouveaux clones
+  s'il est disponible
+- Node.js 22
+- pnpm 10.28.0, de préférence via Corepack
+- Docker avec le plugin Compose
+- un token GitHub classique avec `read:packages`
+- un accès Infisical à l'environnement de développement Stocket
+- Nix avec flakes, `just` et Loggle sont des outils optionnels
 
-## Configuration rapide avec Nix Flakes
+Python 3.12 et MkDocs ne sont nécessaires que pour la documentation. Rust et
+les bibliothèques système Tauri ne sont nécessaires que pour le shell desktop.
 
-Chaque repo possède son propre Nix flake pour un environnement de développement reproductible.
+## Authentification GitHub Packages
 
-### 1. Installer Nix
+Le backend et le frontend installent des packages partagés immuables depuis
+GitHub Packages. Même les packages publics nécessitent une authentification npm.
+Exportez le token comme `GITHUB_PACKAGES_TOKEN` via une invite masquée ou un
+gestionnaire de secrets ; ne saisissez jamais sa valeur dans l'historique.
 
 ```bash
-# macOS/Linux
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+# GITHUB_PACKAGES_TOKEN doit déjà être exporté de manière sûre.
+pnpm config set --global @stocketfr:registry https://npm.pkg.github.com
+pnpm config set --global //npm.pkg.github.com/:_authToken "${GITHUB_PACKAGES_TOKEN}"
+unset GITHUB_PACKAGES_TOKEN
 ```
 
-### 2. Cloner et configurer
+Ne commitez pas le token. GitHub Actions utilise son `GITHUB_TOKEN` temporaire.
+
+## Cloner et initialiser
+
+Choisissez un dossier parent vide, clonez `meta`, puis laissez son manifeste
+assembler le checkout :
 
 ```bash
 git clone https://github.com/stocketfr/meta.git
-cd meta && ./scripts/bootstrap && cd ..
+./meta/scripts/bootstrap
 ```
 
-### 3. Démarrer les services
+Le bootstrap :
+
+1. lit `meta/repos.yaml` et clone/récupère `packages`, `backend`, `frontend`,
+   `remote-desktop`, `documentation` et `landing` à côté de `meta` ;
+2. lie la configuration racine depuis `meta/root/` ;
+3. installe le workspace pnpm racine et les dépendances locales nécessaires ;
+4. construit les projets exposant un script `build` de bootstrap.
+
+Il ne clone pas `infrastructure`, qui doit être cloné séparément. Une entrée
+`mobile-app` est réservée dans le template racine, mais aucun dépôt mobile actif
+n'existe dans le manifeste.
+
+Relancez le bootstrap après une modification de `repos.yaml`, de la
+configuration racine ou de la topologie des dépendances. Utilisez
+`./meta/scripts/clone-or-update` pour uniquement récupérer les dépôts.
+
+## Configuration de l'environnement
+
+`backend/env.template` et `frontend/env.template` documentent les clés
+consommées. Ce sont des références, pas des sources de secrets. Les scripts
+normaux invoquent Infisical :
 
 ```bash
-# Démarrer PostgreSQL et autres services via Docker Compose
-cd meta && docker compose up -d
+infisical login
 ```
 
-### 4. Entrer dans le shell de développement
+Le projet Infisical doit fournir les clés décrites dans
+[Variables d'environnement](../reference/environment-variables.md).
+
+!!! warning "Pas de workflow `.env` versionné"
+    Les `justfile` actuels n'ont pas de recette `just env` et le template
+    s'appelle `env.template`, pas `.env.template`. N'utilisez pas les anciennes
+    commandes qui exportent durablement Infisical dans `.env`.
+
+## Démarrer la stack standard
+
+Depuis le dossier parent :
 
 ```bash
-# Shell de développement backend
-cd backend && nix develop
-
-# Shell de développement frontend
-cd frontend && nix develop
+./meta/scripts/dev
 ```
 
-Cela fournit :
+Si Loggle est installé et qu'aucun processus optionnel n'est demandé, le script
+utilise `meta/.loggle.toml`. Sinon il lance directement les processus.
+PostgreSQL et MinIO sont démarrés via Docker dès que possible, puis l'API et le
+frontend.
 
-- PostgreSQL sur le port 5432
-- API Effect.ts sur le port 8080 (Bun)
-- Frontend TanStack Start sur le port 3000
+!!! warning "Graphe Loggle actuel"
+    `meta/.loggle.toml` appelle actuellement `@stocket/web dev:workspace`, mais
+    le frontend n'a pas ce script. Si Loggle est installé, utilisez
+    [Lancer les projets séparément](#lancer-les-projets-separement) jusqu'à
+    correction de meta. Le runner direct emploie bien le script frontend `dev`.
 
-## Configuration manuelle
+| Service | Endpoint local | Rôle |
+|---------|----------------|------|
+| PostgreSQL | `localhost:5432` | données tenant, auth, inventaire, audit et tâches |
+| API S3 MinIO | `http://localhost:9000` | photos et entrées des tâches |
+| Console MinIO | `http://localhost:9001` | inspection locale (`minio` / `minio123`) |
+| API Effect | `http://localhost:8080` | API, auth, santé et Swagger partiel |
+| TanStack Start | `http://localhost:3000` | application sur l'hôte plateforme |
 
-Si vous préférez ne pas utiliser Nix :
-
-### 1. Installer les dépendances
+Variantes utiles :
 
 ```bash
-# Installer pnpm
-npm install -g pnpm
-
-# Installer les dépendances du projet
-pnpm install
+./meta/scripts/dev --include-docs
+./meta/scripts/dev --include-desktop
 ```
 
-### 2. Configurer PostgreSQL
+`--with-docker` est une option obsolète sans effet actuel. Le runner direct
+tente déjà de démarrer PostgreSQL et MinIO.
+
+### Lancer le worker
+
+Le graphe meta standard ne lance pas encore le worker de tâches. Pour tester
+les imports asynchrones, ouvrez un autre terminal :
 
 ```bash
-# Créer la base de données
-createdb stocket_inventory
-```
-
-### 3. Configurer les variables d'environnement
-
-Créez les fichiers `.env` dans chaque repo :
-
-**Backend (`backend/.env`) :**
-
-```bash
-DATABASE_URL=postgresql://localhost:5432/stocket_inventory
-BETTER_AUTH_SECRET=votre-secret-ici
-PORT=8080
-```
-
-**Frontend (`frontend/.env.local`) :**
-
-```bash
-VITE_API_BASE_URL=http://localhost:8080/api/v1
-```
-
-!!! note "Secret Better Auth"
-    `BETTER_AUTH_SECRET` ne doit se trouver que dans le `.env` du backend -- jamais dans le frontend.
-
-### 4. Démarrer les services
-
-```bash
-# Terminal 1 - Backend
 cd backend
-pnpm start
+pnpm start:worker
+```
 
-# Terminal 2 - Frontend
+L'API et le worker partagent la configuration base et stockage objet.
+
+## Lancer les projets séparément
+
+```bash
+docker compose -f meta/docker-compose.yml up -d --wait postgres minio
+docker compose -f meta/docker-compose.yml up minio-init
+```
+
+Puis, dans deux terminaux :
+
+```bash
+cd backend
+pnpm start:workspace
+```
+
+```bash
 cd frontend
 pnpm dev
 ```
 
-## Vérification
+`start:workspace` ajoute des valeurs locales sûres pour la base, les hôtes,
+CORS, MinIO et le seed autour des secrets Infisical. Pour un développement
+backend isolé, `pnpm start` utilise directement l'environnement Infisical.
 
-Une fois lancé, vérifiez :
+## Créer un tenant et des données de démo
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| API | http://localhost:8080/api/docs | Documentation Swagger |
-| Web | http://localhost:3000 | Application frontend |
-| DB | localhost:5432 | Base PostgreSQL |
-
-## Problèmes courants
-
-### Port déjà utilisé
+Après application des migrations :
 
 ```bash
-# Trouver le processus utilisant le port
-lsof -i :8080
-
-# Tuer le processus
-kill -9 <PID>
+cd backend
+pnpm tenant:seed:workspace
 ```
 
-### Erreurs de connexion PostgreSQL
+Sans cible, la recette ne crée le tenant par défaut que s'il n'en existe aucun,
+choisit l'unique tenant ou demande un choix s'il y en a plusieurs. Elle
+crée/renouvelle `tenant-admin@stocket.fr` avec `admin1234`, crée les rôles et
+remplace les données de démo : catégories, fournisseurs, produits, emplacements,
+clients, inventaire, commandes, mouvements et audit. Pour cibler explicitement
+un tenant existant, définissez `TENANT_ADMIN_TENANT_SLUG` ou
+`TENANT_ADMIN_TENANT_ID`.
 
-Vérifiez que PostgreSQL est en cours d'exécution :
+!!! danger "Destructif dans le tenant sélectionné"
+    Le seed efface puis recrée les données de démo du tenant sélectionné. Ne le
+    pointez pas vers des données à conserver.
+
+Sur une base neuve, ouvrez `http://stocket.localhost:3000` pour le tenant par
+défaut créé. Sinon, utilisez le slug/hôte du tenant choisi. La console plateforme
+reste sur `http://localhost:3000` et exige un superadmin.
+
+## Shells Nix optionnels
+
+Le backend, le frontend, les packages, la documentation et l'infrastructure
+fournissent leurs propres flakes :
 
 ```bash
-pg_isready -h localhost -p 5432
+cd backend
+nix develop
 ```
 
-### Erreurs de dépendances
+Il n'existe pas de flake racine canonique pour le checkout assemblé.
 
-Nettoyez et réinstallez :
+## Vérifications courantes
 
 ```bash
-rm -rf node_modules
-rm -rf backend/node_modules
-rm -rf frontend/node_modules
-pnpm install
+# Backend
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+pnpm test:integration
+
+# Frontend
+cd frontend
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+
+# Packages partagés
+cd packages
+pnpm build
 ```
+
+Consultez les [commandes CLI](../reference/cli-commands.md) et le
+[dépannage](../reference/troubleshooting.md) pour les erreurs de registry,
+d'hôte, de base ou de stockage.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,213 +1,216 @@
 # Development Setup
 
-This guide covers setting up the development environment for contributing to Stocket Inventory.
+This guide creates the coordinated multi-repository checkout used for Stocket
+development.
 
 ## Prerequisites
 
-- Node.js >= 20.0.0
-- pnpm >= 10.0.0
-- Bun (runtime for the backend)
-- PostgreSQL 16
-- Git
-- Nix with flakes enabled (optional — per-package dev shells)
-- Infisical CLI + `just` (optional — used by `backend/justfile` for env setup)
+- Git; `jj` is optional and used automatically for new clones when available
+- Node.js 22
+- pnpm 10.28.0 (Corepack is recommended)
+- Docker with the Compose plugin
+- a classic GitHub token with `read:packages`
+- Infisical CLI access to the Stocket development environment
+- Nix with flakes, `just`, and Loggle are optional conveniences
 
-## Clone & Install (Monorepo Root)
+Python 3.12 and MkDocs are needed only when working on documentation. Rust and
+Tauri system libraries are needed only for the desktop shell.
 
-Stocket is a pnpm monorepo with a single lockfile at the workspace root. One `pnpm install` hydrates every package.
+## Authenticate to GitHub Packages
 
-```bash
-git clone https://github.com/stocketfr/stocket.git
-cd stocket
-pnpm install
-```
-
-!!! warning "Package manager"
-    Only `pnpm` from the repo root. Running `npm install` or `bun install` at root will corrupt the workspace.
-
-### Optional: Per-Package Nix Shells
-
-There is **no root `flake.nix`**. If you want an isolated dev environment for a package, each of `backend/` and `frontend/` has its own flake:
+Backend and frontend install immutable shared packages from GitHub Packages.
+Even public packages require npm registry authentication. Export the token as
+`GITHUB_PACKAGES_TOKEN` through a hidden prompt or secret manager; never type
+the literal value into command history.
 
 ```bash
-cd backend && nix develop
-cd frontend && nix develop
+# GITHUB_PACKAGES_TOKEN must already be exported securely.
+pnpm config set --global @stocketfr:registry https://npm.pkg.github.com
+pnpm config set --global //npm.pkg.github.com/:_authToken "${GITHUB_PACKAGES_TOKEN}"
+unset GITHUB_PACKAGES_TOKEN
 ```
 
-### Start Services
+Do not commit the token. GitHub Actions uses its short-lived `GITHUB_TOKEN`.
 
-Docker Compose lives inside the monorepo at `meta/docker-compose.yml`:
+## Clone and Bootstrap
+
+Choose an empty parent directory, clone `meta`, then let its manifest assemble
+the checkout:
 
 ```bash
-cd meta && docker compose up -d
+git clone https://github.com/stocketfr/meta.git
+./meta/scripts/bootstrap
 ```
 
-Then start the application servers from the repo root using workspace filters:
+Bootstrap performs the following operations:
+
+1. reads `meta/repos.yaml` and clones/fetches `packages`, `backend`, `frontend`,
+   `remote-desktop`, `documentation`, and `landing` as siblings of `meta`;
+2. links workspace-root configuration from `meta/root/`;
+3. installs the root pnpm workspace and any repository-local dependency sets;
+4. builds projects that expose a bootstrap-time `build` script.
+
+It does not clone `infrastructure`; clone that repository separately when
+working on hosted operations. A `mobile-app` workspace slot exists in the root
+template, but there is no active mobile repository in the manifest.
+
+Rerun bootstrap after `repos.yaml`, root workspace configuration, or shared
+dependency topology changes. Use `./meta/scripts/clone-or-update` when you only
+need to fetch the managed repositories.
+
+## Environment Configuration
+
+`backend/env.template` and `frontend/env.template` document consumed keys. They
+are reference files, not local secret sources. Normal project scripts invoke
+Infisical:
 
 ```bash
-# Terminal 1 — Backend (runs with Bun)
-pnpm --filter @stocket/api start
-
-# Terminal 2 — Frontend
-pnpm --filter @stocket/web dev
+infisical login
 ```
 
-Services started:
+Your account/project setup must provide the keys described in
+[Environment Variables](../reference/environment-variables.md). In particular,
+the API requires database, tenancy, Better Auth, and object-storage values; the
+web process requires its internal API and host configuration.
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| PostgreSQL | localhost:5432 | Database |
-| Effect.ts API | http://localhost:8080 | Backend (Bun) |
-| TanStack Start | http://localhost:3000 | Frontend |
-| MkDocs | http://localhost:8000 | Documentation |
+!!! warning "No checked-in `.env` workflow"
+    The current `justfile`s do not contain a `just env` recipe and the template
+    is named `env.template`, not `.env.template`. Do not copy older commands
+    that export Infisical into a tracked or long-lived `.env` file.
 
-## Common Commands
+## Start the Standard Stack
 
-### Workspace Root
+From the workspace parent:
 
 ```bash
-pnpm install                                   # Install every package's deps
-pnpm --filter @stocket/api start            # Run backend
-pnpm --filter @stocket/web dev              # Run frontend
-pnpm --filter @stocket/types barrels        # Regenerate type barrels
-pnpm --filter @stocket/types build          # Build shared types
+./meta/scripts/dev
 ```
 
-!!! note "Legacy meta scripts"
-    Commands like `pnpm sync` / `pnpm bootstrap` in `meta/` exist from the pre-monorepo era and are not needed for day-to-day work.
+When Loggle is installed and no optional processes are requested, the script
+uses `meta/.loggle.toml`. Otherwise it starts processes directly. Docker-backed
+PostgreSQL and MinIO are started whenever Docker is available, followed by the
+API and frontend.
 
-### Backend
+!!! warning "Current Loggle graph"
+    `meta/.loggle.toml` currently invokes `@stocket/web dev:workspace`, but the
+    frontend has no such package script. If Loggle is installed, use
+    [Run Projects Individually](#run-projects-individually) until the meta
+    configuration is corrected. The direct runner uses the valid frontend
+    `dev` script.
+
+| Service | Local endpoint | Purpose |
+|---------|----------------|---------|
+| PostgreSQL | `localhost:5432` | tenant, auth, inventory, audit, and task data |
+| MinIO S3 API | `http://localhost:9000` | product photos and background-task inputs |
+| MinIO console | `http://localhost:9001` | local object inspection (`minio` / `minio123`) |
+| Effect API | `http://localhost:8080` | API, auth, health, and partial Swagger UI |
+| TanStack Start | `http://localhost:3000` | platform-host web application |
+
+Useful variants:
+
+```bash
+./meta/scripts/dev --include-docs
+./meta/scripts/dev --include-desktop
+```
+
+`--with-docker` is a stale option and has no current effect. The direct runner
+already attempts to start PostgreSQL and MinIO.
+
+### Run the Task Worker
+
+The standard meta process graph does not currently launch the background task
+worker. Run it in another terminal when testing asynchronous product imports:
 
 ```bash
 cd backend
-pnpm start             # Development server (Bun)
-pnpm build             # Build (bun build)
-pnpm test              # Run tests (Vitest)
-pnpm test:watch        # Tests in watch mode
-pnpm test:cov          # Tests with coverage
-pnpm test:integration  # Integration tests
-pnpm lint              # Lint (oxlint)
-pnpm type-check        # TypeScript check
-pnpm seed              # Seed sample data
+pnpm start:worker
 ```
 
-### Frontend
+The API and worker use the same database and object-storage configuration.
+
+## Run Projects Individually
+
+Start infrastructure without the meta process runner:
+
+```bash
+docker compose -f meta/docker-compose.yml up -d --wait postgres minio
+docker compose -f meta/docker-compose.yml up minio-init
+```
+
+Then start application processes in separate terminals:
+
+```bash
+cd backend
+pnpm start:workspace
+```
 
 ```bash
 cd frontend
-pnpm dev               # Development server (Vite)
-pnpm build             # Production build
-pnpm lint              # oxlint
-pnpm test:unit         # Vitest unit tests
-pnpm test:e2e          # Playwright E2E
+pnpm dev
 ```
 
-### Shared Types
+`start:workspace` supplies safe local database, host, CORS, MinIO, and seed
+defaults around Infisical-provided secrets. For normal backend-only development,
+`pnpm start` uses the Infisical environment without those workspace overrides.
 
-Barrels must run **before** build — the generator only picks up `.type.ts` and `.enum.ts` files; other suffixes are silently ignored.
+## Seed a Tenant and Demo Data
 
-```bash
-pnpm --filter @stocket/types barrels   # Generate barrel exports
-pnpm --filter @stocket/types build     # Build shared types (ESM + CJS)
-```
-
-!!! warning "Bump the version when you change a shared package"
-    If you edit `packages/types`, `packages/eslint-config`, or `packages/tsconfig`, bump that package's `package.json` version in the same PR. The `tag.yml` workflow publishes to npm on merge.
-
-## Database Setup
-
-### With Docker Compose
-
-The database is automatically created and configured via Docker Compose in `meta/`.
-
-### Manual Setup
-
-```bash
-createdb stocket_inventory
-```
-
-### Seed Data
-
-Populate with sample data:
+With PostgreSQL available and migrations applied, run:
 
 ```bash
 cd backend
-pnpm seed
+pnpm tenant:seed:workspace
 ```
 
-## Environment Variables
+With no target, the recipe creates the default tenant only when none exist,
+selects the only tenant, or prompts when several exist. It creates/rotates
+`tenant-admin@stocket.fr` with password `admin1234`, seeds default roles, and
+replaces that tenant's demo categories, suppliers, products, locations,
+clients, inventory, orders, stock movements, and audit logs. For a deliberate
+existing target, set `TENANT_ADMIN_TENANT_SLUG` or `TENANT_ADMIN_TENANT_ID`.
 
-### Backend (.env)
+!!! danger "Destructive within the selected tenant"
+    The tenant seed clears and recreates demo data for its selected tenant. Do
+    not point it at data you need to preserve.
+
+On a new database, open `http://stocket.localhost:3000` for the created default
+tenant. Otherwise use the selected tenant's slug/hostname. The platform console
+remains at `http://localhost:3000` and requires a platform superadmin.
+
+## Optional Nix Shells
+
+Backend, frontend, packages, documentation, and infrastructure provide their
+own flakes. Enter the shell from the repository you are changing:
 
 ```bash
-DATABASE_URL=postgresql://user@localhost:5432/stocket_inventory
-BETTER_AUTH_SECRET=your-secret-here
-PORT=8080
-NODE_ENV=development
+cd backend
+nix develop
 ```
 
-### Frontend (.env.local)
+There is no canonical root flake for the assembled checkout.
+
+## Common Repository Checks
 
 ```bash
-VITE_API_BASE_URL=http://localhost:8080/api/v1
+# Backend
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+pnpm test:integration
+
+# Frontend
+cd frontend
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+
+# Shared packages
+cd packages
+pnpm build
 ```
 
-!!! note "Better Auth secret"
-    `BETTER_AUTH_SECRET` lives only in the backend `.env` -- never in the frontend.
-
-### Environment Setup with Infisical
-
-Use the `just` command runner and Infisical CLI for managing env variables:
-
-```bash
-cd backend && just env
-cd ../frontend && just env
-```
-
-## IDE Setup
-
-### VS Code
-
-Recommended extensions:
-
-- oxc (oxlint) — `oxc.oxc-vscode`
-- Prettier
-- Tailwind CSS IntelliSense
-- TypeScript Importer
-- Nix IDE (optional)
-
-### Settings
-
-The project includes workspace settings in `.vscode/settings.json`.
-
-## Troubleshooting
-
-### Port Already in Use
-
-```bash
-# Find process using port
-lsof -i :8080
-lsof -i :3000
-
-# Kill process
-kill -9 <PID>
-```
-
-### Database Connection Issues
-
-Check PostgreSQL is running:
-
-```bash
-pg_isready -h localhost -p 5432
-```
-
-### Node Modules Issues
-
-Clean install:
-
-```bash
-rm -rf node_modules
-rm -rf backend/node_modules
-rm -rf frontend/node_modules
-pnpm install
-```
+Use [CLI Commands](../reference/cli-commands.md) for the complete script map and
+[Troubleshooting](../reference/troubleshooting.md) for registry, host, database,
+and object-storage failures.

--- a/docs/development/testing.fr.md
+++ b/docs/development/testing.fr.md
@@ -1,169 +1,84 @@
 # Tests
 
-Le backend Stocket Inventory utilise Vitest pour les tests et Playwright pour les tests E2E frontend.
+Les tests appartiennent au dépôt propriétaire du comportement. Préférez le test déterministe le plus étroit, puis une intégration ou un navigateur lorsque la frontière fait partie du besoin.
 
-## Vue d'ensemble
+## Suites backend
 
-| Module | Framework | Statut |
-|--------|-----------|--------|
-| Backend | Vitest | Actif |
-| Frontend | Playwright | Actif |
+Le backend utilise Vitest sur Node :
 
-## Exécuter les tests
+| Motif | Rôle | `pnpm test` par défaut |
+| --- | --- | --- |
+| `*.spec.ts` | Tests purs/unitaires/services/routeurs | Oui |
+| `*.effect.spec.ts` | Services/couches Effect | Oui |
+| `*.property.spec.ts` | Propriétés Fast-check | Oui |
+| `*.integration.spec.ts` | Intégration PostgreSQL réelle | Non ; `pnpm test:integration` |
 
-### Tests Backend
+Les références internes sont `backend/TESTING.md` et `backend/src/effect/testing/README.md`.
+
+Utilisez `@effect/vitest`/`it.effect` et remplacez uniquement la frontière testée dans les layers. Testez les schémas publiés avec des références réalistes : un produit de test exige une catégorie. Vérifiez les erreurs métier taguées plutôt qu'un texte d'exception incident.
+
+### Intégration PostgreSQL
 
 ```bash
-# Exécuter tous les tests
-pnpm --filter @stocket/api test
-
-# Exécuter les tests en mode watch
-pnpm --filter @stocket/api test:watch
-
-# Exécuter les tests avec couverture
-pnpm --filter @stocket/api test:cov
-
-# Exécuter les tests d'intégration
-pnpm --filter @stocket/api test:integration
-
-# Exécuter un fichier de test spécifique
-pnpm --filter @stocket/api test -- products
+cd backend
+TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory_test \
+  pnpm test:integration
 ```
 
-### Tests Frontend
+La configuration migre une fois, exécute en série et tronque entre tests. Ne ciblez jamais une base de développement/production. Couvrez isolation tenant, contraintes, transactions, concurrence, contrats de mutation et requêtes dupliquées/idempotentes lorsque la persistance compte.
+
+L'audit est lancé en daemon au mieux. Un test qui attend une ligne utilise le polling `waitForAuditLog` existant ; un délai fixe ou une assertion immédiate est instable et ne doit pas laisser croire à une garantie transactionnelle.
+
+### Commandes backend
 
 ```bash
-# Exécuter les tests E2E Playwright
+pnpm test
+pnpm test:watch
+pnpm test:cov
+pnpm test:integration
+pnpm test:mutation:pure
+pnpm test:duplicates
+```
+
+Le smoke test MinIO optionnel ne s'exécute que si MinIO est disponible et si
+`RUN_MINIO_STORAGE_SMOKE=true` est défini explicitement.
+
+## Tests unitaires frontend
+
+Vitest exécute `src/**/*.test.ts` et `src/**/*.test.tsx` dans jsdom.
+
+```bash
+cd frontend
+pnpm test:unit
+pnpm test:unit:watch
+```
+
+Testez via noms accessibles et état visible. Entourez les composants des mêmes providers query/router/i18n que les tests voisins. Pour les hooks de données, vérifiez clés générées, `enabled`, invalidation et variables de mutation `{ data }` sans traverser les détails internes.
+
+Incluez permissions et fonctionnalités des routes protégées. Les helpers sensibles au SSR couvrent hôte, cookie et protocole forwarded sans supposer `window`.
+
+## Playwright full-stack
+
+```bash
 cd frontend
 pnpm test:e2e
+pnpm test:e2e:ui
+pnpm test:e2e:headed
 ```
 
-## Structure des tests
+La CI construit les deux applications et exécute Chromium avec une révision backend épinglée, PostgreSQL 16 et LocalStack S3. Le setup global provisionne tenant/compte via le seed protégé. L'authentification est un projet Playwright séparé ; la plupart des tests réutilisent son état, les specs d'auth restent indépendantes.
 
-### Tests unitaires Backend
+Ajoutez un E2E pour un comportement critique inter-frontières : récupération de compte, résolution hôte/tenant, permissions/fonctionnalités, tâche d'import, stockage ou interaction navigateur/serveur. Les données de seed doivent être explicites et répétables.
 
-Situés à côté des fichiers sources en `*.spec.ts` ou `*.test.ts` :
+Pour une évolution conjointe frontend/backend, mettez `BACKEND_REF` à jour après validation de la paire. Un test vert contre un backend ancien compatible ne prouve pas la paire non publiée.
 
-```
-backend/src/effect/modules/products/
-├── service.ts
-├── service.test.ts          # Tests unitaires
-├── repository.ts
-└── ...
-```
+## Paquets, desktop, docs et infrastructure
 
-## Écrire des tests unitaires
+- `packages` : `pnpm build`, tests tels que `pnpm --filter @stocketfr/emails test`, puis contrôle des barrels générés.
+- `remote-desktop` : `pnpm test` et `pnpm lint` ; la publication reste expérimentale.
+- `documentation` : validez liens/navigation et laissez la PR exécuter `mkdocs build --strict`.
+- `infrastructure` : format/validation Terraform, tests destroy-guard, syntaxe Ansible et rendu compose dans le workflow protégé.
 
-### Pattern de test de service
+## Avant une pull request
 
-Les services Effect sont testés en fournissant des layers mock pour les dépendances :
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { Effect, Layer } from "effect";
-import { ProductsService } from "./service";
-import { ProductsRepository } from "./repository";
-
-describe("ProductsService", () => {
-  const mockProduct = {
-    id: "660e8400-e29b-41d4-a716-446655440000",
-    sku: "PROD-001",
-    name: "Produit Test",
-    is_active: true,
-  };
-
-  // Créer un layer mock du repository
-  const MockProductsRepository = Layer.succeed(ProductsRepository, {
-    findById: (id: string) => Effect.succeed(mockProduct),
-    findBySku: (sku: string) => Effect.succeed(null),
-    create: (data: any) => Effect.succeed({ ...mockProduct, ...data }),
-  });
-
-  const TestLayer = ProductsService.Default.pipe(
-    Layer.provide(MockProductsRepository),
-  );
-
-  it("devrait retourner un produit par id", async () => {
-    const result = await Effect.gen(function* () {
-      const service = yield* ProductsService;
-      return yield* service.findOne("some-id");
-    }).pipe(Effect.provide(TestLayer), Effect.runPromise);
-
-    expect(result.id).toBe(mockProduct.id);
-  });
-
-  it("devrait échouer avec ProductNotFound pour un id invalide", async () => {
-    const EmptyRepo = Layer.succeed(ProductsRepository, {
-      findById: () => Effect.succeed(null),
-    });
-
-    const layer = ProductsService.Default.pipe(Layer.provide(EmptyRepo));
-
-    const result = await Effect.gen(function* () {
-      const service = yield* ProductsService;
-      return yield* service.findOne("invalid-id");
-    }).pipe(Effect.provide(layer), Effect.either, Effect.runPromise);
-
-    expect(result._tag).toBe("Left");
-  });
-});
-```
-
-### Tester les cas d'erreur
-
-Utiliser `Effect.either` pour capturer les échecs attendus :
-
-```typescript
-it("devrait échouer quand le SKU existe déjà", async () => {
-  const RepoWithExisting = Layer.succeed(ProductsRepository, {
-    findBySku: () => Effect.succeed(mockProduct),
-  });
-
-  const layer = ProductsService.Default.pipe(Layer.provide(RepoWithExisting));
-
-  const result = await Effect.gen(function* () {
-    const service = yield* ProductsService;
-    return yield* service.create({ sku: "PROD-001", name: "Duplicate" }, "user-id");
-  }).pipe(Effect.provide(layer), Effect.either, Effect.runPromise);
-
-  expect(result._tag).toBe("Left");
-});
-```
-
-## Patterns de test
-
-### Mocker les services Effect
-
-Créer des implémentations mock avec `Layer.succeed` :
-
-```typescript
-const MockCategoriesService = Layer.succeed(CategoriesService, {
-  existsById: (id: string) => Effect.succeed(true),
-  findAll: () => Effect.succeed([]),
-});
-
-const TestLayer = ProductsService.Default.pipe(
-  Layer.provide(MockProductsRepository),
-  Layer.provide(MockCategoriesService),
-);
-```
-
-## Couverture
-
-Générer le rapport de couverture :
-
-```bash
-pnpm --filter @stocket/api test:cov
-```
-
-Les rapports sont générés dans `backend/coverage/`.
-
-## Bonnes pratiques
-
-1. **Utiliser `Layer.succeed` pour les mocks** — Fournit des implémentations mock type-safe
-2. **Utiliser `Effect.either` pour tester les erreurs** — Capture les échecs attendus sans lever d'exception
-3. **Isoler les tests** — Chaque test doit fournir ses propres layers
-4. **Préférer les tests d'intégration pour les workflows** — Tester la logique inter-modules contre une vraie base de données
-5. **Utiliser `Effect.runPromise`** — Convertit un Effect en promesse pour Vitest
-6. **Tester les types d'erreurs explicitement** — Vérifier la classe d'erreur spécifique
-7. **Garder les mocks minimaux** — Ne mocker que les méthodes utilisées par le test
+Exécutez d'abord les contrôles ciblés, puis type/lint du dépôt propriétaire. Signalez précisément tout contrôle ignoré. Une inspection visuelle ne remplace pas un test manquant.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,241 +1,84 @@
 # Testing
 
-The Stocket Inventory backend uses Vitest for testing and Playwright for frontend E2E tests.
+Tests belong to the repository that owns the behavior. Prefer the narrowest deterministic test, then add an integration or browser test when the boundary itself is part of the requirement.
 
-## Overview
+## Backend suites
 
-| Module | Framework | Status |
-|--------|-----------|--------|
-| Backend | Vitest | Active |
-| Frontend | Playwright | Active |
+The backend uses Vitest on Node and recognizes these conventions:
 
-## Running Tests
+| Pattern | Purpose | Default `pnpm test` |
+| --- | --- | --- |
+| `*.spec.ts` | Pure/unit/service/router tests | Yes |
+| `*.effect.spec.ts` | Effect service/layer tests | Yes |
+| `*.property.spec.ts` | Fast-check/property tests | Yes |
+| `*.integration.spec.ts` | Real PostgreSQL integration | No; `pnpm test:integration` |
 
-### Backend Tests
+Canonical internal detail lives in `backend/TESTING.md` and `backend/src/effect/testing/README.md`.
+
+Use `@effect/vitest`/`it.effect` for effects and construct layers that replace only the boundary under test. Test published request schemas and require realistic references—for example, a Product fixture must have a category. Assert tagged domain errors rather than matching incidental exception text.
+
+### PostgreSQL integration
 
 ```bash
-# Run all tests
-pnpm --filter @stocket/api test
-
-# Run tests in watch mode
-pnpm --filter @stocket/api test:watch
-
-# Run tests with coverage
-pnpm --filter @stocket/api test:cov
-
-# Run integration tests
-pnpm --filter @stocket/api test:integration
-
-# Run a specific test file
-pnpm --filter @stocket/api test -- products
+cd backend
+TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory_test \
+  pnpm test:integration
 ```
 
-### Frontend Tests
+The integration setup migrates once, runs serially, and truncates between tests. Never point it at a development or production database. Cover tenant isolation, constraints, transactions, concurrency, mutation contracts, and duplicate/idempotent requests where persistence behavior matters.
+
+Audit logging is daemon-forked and best-effort. Integration tests that need an audit row must poll with the existing `waitForAuditLog` pattern; a fixed sleep or immediate assertion is flaky and still must not imply transactional completeness.
+
+### Backend commands
 
 ```bash
-# Run Playwright E2E tests
+pnpm test
+pnpm test:watch
+pnpm test:cov
+pnpm test:integration
+pnpm test:mutation:pure
+pnpm test:duplicates
+```
+
+The optional MinIO storage smoke suite runs only when MinIO is available and
+`RUN_MINIO_STORAGE_SMOKE=true` is set explicitly.
+
+## Frontend unit tests
+
+Vitest runs `src/**/*.test.ts` and `src/**/*.test.tsx` in jsdom.
+
+```bash
+cd frontend
+pnpm test:unit
+pnpm test:unit:watch
+```
+
+Test behavior through accessible names and user-visible state. Wrap components with the same query/router/i18n providers used by nearby tests. For data hooks, assert generated query keys, conditional `enabled` behavior, invalidation, and `{ data }` mutation variables without reaching through implementation internals.
+
+Include permission and feature-gate cases for protected routes. SSR-sensitive helpers need cases for host, cookie, and forwarded-protocol handling without assuming `window` exists.
+
+## Full-stack Playwright
+
+```bash
 cd frontend
 pnpm test:e2e
+pnpm test:e2e:ui
+pnpm test:e2e:headed
 ```
 
-## Test Structure
+The CI gate builds both applications and runs Chromium against a pinned backend revision, PostgreSQL 16, and LocalStack S3. Global setup provisions the E2E tenant/account through the protected seed path. Authentication setup is a separate Playwright project; most tests reuse its stored state, while authentication specs run independently.
 
-### Backend Unit Tests
+Add an E2E test for critical cross-boundary behavior: account recovery, host/tenant resolution, permissions/features, product import tasks, file storage, or a workflow whose failure only appears in the browser/server interaction. Keep seed data explicit and tests safe to repeat.
 
-Located alongside source files as `*.spec.ts` or `*.test.ts`:
+When frontend and backend contracts change together, update the pinned `BACKEND_REF` only after the pair passes. A green test against a stale compatible backend is not evidence that the unpublished pair works.
 
-```
-backend/src/effect/modules/products/
-├── service.ts
-├── service.test.ts          # Unit tests
-├── repository.ts
-└── ...
-```
+## Shared packages, desktop, docs, and infrastructure
 
-### Backend Integration Tests
+- `packages`: run `pnpm build`; run package tests such as `pnpm --filter @stocketfr/emails test`; verify generated type barrels before release.
+- `remote-desktop`: run `pnpm test` and `pnpm lint`; the release pipeline remains experimental.
+- `documentation`: validate relative links/navigation and let the PR gate run `mkdocs build --strict`.
+- `infrastructure`: run Terraform formatting/validation, destroy-guard tests, Ansible syntax, and rendered-compose checks in its protected workflow.
 
-Located with a separate Vitest config:
+## Before opening a pull request
 
-```bash
-pnpm --filter @stocket/api test:integration
-```
-
-## Writing Unit Tests
-
-### Service Test Pattern
-
-Effect services are tested by providing mock layers for dependencies:
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { Effect, Layer } from "effect";
-import { ProductsService } from "./service";
-import { ProductsRepository } from "./repository";
-
-describe("ProductsService", () => {
-  // Mock data
-  const mockProduct = {
-    id: "660e8400-e29b-41d4-a716-446655440000",
-    sku: "PROD-001",
-    name: "Test Product",
-    category_id: null,
-    is_active: true,
-  };
-
-  // Create a mock repository layer
-  const MockProductsRepository = Layer.succeed(ProductsRepository, {
-    findById: (id: string) => Effect.succeed(mockProduct),
-    findBySku: (sku: string) => Effect.succeed(null),
-    create: (data: any) => Effect.succeed({ ...mockProduct, ...data }),
-    // ... other methods
-  });
-
-  // Build test layer with all dependencies
-  const TestLayer = ProductsService.Default.pipe(
-    Layer.provide(MockProductsRepository),
-    // ... other mock layers
-  );
-
-  it("should return a product by id", async () => {
-    const result = await Effect.gen(function* () {
-      const service = yield* ProductsService;
-      return yield* service.findOne("some-id");
-    }).pipe(Effect.provide(TestLayer), Effect.runPromise);
-
-    expect(result.id).toBe(mockProduct.id);
-    expect(result.sku).toBe("PROD-001");
-  });
-
-  it("should fail with ProductNotFound for invalid id", async () => {
-    const EmptyRepo = Layer.succeed(ProductsRepository, {
-      findById: () => Effect.succeed(null),
-      // ... other methods
-    });
-
-    const layer = ProductsService.Default.pipe(Layer.provide(EmptyRepo));
-
-    const result = await Effect.gen(function* () {
-      const service = yield* ProductsService;
-      return yield* service.findOne("invalid-id");
-    }).pipe(Effect.provide(layer), Effect.either, Effect.runPromise);
-
-    expect(result._tag).toBe("Left");
-  });
-});
-```
-
-### Testing Error Cases
-
-Use `Effect.either` to catch expected failures:
-
-```typescript
-it("should fail when SKU already exists", async () => {
-  const RepoWithExisting = Layer.succeed(ProductsRepository, {
-    findBySku: () => Effect.succeed(mockProduct),
-    // ... other methods
-  });
-
-  const layer = ProductsService.Default.pipe(Layer.provide(RepoWithExisting));
-
-  const result = await Effect.gen(function* () {
-    const service = yield* ProductsService;
-    return yield* service.create({ sku: "PROD-001", name: "Duplicate" }, "user-id");
-  }).pipe(Effect.provide(layer), Effect.either, Effect.runPromise);
-
-  expect(result._tag).toBe("Left");
-});
-```
-
-### Testing with Real Database (Integration)
-
-Integration tests use a real database connection:
-
-```typescript
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Effect, Layer } from "effect";
-
-describe("ProductsService (integration)", () => {
-  // Use the real Drizzle layer with a test database
-  const TestLayer = ProductsService.Default.pipe(
-    Layer.provide(drizzleTestLayer),
-  );
-
-  it("should create and retrieve a product", async () => {
-    const result = await Effect.gen(function* () {
-      const service = yield* ProductsService;
-      const created = yield* service.create(
-        { sku: "INT-001", name: "Integration Test Product" },
-        "test-user-id"
-      );
-      return yield* service.findOne(created.id);
-    }).pipe(Effect.provide(TestLayer), Effect.runPromise);
-
-    expect(result.sku).toBe("INT-001");
-  });
-});
-```
-
-## Testing Patterns
-
-### Mocking Effect Services
-
-Create mock implementations using `Layer.succeed`:
-
-```typescript
-// Provide a simple mock
-const MockCategoriesService = Layer.succeed(CategoriesService, {
-  existsById: (id: string) => Effect.succeed(true),
-  findAll: () => Effect.succeed([]),
-});
-
-// Combine mock layers
-const TestLayer = ProductsService.Default.pipe(
-  Layer.provide(MockProductsRepository),
-  Layer.provide(MockCategoriesService),
-);
-```
-
-### Testing Fire-and-Forget Operations
-
-Audit logging uses `Effect.forkDaemon` (fire-and-forget). To test that audit logs are written:
-
-```typescript
-it("should write audit log on create", async () => {
-  const auditCalls: any[] = [];
-
-  const MockAudit = Layer.succeed(AuditLogWriter, {
-    log: (entry: any) => {
-      auditCalls.push(entry);
-      return Effect.void;
-    },
-  });
-
-  // ... run the effect with MockAudit in the layer
-
-  // Allow daemon fibers to complete
-  await new Promise((resolve) => setTimeout(resolve, 10));
-
-  expect(auditCalls).toHaveLength(1);
-  expect(auditCalls[0].action).toBe("CREATE");
-});
-```
-
-## Coverage
-
-Generate coverage report:
-
-```bash
-pnpm --filter @stocket/api test:cov
-```
-
-Coverage reports are generated in `backend/coverage/`.
-
-## Best Practices
-
-1. **Use `Layer.succeed` for mocks** — Provides type-safe mock implementations for Effect services
-2. **Use `Effect.either` for error testing** — Catches expected failures without throwing
-3. **Isolate tests** — Each test should provide its own layers and not share mutable state
-4. **Prefer integration tests for workflows** — Mock boundaries, not neighbors; test cross-module logic against a real database
-5. **Use `Effect.runPromise`** — Converts Effect to a promise for Vitest's async test runner
-6. **Test error types explicitly** — Verify the specific error class, not just that it failed
-7. **Keep mocks minimal** — Only mock the methods the test actually exercises
+Run the smallest relevant checks first, then the owning repository's type/lint suite. Report anything skipped and why. Do not replace a missing test with a statement that the code “looks correct.”

--- a/docs/getting-started/configuration.fr.md
+++ b/docs/getting-started/configuration.fr.md
@@ -1,108 +1,69 @@
 # Configuration
 
-Ce guide couvre toutes les options de configuration pour Stocket Inventory.
+La configuration Stocket est séparée par processus. Infisical est la source
+opérationnelle des secrets ; les fichiers `env.template` sont des références.
 
-## Variables d'Environnement
+## Processus backend
 
-### Backend API
+L'API et le worker partagent base, hôtes tenant, stockage, logs et observabilité.
+Le worker ne compose pas le layer auth, mais son graphe d'entrée importe
+immédiatement la configuration auth partagée. Il exige donc Better Auth/frontend
+et la configuration e-mail de staging/production. L'API exige en plus son port
+HTTP et les origines CORS. Smart Import peut appeler
+une API compatible OpenAI. Concurrence, leases, heartbeats, polling, reprise,
+retry et limitation des progrès du worker sont configurables.
 
-Situé dans `backend/.env` :
+L'API valide `NODE_ENV` et `PORT` à l'entrée. Les identifiants comme
+`DATABASE_URL`, `BETTER_AUTH_SECRET` et les clés S3 doivent être présents avant
+l'initialisation des layers.
 
-| Variable | Requis | Description |
-|----------|--------|-------------|
-| `DATABASE_URL` | Oui | Chaîne de connexion PostgreSQL |
-| `NODE_ENV` | Non | Mode d'environnement (défaut : `development`) |
-| `PORT` | Non | Port API (défaut : `8080`) |
-| `CORS_ORIGIN` | Non | Origine CORS autorisée (défaut : `http://localhost:3000`) |
-| `BETTER_AUTH_SECRET` | Oui | Chaîne aléatoire de 32+ octets pour la signature de session Better Auth |
-| `BETTER_AUTH_URL` | Oui | URL du serveur Better Auth (ex : `http://localhost:8080`) |
-| `FRONTEND_URL` | Non | URL du frontend pour les redirections (défaut : `http://localhost:3000`) |
+Voir la [référence des variables](../reference/environment-variables.md).
 
-Les variables de base de données individuelles sont également supportées : `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`.
+## Processus frontend
 
-**Exemple :**
+L'application web utilise des valeurs runtime côté serveur :
 
-```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
-NODE_ENV=development
-PORT=8080
-CORS_ORIGIN=http://localhost:3000
-BETTER_AUTH_SECRET=<chaîne aléatoire de 32+ octets>
-BETTER_AUTH_URL=http://localhost:8080
-FRONTEND_URL=http://localhost:3000
-```
+| Variable | Rôle |
+|----------|------|
+| `INTERNAL_API_ORIGIN` | origine privée utilisée par SSR et le proxy Vite `/api` |
+| `WEB_URL` | origine web canonique utilisée par Better Auth côté serveur |
+| `TENANT_BASE_DOMAIN` | suffixe des hôtes tenant |
+| `PLATFORM_HOST` | hôte d'administration plateforme |
+| `TRUSTED_PROXY` | `1` uniquement derrière un proxy de confiance gérant les en-têtes forwarded |
+| `PORT`, `HOST` | adresse d'écoute du serveur Node de production |
 
-### Frontend Web
+Le navigateur utilise `/api/v1` et `/api/auth` sur la même origine ; il n'a pas
+besoin de `VITE_API_BASE_URL`. `VITE_CSP_NONCE` est la seule valeur de build
+navigateur optionnelle actuellement référencée.
 
-Situé dans `frontend/.env` :
+## Services locaux
 
-| Variable | Requis | Description |
-|----------|--------|-------------|
-| `VITE_API_BASE_URL` | Oui | URL de l'API backend |
-| `VITE_SENTRY_DSN` | Non | DSN Sentry pour le suivi des erreurs |
-| `SENTRY_AUTH_TOKEN` | Non | Token d'authentification Sentry pour les source maps |
-
-**Exemple :**
+`meta/docker-compose.yml` fournit PostgreSQL et MinIO. `pnpm start:workspace`
+ajoute des valeurs locales, tandis que les secrets viennent d'Infisical.
 
 ```bash
-VITE_API_BASE_URL=http://localhost:8080/api/v1
-VITE_SENTRY_DSN=<dsn sentry>
-SENTRY_AUTH_TOKEN=<token auth sentry>
+docker compose -f meta/docker-compose.yml up -d --wait postgres minio
+docker compose -f meta/docker-compose.yml up minio-init
 ```
 
-## Authentification Better Auth
+## Tenancy
 
-Better Auth est configuré uniquement dans le backend. Le `BETTER_AUTH_SECRET` doit être une chaîne aléatoire d'au moins 32 octets. Vous pouvez en générer un avec :
+- plateforme locale : `localhost:3000`
+- tenant local : `<slug>.localhost:3000`
+- plateforme hébergée : `PLATFORM_HOST`
+- tenants hébergés : sous-domaines de `TENANT_BASE_DOMAIN` ou domaines vérifiés
 
-```bash
-openssl rand -base64 32
-```
-
-`BETTER_AUTH_URL` doit pointer vers l'URL du serveur backend où les endpoints Better Auth sont servis.
-
-!!!note
-    `BETTER_AUTH_SECRET` ne se trouve que dans le `.env` du backend -- il n'est jamais défini dans le frontend.
-
-## Configuration de la Base de Données
-
-### Utilisation de Docker Compose (Recommandé)
-
-PostgreSQL est fourni par Docker Compose :
-
-```bash
-docker compose -f meta/docker-compose.yml up -d
-```
-
-Configuration par défaut :
-
-- Nom de la base : `stocket_inventory`
-- Hôte : `localhost`
-- Port : `5432`
-- Utilisateur : `postgres`
-- Mot de passe : `postgres`
-
-### Configuration Manuelle
-
-Créez la base de données :
-
-```bash
-createdb stocket_inventory
-```
-
-Définissez la chaîne de connexion :
-
-```bash
-DATABASE_URL=postgresql://username:password@localhost:5432/stocket_inventory
-```
+Le proxy web transmet l'hôte/protocole d'origine. N'activez `TRUSTED_PROXY=1`
+que derrière un reverse proxy de confiance.
 
 ## Documentation API
 
-Swagger UI est disponible sur :
+Swagger est monté sur `http://localhost:8080/docs`. Il ne couvre actuellement
+que le groupe santé migré vers Effect `HttpApiBuilder` ; consultez les routers
+et contrats partagés pour le reste.
 
-- http://localhost:8080/api/docs
-- OpenAPI JSON : http://localhost:8080/api/docs-json
+## Suite
 
-## Prochaines Étapes
-
-- [Architecture](../development/architecture.md) - Comprendre la conception du système
-- [Configuration de développement](../development/setup.md) - Configuration pour le développement
+- [Variables d'environnement](../reference/environment-variables.md)
+- [Architecture](../development/architecture.md)
+- [Configuration de développement](../development/setup.md)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,108 +1,72 @@
 # Configuration
 
-This guide covers all configuration options for Stocket Inventory.
+Stocket configuration is split by process. Infisical is the operational source
+for secrets; checked-in `env.template` files are references.
 
-## Environment Variables
+## Backend Processes
 
-### Backend API
+The API and task worker share database, tenant-host, object-storage, logging,
+and observability configuration. The worker does not compose the auth layer,
+but its current entry graph eagerly imports shared auth configuration. It
+therefore needs Better Auth/frontend values and the staging/production email
+configuration. The API additionally needs its HTTP port and CORS origins.
+Smart Import can optionally call an OpenAI-compatible
+API. Worker concurrency, leases, heartbeats, polling, recovery, retry, and
+progress throttling are independently tunable.
 
-Located in `backend/.env`:
+The API validates `NODE_ENV` and `PORT` at entry. Required credentials such as
+`DATABASE_URL`, `BETTER_AUTH_SECRET`, and S3 keys must be available before
+their layers initialize.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `NODE_ENV` | No | Environment mode (default: `development`) |
-| `PORT` | No | API port (default: `8080`) |
-| `CORS_ORIGIN` | No | Allowed CORS origin (default: `http://localhost:3000`) |
-| `BETTER_AUTH_SECRET` | Yes | Random 32+ byte string for Better Auth session signing |
-| `BETTER_AUTH_URL` | Yes | Better Auth server URL (e.g. `http://localhost:8080`) |
-| `FRONTEND_URL` | No | Frontend URL for redirects (default: `http://localhost:3000`) |
+See the complete [Environment Variable Reference](../reference/environment-variables.md).
 
-Individual database variables are also supported: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`.
+## Frontend Process
 
-**Example:**
+The web application uses server-only runtime values:
 
-```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
-NODE_ENV=development
-PORT=8080
-CORS_ORIGIN=http://localhost:3000
-BETTER_AUTH_SECRET=<random 32+ byte string>
-BETTER_AUTH_URL=http://localhost:8080
-FRONTEND_URL=http://localhost:3000
-```
+| Variable | Purpose |
+|----------|---------|
+| `INTERNAL_API_ORIGIN` | private origin used by SSR and the Vite `/api` proxy |
+| `WEB_URL` | canonical web origin used by Better Auth on the server |
+| `TENANT_BASE_DOMAIN` | tenant hostname suffix |
+| `PLATFORM_HOST` | platform administration hostname |
+| `TRUSTED_PROXY` | set to `1` only behind a trusted proxy that owns forwarded headers |
+| `PORT`, `HOST` | production Node server bind values |
 
-### Frontend Web
+Browser code uses same-origin `/api/v1` and `/api/auth`; it does not need a
+public `VITE_API_BASE_URL`. `VITE_CSP_NONCE` is the only optional browser-build
+value currently referenced by application source.
 
-Located in `frontend/.env`:
+## Local Services
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `VITE_API_BASE_URL` | Yes | Backend API URL |
-| `VITE_SENTRY_DSN` | No | Sentry DSN for error tracking |
-| `SENTRY_AUTH_TOKEN` | No | Sentry auth token for source maps |
-
-**Example:**
-
-```bash
-VITE_API_BASE_URL=http://localhost:8080/api/v1
-VITE_SENTRY_DSN=<sentry dsn>
-SENTRY_AUTH_TOKEN=<sentry auth token>
-```
-
-## Better Auth Authentication
-
-Better Auth is configured in the backend only. The `BETTER_AUTH_SECRET` must be a random string of at least 32 bytes. You can generate one with:
+`meta/docker-compose.yml` provides PostgreSQL and MinIO. Default local values
+are embedded in `pnpm start:workspace` for convenience, while secrets still
+come from Infisical.
 
 ```bash
-openssl rand -base64 32
+docker compose -f meta/docker-compose.yml up -d --wait postgres minio
+docker compose -f meta/docker-compose.yml up minio-init
 ```
 
-`BETTER_AUTH_URL` should point to the backend server URL where Better Auth endpoints are served.
+## Tenancy
 
-!!!note
-    `BETTER_AUTH_SECRET` lives only in the backend `.env` -- it is never set in the frontend.
+- local platform: `localhost:3000`
+- local tenant: `<slug>.localhost:3000`
+- hosted platform: `PLATFORM_HOST`
+- hosted tenants: subdomains of `TENANT_BASE_DOMAIN` or verified tenant domains
 
-## Database Configuration
-
-### Using Docker Compose (Recommended)
-
-PostgreSQL is provided by Docker Compose:
-
-```bash
-docker compose -f meta/docker-compose.yml up -d
-```
-
-Default configuration:
-
-- Database name: `stocket_inventory`
-- Host: `localhost`
-- Port: `5432`
-- User: `postgres`
-- Password: `postgres`
-
-### Manual Configuration
-
-Create the database:
-
-```bash
-createdb stocket_inventory
-```
-
-Set the connection string:
-
-```bash
-DATABASE_URL=postgresql://username:password@localhost:5432/stocket_inventory
-```
+The web proxy forwards the original host/protocol to the API. Set
+`TRUSTED_PROXY=1` only when the SSR process is actually behind a trusted reverse
+proxy; otherwise it uses the direct request host.
 
 ## API Documentation
 
-Swagger UI is available at:
-
-- http://localhost:8080/api/docs
-- OpenAPI JSON: http://localhost:8080/api/docs-json
+Swagger is mounted at `http://localhost:8080/docs`. It currently covers only
+the health group migrated to Effect `HttpApiBuilder`, so inspect router source
+and shared contracts for the rest of the API.
 
 ## Next Steps
 
-- [Architecture](../development/architecture.md) - Understand the system design
-- [Development Setup](../development/setup.md) - Set up for development
+- [Environment Variables](../reference/environment-variables.md)
+- [Architecture](../development/architecture.md)
+- [Development Setup](../development/setup.md)

--- a/docs/getting-started/index.fr.md
+++ b/docs/getting-started/index.fr.md
@@ -1,18 +1,24 @@
 # Démarrage
 
-Cette section vous aidera à installer et configurer Stocket Inventory.
+Stocket est une application d'inventaire multi-tenant composée de dépôts
+backend, frontend, packages et support indépendants. Le projet `meta` assemble
+le checkout local pris en charge.
 
 ## Prérequis
 
-Avant de commencer, assurez-vous d'avoir :
+- Node.js 22 et pnpm 10.28.0
+- Git et Docker Compose
+- identifiants GitHub Packages (`read:packages`)
+- accès Infisical pour les secrets d'exécution
+- Nix est optionnel ; plusieurs dépôts fournissent leur propre flake
 
-- Node.js >= 20
-- pnpm >= 10
-- Nix avec flakes activé (chaque dépôt possède son propre `flake.nix`)
-- Docker & Docker Compose (pour PostgreSQL et les autres services)
+## Parcours
 
-## Prochaines Étapes
+1. [Installation](installation.md) — s'authentifier, initialiser et démarrer
+2. [Démarrage rapide](quick-start.md) — créer un tenant de démo et parcourir le
+   vrai workflow produit, emplacement et inventaire
+3. [Configuration](configuration.md) — comprendre les frontières d'exécution et
+   trouver la référence complète des variables
 
-1. [Installation](installation.md) - Configurer l'environnement de développement
-2. [Démarrage rapide](quick-start.md) - Créer vos premiers produits
-3. [Configuration](configuration.md) - Configurer les variables d'environnement
+Les développeurs peuvent ensuite consulter la
+[carte des projets et modules](../development/project-map.md).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,18 +1,23 @@
 # Getting Started
 
-This section will help you get Stocket Inventory up and running.
+Stocket is a tenant-aware inventory application built from independent backend,
+frontend, shared-package, and support repositories. The `meta` project assembles
+the supported local development checkout.
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+- Node.js 22 and pnpm 10.28.0
+- Git and Docker Compose
+- GitHub Packages credentials (`read:packages`)
+- Infisical access for runtime secrets
+- Nix is optional; several repositories provide their own flake
 
-- Node.js >= 20
-- pnpm >= 10
-- Nix with flakes enabled (each repo has its own `flake.nix`)
-- Docker & Docker Compose (for PostgreSQL and other services)
+## Path Through This Guide
 
-## Next Steps
+1. [Installation](installation.md) — authenticate, bootstrap, and start the stack
+2. [Quick Start](quick-start.md) — seed a tenant and exercise the real product,
+   location, and inventory workflow
+3. [Configuration](configuration.md) — understand runtime boundaries and find
+   the complete environment reference
 
-1. [Installation](installation.md) - Set up the development environment
-2. [Quick Start](quick-start.md) - Create your first products
-3. [Configuration](configuration.md) - Configure environment variables
+Developers should continue with the [Project and Module Map](../development/project-map.md).

--- a/docs/getting-started/installation.fr.md
+++ b/docs/getting-started/installation.fr.md
@@ -1,154 +1,106 @@
 # Installation
 
-Ce guide couvre la configuration de l'environnement de développement Stocket Inventory.
+Cette procédure crée un checkout multi-dépôts local et démarre la plateforme,
+une application tenant, PostgreSQL et MinIO.
 
-## Utilisation de Nix Flakes + Docker (Recommandé)
+## 1. Configurer GitHub Packages
 
-Le projet utilise des [Nix flakes](https://nixos.wiki/wiki/Flakes) par dépôt pour des environnements de développement reproductibles et Docker Compose pour les services comme PostgreSQL.
-
-### 1. Installer Nix
+Créez un token GitHub classique avec `read:packages`. Exportez-le comme
+`GITHUB_PACKAGES_TOKEN` via une invite masquée ou un gestionnaire de secrets —
+ne saisissez pas le token dans l'historique — puis configurez pnpm :
 
 ```bash
-sh <(curl -L https://nixos.org/nix/install) --daemon
+# GITHUB_PACKAGES_TOKEN doit déjà être exporté de manière sûre.
+pnpm config set --global @stocketfr:registry https://npm.pkg.github.com
+pnpm config set --global //npm.pkg.github.com/:_authToken "${GITHUB_PACKAGES_TOKEN}"
+unset GITHUB_PACKAGES_TOKEN
 ```
 
-Assurez-vous que les flakes sont activés dans votre configuration Nix.
+## 2. Cloner le contrôleur du workspace
 
-### 2. Cloner le Workspace
+Depuis un dossier parent vide :
 
 ```bash
 git clone https://github.com/stocketfr/meta.git
-cd meta && ./scripts/bootstrap && cd ..
-```
-
-### 3. Initialiser le Workspace
-
-```bash
 ./meta/scripts/bootstrap
 ```
 
-Ceci synchronise tous les dépôts et installe les dépendances.
+`meta/repos.yaml` clone les dépôts gérés à côté de `meta` et le bootstrap lie
+la configuration racine locale. Le dépôt infrastructure reste séparé.
 
-### 4. Entrer dans un Shell Nix (par dépôt)
-
-Chaque dépôt (backend, frontend, etc.) possède son propre `flake.nix`. Entrez dans le shell du dépôt souhaité :
-
-```bash
-cd backend && nix develop
-# ou
-cd frontend && nix develop
-```
-
-Ceci fournit :
-
-- Node.js 20+ et pnpm 10
-- Tous les outils spécifiques au dépôt
-
-### 5. Démarrer les Services de Développement
-
-Démarrez PostgreSQL et les autres services via Docker Compose :
+## 3. S'authentifier auprès d'Infisical
 
 ```bash
-docker compose -f meta/docker-compose.yml up -d
+infisical login
 ```
 
-Ou utilisez le script meta dev pour tout démarrer (serveurs de développement backend + frontend) :
+Les fichiers versionnés s'appellent `backend/env.template` et
+`frontend/env.template`. Ils documentent les clés sans devenir la source locale
+des secrets. Voir [Configuration](configuration.md).
+
+## 4. Démarrer la stack
 
 ```bash
 ./meta/scripts/dev
 ```
 
-Pour démarrer également les services Docker automatiquement :
+Le script démarre PostgreSQL, MinIO et son bucket local, l'API Effect Node.js et
+le processus web TanStack Start. Loggle est utilisé s'il est disponible. Le
+flag historique `--with-docker` n'est pas nécessaire et n'a pas d'effet actuel.
+
+!!! warning "Utilisateurs de Loggle"
+    Le `meta/.loggle.toml` actuel appelle un script frontend `dev:workspace`
+    absent. Jusqu'à sa correction, [lancez les projets séparément](../development/setup.md#lancer-les-projets-separement)
+    lorsque Loggle est installé.
+
+Pour les imports asynchrones, lancez le worker séparément :
 
 ```bash
-./meta/scripts/dev --with-docker
+cd backend
+pnpm start:worker
 ```
 
-Ceci démarre :
+## 5. Créer un tenant local
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| PostgreSQL | localhost:5432 | Base de données |
-| API Effect.ts | http://localhost:8080 | Backend (Bun) |
-| TanStack Start Web | http://localhost:3000 | Frontend |
-
-### 6. Configurer les Variables d'Environnement
-
-**Backend :**
+Après l'application des migrations de développement :
 
 ```bash
-cp backend/.env.template backend/.env
+cd backend
+pnpm tenant:seed:workspace
 ```
 
-Modifiez `backend/.env` avec votre configuration :
+Sans cible, cette commande ne crée le tenant par défaut que s'il n'en existe
+aucun, choisit l'unique tenant ou demande parmi plusieurs. Elle crée/renouvelle
+`tenant-admin@stocket.fr` avec `admin1234` et remplace les données du tenant
+choisi. Définissez `TENANT_ADMIN_TENANT_SLUG` ou `TENANT_ADMIN_TENANT_ID` pour
+cibler explicitement un tenant existant.
+
+!!! danger "Les données tenant sont remplacées"
+    N'exécutez pas ce seed sur un tenant dont les données doivent être conservées.
+
+## 6. Vérifier l'installation
+
+| Vérification | URL |
+|--------------|-----|
+| Liveness API | `http://localhost:8080/health-check/live` |
+| Readiness API | `http://localhost:8080/health-check/ready` |
+| Swagger partiel | `http://localhost:8080/docs` |
+| Hôte web plateforme | `http://localhost:3000` |
+| Tenant par défaut sur base neuve | `http://stocket.localhost:3000` |
+| Console MinIO | `http://localhost:9001` |
+
+Swagger ne décrit actuellement que le groupe santé implémenté avec Effect
+`HttpApiBuilder`, pas tous les endpoints.
+
+## Shell Nix optionnel
+
+Plusieurs dépôts possèdent leur propre flake :
 
 ```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
-NODE_ENV=development
-PORT=8080
-CORS_ORIGIN=http://localhost:3000
-BETTER_AUTH_SECRET=<chaîne aléatoire de 32+ octets>
-BETTER_AUTH_URL=http://localhost:8080
-FRONTEND_URL=http://localhost:3000
+cd backend
+nix develop
 ```
 
-**Frontend :**
-
-```bash
-echo "VITE_API_BASE_URL=http://localhost:8080/api/v1" > frontend/.env
-```
-
-!!!tip "Infisical CLI"
-    Le backend et le frontend disposent d'un `justfile` avec une tâche `env`. Si vous utilisez Infisical CLI, vous pouvez générer les fichiers `.env` automatiquement :
-    ```bash
-    cd backend && just env
-    cd frontend && just env
-    ```
-    Ceci exécute `infisical export --env=dev --format=dotenv > .env` pour injecter les secrets depuis Infisical.
-
-## Configuration Manuelle (Alternative)
-
-Si vous préférez ne pas utiliser Nix :
-
-### Prérequis
-
-- Node.js >= 20
-- pnpm >= 10
-- PostgreSQL 16
-- Python 3.12 (pour la documentation)
-
-### Configuration de la Base de Données
-
-```bash
-createdb stocket_inventory
-```
-
-### Variables d'Environnement
-
-Copiez le modèle d'environnement :
-
-```bash
-cp backend/.env.template backend/.env
-```
-
-Modifiez `backend/.env` avec votre configuration (voir le tableau ci-dessus).
-
-### Démarrer les Services
-
-```bash
-# Terminal 1 : API
-cd backend && pnpm start
-
-# Terminal 2 : Web
-cd frontend && pnpm dev
-```
-
-## Vérifier l'Installation
-
-1. Ouvrez http://localhost:8080/api/docs - Vous devriez voir Swagger UI
-2. Ouvrez http://localhost:3000 - Vous devriez voir la page de connexion
-
-## Prochaines Étapes
-
-- [Démarrage rapide](quick-start.md) - Créer vos premiers produits
-- [Configuration](configuration.md) - En savoir plus sur les options de configuration
+Il n'existe pas de flake racine. Consultez la
+[configuration de développement](../development/setup.md) pour le démarrage
+manuel et le dépannage.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,154 +1,110 @@
 # Installation
 
-This guide covers setting up the Stocket Inventory development environment.
+This procedure creates a local multi-repository checkout and starts the
+platform, a tenant application, PostgreSQL, and MinIO.
 
-## Using Nix Flakes + Docker (Recommended)
+## 1. Configure GitHub Packages
 
-The project uses per-repo [Nix flakes](https://nixos.wiki/wiki/Flakes) for reproducible development environments and Docker Compose for services like PostgreSQL.
-
-### 1. Install Nix
+Create a classic GitHub token with `read:packages`. Export it as
+`GITHUB_PACKAGES_TOKEN` through a hidden shell prompt or secret manager—do not
+type the token into command history—then configure pnpm:
 
 ```bash
-sh <(curl -L https://nixos.org/nix/install) --daemon
+# GITHUB_PACKAGES_TOKEN must already be exported securely.
+pnpm config set --global @stocketfr:registry https://npm.pkg.github.com
+pnpm config set --global //npm.pkg.github.com/:_authToken "${GITHUB_PACKAGES_TOKEN}"
+unset GITHUB_PACKAGES_TOKEN
 ```
 
-Ensure flakes are enabled in your Nix configuration.
+## 2. Clone the Workspace Controller
 
-### 2. Clone the Workspace
+From an empty parent directory:
 
 ```bash
 git clone https://github.com/stocketfr/meta.git
-cd meta && ./scripts/bootstrap && cd ..
-```
-
-### 3. Bootstrap the Workspace
-
-```bash
 ./meta/scripts/bootstrap
 ```
 
-This will sync all repos and install dependencies.
+`meta/repos.yaml` clones the managed repositories beside `meta` and the
+bootstrap links the local root workspace configuration. The infrastructure
+repository is intentionally separate and is not cloned by this command.
 
-### 4. Enter a Nix Shell (per-repo)
+## 3. Authenticate to Infisical
 
-Each repo (backend, frontend, etc.) has its own `flake.nix`. Enter the shell for the repo you need:
-
-```bash
-cd backend && nix develop
-# or
-cd frontend && nix develop
-```
-
-This will provide:
-
-- Node.js 20+ and pnpm 10
-- All repo-specific tooling
-
-### 5. Start Development Services
-
-Start PostgreSQL and other services via Docker Compose:
+The backend and frontend scripts inject runtime values through Infisical:
 
 ```bash
-docker compose -f meta/docker-compose.yml up -d
+infisical login
 ```
 
-Or use the meta dev script to start everything (backend + frontend dev servers):
+The checked-in files are named `backend/env.template` and
+`frontend/env.template`. They document keys but are not meant to become the
+local source of truth. See [Configuration](configuration.md).
+
+## 4. Start the Stack
 
 ```bash
 ./meta/scripts/dev
 ```
 
-To also start Docker services automatically:
+The script starts PostgreSQL, MinIO and its local bucket, the Node.js Effect
+API, and the TanStack Start web process. Loggle is used when available;
+otherwise output is prefixed by process. The historical `--with-docker` flag is
+not required and has no current effect.
+
+!!! warning "Loggle users"
+    The current `meta/.loggle.toml` calls a missing frontend `dev:workspace`
+    script. Until it is fixed, [run the projects separately](../development/setup.md#run-projects-individually)
+    when Loggle is installed.
+
+For asynchronous imports, run the worker separately:
 
 ```bash
-./meta/scripts/dev --with-docker
+cd backend
+pnpm start:worker
 ```
 
-This starts:
+## 5. Seed a Local Tenant
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| PostgreSQL | localhost:5432 | Database |
-| Effect.ts API | http://localhost:8080 | Backend (Bun) |
-| TanStack Start Web | http://localhost:3000 | Frontend |
-
-### 6. Configure Environment Variables
-
-**Backend:**
+After the API has applied development migrations:
 
 ```bash
-cp backend/.env.template backend/.env
+cd backend
+pnpm tenant:seed:workspace
 ```
 
-Edit `backend/.env` with your configuration:
+With no target, this creates the default tenant only when none exist, selects
+the only tenant, or prompts when several exist. It creates/rotates
+`tenant-admin@stocket.fr` with password `admin1234` and replaces the selected
+tenant's demo data. Set `TENANT_ADMIN_TENANT_SLUG` or
+`TENANT_ADMIN_TENANT_ID` to target an existing tenant explicitly.
+
+!!! danger "Tenant data is replaced"
+    Do not run the workspace seed against a tenant whose data must be kept.
+
+## 6. Verify the Installation
+
+| Check | URL |
+|-------|-----|
+| API liveness | `http://localhost:8080/health-check/live` |
+| API readiness | `http://localhost:8080/health-check/ready` |
+| Partial Swagger UI | `http://localhost:8080/docs` |
+| Platform web host | `http://localhost:3000` |
+| Default tenant on a new database | `http://stocket.localhost:3000` |
+| MinIO console | `http://localhost:9001` |
+
+Swagger currently describes only the health group implemented with Effect
+`HttpApiBuilder`; it is not a complete endpoint catalog.
+
+## Optional Nix Shell
+
+Several repositories have their own flake. For example:
 
 ```bash
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
-NODE_ENV=development
-PORT=8080
-CORS_ORIGIN=http://localhost:3000
-BETTER_AUTH_SECRET=<random 32+ byte string>
-BETTER_AUTH_URL=http://localhost:8080
-FRONTEND_URL=http://localhost:3000
+cd backend
+nix develop
 ```
 
-**Frontend:**
-
-```bash
-echo "VITE_API_BASE_URL=http://localhost:8080/api/v1" > frontend/.env
-```
-
-!!!tip "Infisical CLI"
-    Both backend and frontend have a `justfile` with a `env` task. If you use Infisical CLI, you can generate `.env` files automatically:
-    ```bash
-    cd backend && just env
-    cd frontend && just env
-    ```
-    This runs `infisical export --env=dev --format=dotenv > .env` to populate secrets from Infisical.
-
-## Manual Setup (Alternative)
-
-If you prefer not to use Nix:
-
-### Prerequisites
-
-- Node.js >= 20
-- pnpm >= 10
-- PostgreSQL 16
-- Python 3.12 (for docs)
-
-### Database Setup
-
-```bash
-createdb stocket_inventory
-```
-
-### Environment Variables
-
-Copy the environment template:
-
-```bash
-cp backend/.env.template backend/.env
-```
-
-Edit `backend/.env` with your configuration (see table above).
-
-### Start Services
-
-```bash
-# Terminal 1: API
-cd backend && pnpm start
-
-# Terminal 2: Web
-cd frontend && pnpm dev
-```
-
-## Verify Installation
-
-1. Open http://localhost:8080/api/docs - You should see Swagger UI
-2. Open http://localhost:3000 - You should see the login page
-
-## Next Steps
-
-- [Quick Start](quick-start.md) - Create your first products
-- [Configuration](configuration.md) - Learn about configuration options
+There is no root flake for the assembled workspace. For manual process startup,
+advanced credentials, and troubleshooting, see
+[Development Setup](../development/setup.md).

--- a/docs/getting-started/quick-start.fr.md
+++ b/docs/getting-started/quick-start.fr.md
@@ -1,61 +1,79 @@
-# Démarrage Rapide
+# Démarrage rapide
 
-Ce guide vous accompagnera dans la création de vos premiers produits dans Stocket Inventory.
+Ce parcours suppose une base locale neuve : le seed sans cible crée donc le
+tenant par défaut. Sur une base existante, il choisit l'unique tenant ou demande
+parmi plusieurs ; utilisez alors l'hôte choisi. Un utilisateur tenant ne se
+connecte pas sur l'hôte plateforme.
 
-## 1. Connexion
-
-Accédez à http://localhost:3000 et connectez-vous avec votre compte Better Auth.
-
-## 2. Données d'Exemple (Optionnel)
-
-Pour remplir la base de données avec des données d'exemple pour les tests :
+## 1. Créer les données et se connecter
 
 ```bash
-pnpm --filter @stocket/api seed
+cd backend
+pnpm tenant:seed:workspace
 ```
 
-Ceci crée :
+Sur une base neuve, ouvrez `http://stocket.localhost:3000` ; sinon remplacez
+`stocket` par le slug/hôte choisi. Connectez-vous avec :
 
-- Des catégories
-- Des fournisseurs
-- Des produits
-- Des emplacements
-- Des clients
-- Des enregistrements d'inventaire
-- Des commandes
-- Des mouvements de stock
-- Des journaux d'audit
+- e-mail : `tenant-admin@stocket.fr`
+- mot de passe : `admin1234`
 
-## 3. Créer une Catégorie
+`http://localhost:3000` est l'hôte séparé des superadmins plateforme.
 
-1. Accédez à **Produits** dans la barre latérale
-2. Cliquez sur **Gérer les Catégories**
-3. Cliquez sur **Créer une Catégorie**
-4. Entrez un nom (ex: "Fournitures de Cuisine")
-5. Sélectionnez éventuellement une catégorie parente
-6. Cliquez sur **Enregistrer**
+## 2. Examiner le tableau de bord
 
-## 4. Créer un Produit
+Le tableau de bord résume produits, emplacements, quantité, stock faible et
+activité récente. L'accès dépend des permissions résolues de l'utilisateur.
 
-1. Accédez à **Produits**
-2. Cliquez sur **Créer un Produit**
-3. Remplissez les champs obligatoires :
-   - **SKU** - Entrez manuellement ou scannez un code-barres
-   - **Nom** - Nom du produit
-   - **Catégorie** - Sélectionnez dans l'arborescence
-   - **Point de Réapprovisionnement** - Niveau de stock minimum
-4. Cliquez sur **Enregistrer**
+## 3. Créer un produit
 
-## 5. Voir les Journaux d'Audit
+1. Ouvrez **Produits** puis **Créer un produit**.
+2. Saisissez un SKU unique et un nom.
+3. Sélectionnez une catégorie existante ou créez-en une depuis ce flux.
+4. Ajoutez éventuellement unité, code-barres, coût, prix, seuil, état
+   périssable, notes et photos.
+5. Enregistrez.
 
-Toutes les modifications sont suivies automatiquement :
+L'action QR remplit le SKU si le navigateur prend en charge `BarcodeDetector`
+et si l'accès caméra est autorisé.
 
-1. Accédez aux **Journaux d'Audit**
-2. Consultez l'historique de toutes les modifications
-3. Filtrez par type d'entité, utilisateur ou date
+## 4. Créer un emplacement et une zone
 
-## Prochaines Étapes
+1. Ouvrez **Emplacements** et créez un entrepôt, fournisseur, client ou transit.
+2. Ouvrez le détail de l'emplacement.
+3. Ajoutez une zone, étagère ou bac ; les zones peuvent être imbriquées.
 
-- [Produits](../user-guide/products.md) - En savoir plus sur la gestion des produits
-- [Catégories](../user-guide/categories.md) - Organiser votre inventaire
-- [Configuration](configuration.md) - Personnaliser votre installation
+Évitez de supprimer une zone parent contenant des enfants. La suppression
+actuelle enlève uniquement la ligne sélectionnée et peut rendre les descendants
+inaccessibles.
+
+## 5. Ajouter et ajuster l'inventaire
+
+1. Ouvrez **Inventaire** puis **Ajouter**.
+2. Choisissez produit, emplacement et éventuellement zone.
+3. Saisissez la quantité et les données de lot/expiration éventuelles.
+4. Utilisez **Ajuster** pour appliquer ensuite un delta positif ou négatif.
+
+Les ajustements et le registre des mouvements sont indépendants : l'un ne crée
+ni ne met automatiquement à jour l'autre.
+
+## 6. Tester un import CSV guidé (optionnel)
+
+Smart Import exige le droit fonctionnel `smartImport` du tenant et un worker
+actif.
+
+1. Ouvrez **Produits** puis **Importer**.
+2. Chargez un CSV normalisé ou un export Sortly pris en charge.
+3. Examinez le preview et les suggestions déterministes/IA.
+4. Résolvez catégories, emplacements/zones, doublons SKU et photos.
+5. Approuvez le plan et suivez la tâche durable.
+6. Examinez les compteurs et téléchargez le CSV d'incidents proposé.
+
+Voir [Produits](../user-guide/products.md) pour le workflow complet.
+
+## Suite
+
+- [Emplacements et zones](../user-guide/locations.md)
+- [Inventaire](../user-guide/inventory.md)
+- [Utilisateurs et rôles](../user-guide/users-roles.md)
+- [Configuration](configuration.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,61 +1,83 @@
 # Quick Start
 
-This guide will walk you through creating your first products in Stocket Inventory.
+This walkthrough assumes a new local database, so the untargeted seed creates
+the default tenant. On an existing database it selects the only tenant or
+prompts among several; use that tenant's hostname instead. Tenant users do not
+sign in on the platform host.
 
-## 1. Sign In
-
-Navigate to http://localhost:3000 and sign in with your Better Auth account.
-
-## 2. Seed Sample Data (Optional)
-
-To populate the database with sample data for testing:
+## 1. Seed and Sign In
 
 ```bash
-pnpm --filter @stocket/api seed
+cd backend
+pnpm tenant:seed:workspace
 ```
 
-This creates:
+On a new database, open `http://stocket.localhost:3000`; otherwise replace
+`stocket` with the selected tenant slug/hostname. Sign in with:
 
-- Categories
-- Suppliers
-- Products
-- Locations
-- Clients
-- Inventory records
-- Orders
-- Stock movements
-- Audit logs
+- email: `tenant-admin@stocket.fr`
+- password: `admin1234`
 
-## 3. Create a Category
+`http://localhost:3000` is the separate platform-superadmin host.
 
-1. Navigate to **Products** in the sidebar
-2. Click on **Manage Categories**
-3. Click **Create Category**
-4. Enter a name (e.g., "Galley Supplies")
-5. Optionally select a parent category
-6. Click **Save**
+## 2. Review the Dashboard
 
-## 4. Create a Product
+The dashboard summarizes products, locations, inventory quantity, low-stock
+items, and recent activity. Access depends on the user's resolved resource
+permissions.
 
-1. Navigate to **Products**
-2. Click **Create Product**
-3. Fill in the required fields:
-   - **SKU** - Enter manually or scan a barcode
-   - **Name** - Product name
-   - **Category** - Select from the category tree
-   - **Reorder Point** - Minimum stock level
-4. Click **Save**
+## 3. Create a Product
 
-## 5. View Audit Logs
+1. Open **Products**.
+2. Choose **Create Product**.
+3. Enter a unique SKU and name.
+4. Select an existing category or create a category from the product flow.
+5. Optionally set unit, barcode, cost, price, reorder point, perishable state,
+   notes, and photos.
+6. Save the product.
 
-All changes are tracked automatically:
+The QR action reads a QR code into the SKU field when the browser supports the
+`BarcodeDetector` API and camera access is granted.
 
-1. Navigate to **Audit Logs**
-2. View the history of all changes
-3. Filter by entity type, user, or date
+## 4. Create a Location and Area
+
+1. Open **Locations** and create a warehouse, supplier, client, or in-transit
+   location.
+2. Open the location detail page.
+3. Add an area such as a room, shelf, or bin; child areas may be nested.
+
+Avoid deleting a parent area while it still has children. Current deletion
+removes only the selected row and can leave descendants unreachable until
+repaired.
+
+## 5. Add and Adjust Inventory
+
+1. Open **Inventory** and choose **Add Inventory**.
+2. Select the product and location, plus an optional area.
+3. Enter quantity and optional batch/expiry data.
+4. Use **Adjust** later to apply a positive or negative delta.
+
+Inventory adjustments and stock-movement records are currently independent.
+Adjusting quantity does not create a movement, and creating a movement does not
+change quantity.
+
+## 6. Try a Guided CSV Import (Optional)
+
+Smart Import is available only when the tenant's `smartImport` entitlement is
+enabled and a background worker is running.
+
+1. Open **Products** and choose **Import**.
+2. Upload a normalized product CSV or supported Sortly export.
+3. Review the structured preview and any deterministic/AI suggestions.
+4. Resolve category, location/area, duplicate-SKU, and photo decisions.
+5. Approve the plan and monitor the durable task.
+6. Review created/updated counts and download the issue CSV when offered.
+
+See [Products](../user-guide/products.md) for the full workflow.
 
 ## Next Steps
 
-- [Products](../user-guide/products.md) - Learn more about product management
-- [Categories](../user-guide/categories.md) - Organize your inventory
-- [Configuration](configuration.md) - Customize your setup
+- [Locations and Areas](../user-guide/locations.md)
+- [Inventory](../user-guide/inventory.md)
+- [Users and Roles](../user-guide/users-roles.md)
+- [Configuration](configuration.md)

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -1,60 +1,71 @@
-# Système d'Inventaire Stocket
+# Stocket Inventory
 
-Bienvenue dans la documentation Stocket Inventory. Ce système aide à gérer l'inventaire d'approvisionnement des yachts avec des fonctionnalités de gestion des produits, de suivi des commandes et de journalisation des audits.
+Stocket est une plateforme d'inventaire multi-tenant destinée aux équipes qui doivent savoir quel stock elles possèdent, où il se trouve et comment il se déplace. Elle réunit les catalogues de produits, les emplacements, l'inventaire, les commandes, les utilisateurs et l'historique d'audit dans une seule application web.
 
-Construit avec Effect.ts sur Bun (backend), TanStack Start avec React 19 (frontend), PostgreSQL, Better Auth et Drizzle ORM.
+Le système actuel combine un backend Effect et un worker en arrière-plan sous Node.js 22, une application TanStack Start avec React 19, PostgreSQL avec Drizzle ORM, Better Auth et un stockage d'objets compatible S3.
 
-## Liens Rapides
+## Liens rapides
 
 <div class="grid cards" markdown>
 
 - :material-rocket-launch: **Démarrage**
 
-    Commencez avec Stocket Inventory en quelques minutes.
+    Assemblez le workspace, démarrez les services locaux et créez les données de développement.
 
     [:octicons-arrow-right-24: Installation](getting-started/installation.md)
 
-- :material-book-open-variant: **Guide Utilisateur**
+- :material-book-open-variant: **Guide utilisateur**
 
-    Apprenez à utiliser toutes les fonctionnalités de l'application.
+    Découvrez les workflows actuels du produit et les fonctions d'administration.
 
-    [:octicons-arrow-right-24: Guide Utilisateur](user-guide/index.md)
+    [:octicons-arrow-right-24: Guide utilisateur](user-guide/index.md)
 
 - :material-code-braces: **Développement**
 
-    Configurez votre environnement de développement et contribuez.
+    Comprenez l'architecture multi-dépôts et contribuez en toute sécurité.
 
     [:octicons-arrow-right-24: Développement](development/index.md)
 
-- :material-map: **Feuille de Route**
+- :material-map: **Feuille de route**
 
-    Découvrez ce qui est prévu pour les prochaines versions.
+    Comparez le socle livré avec les lacunes connues et les décisions futures.
 
-    [:octicons-arrow-right-24: Feuille de Route](roadmap.md)
+    [:octicons-arrow-right-24: Feuille de route](roadmap.md)
 
 </div>
 
-## Fonctionnalités
+## Ce qui est disponible aujourd'hui
 
-- **Gestion des Produits** - Créez et organisez des produits avec SKUs, prix et catégories
-- **Hiérarchie des Catégories** - Catégorisation multi-niveaux avec imbrication illimitée
-- **Suivi des Emplacements** - Gérez les entrepôts, fournisseurs, clients et emplacements en transit
-- **Gestion des Zones** - Définissez des zones, étagères et bacs au sein des emplacements
-- **Contrôle d'Inventaire** - Suivez les quantités en stock à travers les emplacements avec suivi des lots et dates d'expiration
-- **Mouvements de Stock** - Suivez et enregistrez les mouvements de stock entre emplacements
-- **Traitement des Commandes** - Suivez les commandes d'approvisionnement des yachts tout au long du cycle complet (DRAFT, CONFIRMED, SOURCING, PICKING, PACKED, SHIPPED, DELIVERED, CANCELLED, ON_HOLD)
-- **Module Clients** - Gérez les informations et relations clients
-- **Module Fournisseurs** - Gérez les informations et relations fournisseurs
-- **Piste d'Audit** - Historique complet des modifications avec suivi des utilisateurs
-- **Authentification** - Système d'authentification Better Auth
-- **Rôles & Permissions** - Contrôle d'accès basé sur les rôles avec PermissionGuard et @RequirePermission
-- **Gestion des Utilisateurs** - Administration des utilisateurs
-- **Gestion des Photos** - Gestion des photos de produits et d'inventaire
-- **Personnalisation/Branding** - Options de personnalisation de la marque
-- **Multi-langue** - Support anglais, français et allemand
-- **API REST HATEOAS** - Conception d'API pilotée par hypermédia
-- **Tests E2E** - Tests de bout en bout avec Playwright
-- **Support Docker** - Docker Compose pour le déploiement conteneurisé
-- **CI/CD** - Pipelines GitHub Actions par dépôt
-- **Documentation** - Site MkDocs avec GitHub Pages
-- **Scan QR** - Numérisation de codes-barres pour une recherche rapide des produits
+### Catalogue et inventaire
+
+- Produits avec SKU, prix, catégories imbriquées, seuils de réapprovisionnement et photos
+- Emplacements et zones imbriquées pour les entrepôts, clients, fournisseurs et stocks en transit
+- Quantités d'inventaire avec informations de batch, de lot et d'expiration
+- Ajustements d'inventaire et registre manuel séparé des mouvements ; aucun ne met l'autre à jour automatiquement
+- Fiches clients, fournisseurs et commandes avec transitions de statut de commande validées
+- Import de produits via des tâches persistantes en arrière-plan, notamment depuis des entrées compatibles CSV/Sortly et avec un mapping assisté optionnel
+
+### Équipes et administration de la plateforme
+
+- Sessions Better Auth avec connexion et routage par hôte tenant
+- Administration des utilisateurs, rôles personnalisés, permissions par ressource et droits liés aux fonctionnalités
+- Console plateforme pour le cycle de vie des tenants, l'affectation des offres et les dérogations de fonctionnalités
+- Branding par tenant et traductions de l'application en anglais, français et allemand
+- Métadonnées d'audit au mieux pour certaines mutations métier tenant
+
+### Expérience quotidienne
+
+- Application web SSR avec des workflows d'inventaire responsives
+- Tableau de bord récapitulant produits, emplacements, inventaire, stocks faibles, mouvements et commandes
+- Filtres de stock faible et pipeline backend pour les notifications planifiées par e-mail
+- Scan QR par caméra lorsque le navigateur le permet
+- Manifest PWA installable, cache runtime des ressources statiques récupérées et page de repli hors ligne
+
+!!! important "Ce que signifie le support hors ligne"
+    Le support PWA installe l'application, précharge repli/manifeste/icônes et peut mettre en cache les ressources statiques récupérées. Les pages de navigation réussies et les requêtes API ne sont pas mises en cache pour un usage hors ligne. Données, écritures, synchronisation et conflits exigent une connexion.
+
+## Organisation du projet
+
+Stocket n'est pas un dépôt Git unique. Le dépôt `meta` assemble des dépôts séparés pour le backend, le frontend, les packages, le client desktop, la documentation et la landing page dans un workspace local. L'infrastructure est maintenue dans son propre dépôt. Consultez la [carte des projets](development/project-map.md) et le [guide d'architecture](development/architecture.md) pour connaître les responsabilités et les frontières d'exécution.
+
+La CI valide le backend et le frontend actuels, mais ces dépôts ne publient ni ne déploient d'artefacts applicatifs automatiquement après un merge. Un rollout manuel temporaire en juillet 2026 n'a pas créé de CD persistant. La publication des packages, le déploiement de la documentation, l'application de l'infrastructure et le packaging desktop disposent chacun de workflows et contrôles distincts. La [feuille de route](roadmap.md#statut-des-releases-et-du-deploiement) décrit cette frontière.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,60 +1,71 @@
-# Stocket Inventory System
+# Stocket Inventory
 
-Welcome to the Stocket Inventory documentation. This system helps manage yacht provisioning inventory with features for product management, order tracking, and audit logging.
+Stocket is a multi-tenant inventory platform for teams that need to understand what stock they have, where it is, and how it moves. It brings product catalogues, locations, inventory, orders, people, and audit history into one web application.
 
-Built with Effect.ts on Bun (backend), TanStack Start with React 19 (frontend), PostgreSQL, Better Auth, and Drizzle ORM.
+The current system combines a Node.js 22 Effect backend and background worker, a TanStack Start application with React 19, PostgreSQL with Drizzle ORM, Better Auth, and S3-compatible object storage.
 
-## Quick Links
+## Quick links
 
 <div class="grid cards" markdown>
 
-- :material-rocket-launch: **Getting Started**
+- :material-rocket-launch: **Getting started**
 
-    Get up and running with Stocket Inventory in minutes.
+    Assemble the workspace, start the local services, and create development data.
 
     [:octicons-arrow-right-24: Installation](getting-started/installation.md)
 
-- :material-book-open-variant: **User Guide**
+- :material-book-open-variant: **User guide**
 
-    Learn how to use all features of the application.
+    Learn the current product workflows and administration features.
 
-    [:octicons-arrow-right-24: User Guide](user-guide/index.md)
+    [:octicons-arrow-right-24: User guide](user-guide/index.md)
 
 - :material-code-braces: **Development**
 
-    Set up your development environment and contribute.
+    Understand the multi-repository architecture and contribute safely.
 
     [:octicons-arrow-right-24: Development](development/index.md)
 
 - :material-map: **Roadmap**
 
-    See what's planned for future releases.
+    Compare the shipped baseline with known gaps and future decisions.
 
     [:octicons-arrow-right-24: Roadmap](roadmap.md)
 
 </div>
 
-## Features
+## What is available today
 
-- **Product Management** - Create and organize products with SKUs, pricing, and categories
-- **Category Hierarchy** - Multi-level categorization with unlimited nesting
-- **Location Tracking** - Manage warehouses, suppliers, clients, and in-transit locations
-- **Area Management** - Define zones, shelves, and bins within locations
-- **Inventory Control** - Track stock quantities across locations with batch and expiry tracking
-- **Stock Movements** - Track and record stock movements between locations
-- **Order Processing** - Track yacht provisioning orders through complete lifecycle (DRAFT, CONFIRMED, SOURCING, PICKING, PACKED, SHIPPED, DELIVERED, CANCELLED, ON_HOLD)
-- **Clients Module** - Manage client information and relationships
-- **Suppliers Module** - Manage supplier information and relationships
-- **Audit Trail** - Complete change history with user tracking
-- **Authentication** - Better Auth authentication system
-- **Roles & Permissions** - Role-based access control with requirePermission
-- **Users Management** - Admin user management
-- **Photos Management** - Product and inventory photo management
-- **Branding/Customization** - Customizable branding options
-- **Multi-language** - English, French, and German support
-- **HATEOAS REST API** - Hypermedia-driven API design
-- **E2E Testing** - End-to-end testing with Playwright
-- **Docker Support** - Docker Compose for containerized deployment
-- **CI/CD** - Per-repo GitHub Actions pipelines
-- **Documentation** - MkDocs site with GitHub Pages
-- **QR Scanning** - Barcode scanning for quick product lookup
+### Catalogue and inventory
+
+- Products with SKUs, pricing, nested categories, reorder points, and photos
+- Locations and nested areas for warehouses, clients, suppliers, and stock in transit
+- Inventory quantities with batch, lot, and expiry information
+- Inventory adjustments plus a separate manual movement ledger; neither updates the other automatically
+- Client, supplier, and order records with validated order-status transitions
+- Product import through persisted background tasks, including CSV/Sortly-compatible input and optional assisted mapping
+
+### Teams and platform administration
+
+- Better Auth sessions with tenant-aware sign-in and host routing
+- User administration, custom roles, resource permissions, and feature entitlements
+- A platform console for tenant lifecycle, plan assignment, and feature overrides
+- Tenant branding and English, French, and German application translations
+- Best-effort audit metadata for selected tenant business mutations
+
+### Daily experience
+
+- An SSR web application with responsive inventory workflows
+- A dashboard for product, location, inventory, low-stock, movement, and order summaries
+- Low-stock filters and a backend pipeline for scheduled email notifications
+- Camera-based QR scanning where supported by the browser
+- An installable PWA manifest, runtime caching for fetched static assets, and an offline fallback page
+
+!!! important "What offline support means"
+    The shipped PWA support installs the web application, precaches the fallback/manifest/brand icons, and can cache fetched static assets. Successful navigation HTML and API requests are not cached for offline use. Inventory data, writes, background synchronization, and conflict resolution require a network connection.
+
+## Project shape
+
+Stocket is not a single Git repository. The `meta` repository assembles separate backend, frontend, package, desktop, documentation, and landing repositories into a local workspace. Infrastructure is maintained in its own repository. See the [project map](development/project-map.md) and [architecture guide](development/architecture.md) for ownership and runtime boundaries.
+
+CI validates the current backend and frontend, but those repositories do not publish or deploy application artifacts automatically after merge. A temporary manual-only July 2026 rollout did not create persistent CD. Package publication, documentation deployment, infrastructure apply, and desktop packaging each have separate workflows and controls. The [roadmap](roadmap.md#release-and-deployment-status) records the current boundary.

--- a/docs/reference/cli-commands.fr.md
+++ b/docs/reference/cli-commands.fr.md
@@ -1,205 +1,161 @@
 # Commandes CLI
 
-Référence de toutes les commandes disponibles en ligne de commande pour Stocket Inventory.
+Le checkout contient des dépôts indépendants. Exécutez chaque commande depuis le dépôt indiqué. L'espace pnpm généré à la racine facilite le développement local, mais ne définit pas les versions publiées.
 
-## Gestionnaire de paquets
-
-Toutes les commandes utilisent pnpm. Exécutez depuis la racine du repository ou utilisez le flag `--filter`.
-
-## Commandes Backend
-
-Utilisez `pnpm --filter @stocket/api <commande>` ou `cd backend && pnpm <commande>`.
-
-### Développement
+## Contrôleur d'espace (`meta`)
 
 ```bash
-# Démarrer le serveur de développement (Bun)
-pnpm --filter @stocket/api start
-
-# Build l'application (bun build)
-pnpm --filter @stocket/api build
-
-# Démarrer le serveur de production
-pnpm --filter @stocket/api start:prod
-```
-
-### Tests
-
-```bash
-# Exécuter les tests unitaires (Vitest)
-pnpm --filter @stocket/api test
-
-# Exécuter les tests en mode watch
-pnpm --filter @stocket/api test:watch
-
-# Exécuter les tests avec couverture
-pnpm --filter @stocket/api test:cov
-
-# Exécuter les tests d'intégration
-pnpm --filter @stocket/api test:integration
-```
-
-### Qualité du code
-
-```bash
-# Lint le code
-pnpm --filter @stocket/api lint
-
-# Formater le code avec Prettier
-pnpm --filter @stocket/api format
-
-# Vérification de types TypeScript
-pnpm --filter @stocket/api type-check
-```
-
-### Base de données
-
-```bash
-# Alimenter la base de données avec des données d'exemple
-pnpm --filter @stocket/api seed
-
-# Importer depuis Sortly
-pnpm --filter @stocket/api import:sortly
-```
-
-!!! note "Migrations"
-    Le schéma de la base de données est géré via Drizzle ORM. Les changements de schéma sont définis dans `backend/src/effect/platform/db/schema.ts` et appliqués automatiquement au démarrage en développement.
-
-## Commandes Frontend
-
-Utilisez `pnpm --filter @stocket/web <commande>` ou `cd frontend && pnpm <commande>`.
-
-### Développement
-
-```bash
-# Démarrer le serveur de développement (port 3000)
-pnpm --filter @stocket/web dev
-
-# Build pour la production
-pnpm --filter @stocket/web build
-
-# Démarrer le serveur de production
-pnpm --filter @stocket/web start
-```
-
-### Qualité du code
-
-```bash
-# Lint le code
-pnpm --filter @stocket/web lint
-
-# Lint et corriger
-pnpm --filter @stocket/web lint:fix
-
-# Vérification de types TypeScript
-pnpm --filter @stocket/web type-check
-
-# Exécuter toutes les validations (type-check + lint + format check)
-pnpm --filter @stocket/web validate
-
-# Prettier write + ESLint fix
-pnpm --filter @stocket/web check
-```
-
-### Tests
-
-```bash
-# Exécuter les tests E2E Playwright
-pnpm --filter @stocket/web test:e2e
-
-# Mode UI Playwright
-pnpm --filter @stocket/web test:e2e:ui
-
-# Tests en navigateur visible
-pnpm --filter @stocket/web test:e2e:headed
-```
-
-## Types partagés
-
-```bash
-# Générer les fichiers barrel
-pnpm --filter @stocket/types barrels
-
-# Build des types partagés
-pnpm --filter @stocket/types build
-```
-
-## Commandes du Workspace Meta
-
-Exécutez depuis le répertoire `meta/` :
-
-```bash
-# Synchroniser les dépôts + installer les dépendances
+# Cloner/mettre à jour, créer les liens racine, installer et construire les paquets
 ./scripts/bootstrap
 
-# Démarrer les serveurs de développement backend + frontend
+# Démarrer PostgreSQL, MinIO, l'API backend et le frontend
 ./scripts/dev
 
-# Démarrer également les services Docker (PostgreSQL, etc.)
-./scripts/dev --with-docker
+# Ajouter le shell desktop ou le watcher de documentation
+./scripts/dev --include-desktop
+./scripts/dev --include-docs
 
-# Synchroniser les dépôts depuis repos.yaml
+# Synchroniser uniquement les dépôts
 ./scripts/clone-or-update
-
-# Alternative : utiliser workspace.mjs directement
-node scripts/workspace.mjs sync
-node scripts/workspace.mjs bootstrap
-node scripts/workspace.mjs dev [--include-desktop] [--include-docs] [--with-docker]
 ```
 
-## Docker Compose
+L'espace actuel n'accepte que `--include-desktop` et `--include-docs`. PostgreSQL et MinIO sont lancés automatiquement via Docker lorsque celui-ci est disponible ; `--with-docker` est obsolète.
 
-Démarrer les services de développement (PostgreSQL) :
+Le processus standard ne lance pas le worker de tâches. Démarrez-le séparément depuis `backend` pour Smart Import.
+
+## Backend (`backend`)
 
 ```bash
-docker compose -f meta/docker-compose.yml up -d
+pnpm start                   # API via Infisical et tsx
+pnpm start:worker            # worker de tâches
+pnpm start:workspace         # API avec les services locaux
+pnpm build                   # bundle API + worker pour Node 22
+pnpm start:prod              # API construite
+pnpm start:prod:worker       # worker construit
+pnpm start:prod:infisical    # API construite via le lanceur Infisical configuré
+
+pnpm type-check
+pnpm lint
+pnpm lint:fix
+pnpm format
+
+pnpm test
+pnpm test:watch
+pnpm test:cov
+pnpm test:integration
+pnpm test:mutation:pure
+pnpm test:duplicates
 ```
 
-## Commandes Just
-
-Le backend et le frontend disposent d'un `justfile`. Nécessite le lanceur de commandes [`just`](https://github.com/casey/just).
+Données et opérations :
 
 ```bash
-# Installer les dépendances
-just bootstrap
-
-# Exporter les variables d'environnement avec Infisical CLI
-just env
-
-# Démarrer le serveur de développement
-just dev
-
-# Build pour la production
-just build
-
-# Exécuter les tests
-just test
+pnpm drizzle -- <arguments drizzle-kit>
+pnpm tenant:seed:workspace
+IMPORT_USER_ID=<uuid-utilisateur> pnpm import:products <produits-normalises.csv>
 ```
 
-!!!tip "Infisical CLI"
-    La commande `just env` exécute `infisical export --env=dev --format=dotenv > .env` pour générer les fichiers `.env` à partir des templates en utilisant Infisical CLI.
+`tenant:seed:workspace` remplace les données de démo du tenant sélectionné. Ciblez un tenant existant avec exactement un de `TENANT_ADMIN_TENANT_SLUG=<slug>` ou `TENANT_ADMIN_TENANT_ID=<uuid>` ; `TENANT_ADMIN_TENANT_HOSTNAME` peut remplacer son hôte principal. Sans cible, le script choisit l'unique tenant, demande un choix s'il y en a plusieurs, ou crée le tenant par défaut s'il n'y en a aucun. Vérifiez la cible avant toute exécution hors d'une base locale jetable.
 
-## Commandes Base de données
+`tenant-admin:seed:workspace` reste un alias de compatibilité ; préférez `tenant:seed:workspace`.
 
-Avec PostgreSQL en cours d'exécution :
+`superadmin:hash-password` lit stdin et imprime le hash Better Auth. Fournissez-le depuis une invite masquée de votre shell ; ne placez jamais le mot de passe littéral dans l'historique. Le seed est une opération explicite séparée, normalement via Infisical :
 
 ```bash
-# Se connecter à la base de données
-psql -h localhost -p 5432 -U postgres -d stocket_inventory
-
-# Vérifier le statut de la base
-pg_isready -h localhost -p 5432
+infisical run --env=dev -- pnpm exec tsx src/scripts/seed-superadmin.ts
 ```
 
-## Combinaisons utiles
+Configurez d'abord `SUPERADMIN_*`. Cette invocation CLI est distincte ; le démarrage API appelle la même fonction seulement si sa séquence de migration s'exécute et si `0000`/`0001` sont en attente. En production, la séquence est ignorée sauf avec `RUN_BETTER_AUTH_MIGRATIONS=true`.
+
+L'importeur CLI accepte un seul CSV produit déjà normalisé. `IMPORT_USER_ID` est obligatoire pour l'attribution ; `IMPORT_TENANT_ID`, `IMPORT_TENANT_NAME` et `IMPORT_TENANT_SLUG` peuvent remplacer le contexte tenant. La reconnaissance Sortly et la revue appartiennent au Smart Import web, pas à cette CLI.
+
+## Frontend (`frontend`)
 
 ```bash
-# Rebuild complet
-pnpm install && pnpm build
+pnpm dev
+pnpm build
+pnpm build:infisical         # build via le lanceur Infisical configuré
+pnpm start                   # serveur SSR construit
 
-# Vérification pré-commit
-pnpm lint && pnpm test && pnpm build
+pnpm validate                # type-check + lint + format
+pnpm type-check
+pnpm lint
+pnpm lint:fix
+pnpm format:check
+pnpm check                   # reformater et corriger le lint
 
-# Mettre à jour les types partagés après des changements backend
-pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+pnpm test:unit
+pnpm test:unit:watch
+pnpm test:e2e
+pnpm test:e2e:ui
+pnpm test:e2e:headed
 ```
+
+## Paquets partagés (`packages`)
+
+```bash
+pnpm build
+pnpm --filter @stocketfr/types barrels
+pnpm --filter @stocketfr/types build
+pnpm --filter @stocketfr/emails test
+
+pnpm changeset
+pnpm version:packages
+pnpm publish:prepare
+pnpm release
+```
+
+Changesets pilote les pull requests de version et GitHub Packages. Une évolution publiable ajoute un changeset ; les pull requests éligibles du même dépôt publient automatiquement des snapshots immuables. `version:packages` modifie versions/changelogs et `release` publie à l'extérieur : ce sont des opérations mainteneur/CI, pas des contrôles locaux ordinaires.
+
+## Desktop distant (`remote-desktop`)
+
+```bash
+pnpm dev
+pnpm build
+pnpm test
+pnpm lint
+```
+
+La publication Tauri est expérimentale et doit encore être réconciliée avec la sortie SSR du frontend avant d'être considérée comme supportée.
+
+## Documentation (`documentation`)
+
+```bash
+node scripts/audit-docs.mjs
+mkdocs serve
+mkdocs build --strict
+```
+
+Utilisez l'environnement virtuel Python 3.12 décrit dans le README du dépôt. Le
+shell Nix actuel ne fournit pas `mkdocs-static-i18n` de manière fiable ; il ne
+constitue donc pas encore le chemin de vérification reproductible. Les pull
+requests exécutent l'audit et la construction stricte. Les merges sur `main`
+répètent l'audit puis déploient avec `mkdocs gh-deploy` dans GitHub Actions.
+
+## Infrastructure (`infrastructure`)
+
+L'infrastructure reste volontairement hors de l'espace applicatif généré. Depuis ce dépôt :
+
+```bash
+terraform fmt -check -recursive
+terraform init
+terraform validate
+terraform plan
+
+ansible-galaxy collection install -r ansible/requirements.yml
+ansible-playbook -i localhost, -c local ansible/site.yml --syntax-check \
+  --extra-vars @ansible/syntax-check-vars.yml
+```
+
+Les apply/destroy de production exigent des identifiants protégés et une revue. Suivez le runbook du dépôt et sa protection contre la destruction.
+
+## Authentification GitHub Packages
+
+L'installation des paquets exige un token GitHub avec `read:packages` dans la configuration npm utilisateur :
+
+```ini
+@stocketfr:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Ne placez jamais le token dans un fichier du dépôt ni dans l'historique du shell.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1,208 +1,161 @@
 # CLI Commands
 
-Reference of all available command line commands for Stocket Inventory.
+The checkout contains independent repositories. Run each command from the repository named in its heading. The generated root pnpm workspace is useful for local navigation, but it is not the release boundary.
 
-## Package Manager
-
-All commands use pnpm. Run from the repository root or use the `--filter` flag.
-
-## Backend Commands
-
-Use `pnpm --filter @stocket/api <command>` or `cd backend && pnpm <command>`.
-
-### Development
+## Workspace controller (`meta`)
 
 ```bash
-# Start development server (Bun)
-pnpm --filter @stocket/api start
-
-# Build the application (bun build)
-pnpm --filter @stocket/api build
-
-# Start production server
-pnpm --filter @stocket/api start:prod
-```
-
-### Testing
-
-```bash
-# Run unit tests (Vitest)
-pnpm --filter @stocket/api test
-
-# Run tests in watch mode
-pnpm --filter @stocket/api test:watch
-
-# Run tests with coverage
-pnpm --filter @stocket/api test:cov
-
-# Run integration tests
-pnpm --filter @stocket/api test:integration
-```
-
-### Code Quality
-
-```bash
-# Lint code (oxlint)
-pnpm --filter @stocket/api lint
-
-# Lint with auto-fix
-pnpm --filter @stocket/api lint:fix
-
-# Format code with Prettier
-pnpm --filter @stocket/api format
-
-# TypeScript type check
-pnpm --filter @stocket/api type-check
-```
-
-### Database
-
-```bash
-# Seed the database with sample data
-pnpm --filter @stocket/api seed
-
-# Import from Sortly
-pnpm --filter @stocket/api import:sortly
-```
-
-!!! note "Migrations"
-    Database schema is managed via Drizzle ORM. Schema changes are defined in `backend/src/effect/platform/db/schema.ts` and applied automatically on startup in development.
-
-## Frontend Commands
-
-Use `pnpm --filter @stocket/web <command>` or `cd frontend && pnpm <command>`.
-
-### Development
-
-```bash
-# Start development server (port 3000)
-pnpm --filter @stocket/web dev
-
-# Build for production
-pnpm --filter @stocket/web build
-
-# Start production server
-pnpm --filter @stocket/web start
-```
-
-### Code Quality
-
-```bash
-# Lint code
-pnpm --filter @stocket/web lint
-
-# Lint and fix
-pnpm --filter @stocket/web lint:fix
-
-# TypeScript type check
-pnpm --filter @stocket/web type-check
-
-# Run all validations (type-check + lint + format check)
-pnpm --filter @stocket/web validate
-
-# Prettier write + ESLint fix
-pnpm --filter @stocket/web check
-```
-
-### Testing
-
-```bash
-# Run Playwright E2E tests
-pnpm --filter @stocket/web test:e2e
-
-# Playwright UI mode
-pnpm --filter @stocket/web test:e2e:ui
-
-# Headed browser tests
-pnpm --filter @stocket/web test:e2e:headed
-```
-
-## Shared Types
-
-```bash
-# Generate barrel files
-pnpm --filter @stocket/types barrels
-
-# Build shared types
-pnpm --filter @stocket/types build
-```
-
-## Meta Workspace Commands
-
-Run from the `meta/` directory:
-
-```bash
-# Sync repos + install dependencies
+# Clone/update managed repositories, create root links, install, and build packages
 ./scripts/bootstrap
 
-# Run backend + frontend dev servers
+# Start PostgreSQL, MinIO, backend API, and frontend
 ./scripts/dev
 
-# Also start Docker services (PostgreSQL, etc.)
-./scripts/dev --with-docker
+# Also include the desktop shell or documentation watcher
+./scripts/dev --include-desktop
+./scripts/dev --include-docs
 
-# Sync repos from repos.yaml
+# Repository synchronization only
 ./scripts/clone-or-update
-
-# Alternative: use workspace.mjs directly
-node scripts/workspace.mjs sync
-node scripts/workspace.mjs bootstrap
-node scripts/workspace.mjs dev [--include-desktop] [--include-docs] [--with-docker]
 ```
 
-## Docker Compose
+The current workspace accepts only `--include-desktop` and `--include-docs`. Docker-backed PostgreSQL and MinIO are attempted automatically when Docker is available; `--with-docker` is an obsolete flag.
 
-Start development services (PostgreSQL):
+The standard workspace process does not start the background task worker. Start it separately from `backend` for Smart Import jobs.
+
+## Backend (`backend`)
 
 ```bash
-docker compose -f meta/docker-compose.yml up -d
+pnpm start                   # API through Infisical and tsx
+pnpm start:worker            # background task worker
+pnpm start:workspace         # API with local workspace service overrides
+pnpm build                   # bundle API and worker for Node 22
+pnpm start:prod              # run built API
+pnpm start:prod:worker       # run built worker
+pnpm start:prod:infisical    # run built API through the configured Infisical launcher
+
+pnpm type-check
+pnpm lint
+pnpm lint:fix
+pnpm format
+
+pnpm test
+pnpm test:watch
+pnpm test:cov
+pnpm test:integration
+pnpm test:mutation:pure
+pnpm test:duplicates
 ```
 
-## Just Commands
-
-Both backend and frontend have a `justfile`. Requires the [`just`](https://github.com/casey/just) command runner.
+Data and operations:
 
 ```bash
-# Install dependencies
-just bootstrap
-
-# Export env vars with Infisical CLI
-just env
-
-# Run dev server
-just dev
-
-# Build for production
-just build
-
-# Run tests
-just test
+pnpm drizzle -- <drizzle-kit arguments>
+pnpm tenant:seed:workspace
+IMPORT_USER_ID=<user-uuid> pnpm import:products <normalized-products.csv>
 ```
 
-!!!tip "Infisical CLI"
-    The `just env` command runs `infisical export --env=dev --format=dotenv > .env` to generate `.env` files from templates using Infisical CLI.
+`tenant:seed:workspace` is destructive for the selected tenant's demo dataset. Target an existing tenant with exactly one of `TENANT_ADMIN_TENANT_SLUG=<slug>` or `TENANT_ADMIN_TENANT_ID=<uuid>`; `TENANT_ADMIN_TENANT_HOSTNAME` can replace its primary hostname. With no target, the script selects the only tenant, prompts when several exist, or creates the default tenant when none exist. Inspect the target before running it outside an expendable local database.
 
-## Database Commands
+`tenant-admin:seed:workspace` remains as a compatibility alias; prefer `tenant:seed:workspace`.
 
-With PostgreSQL running:
+`superadmin:hash-password` reads a password from stdin and prints its Better Auth hash. Feed it from a hidden prompt provided by your shell; never place a literal password in command history. Seeding is a separate explicit script operation, normally through Infisical:
 
 ```bash
-# Connect to database
-psql -h localhost -p 5432 -U postgres -d stocket_inventory
-
-# Check database status
-pg_isready -h localhost -p 5432
+infisical run --env=dev -- pnpm exec tsx src/scripts/seed-superadmin.ts
 ```
 
-## Useful Combinations
+Configure the `SUPERADMIN_*` values first. This CLI invocation is separate; API startup calls the same seed function only when its migration sequence runs and data migrations `0000`/`0001` are pending. Production skips that sequence unless `RUN_BETTER_AUTH_MIGRATIONS=true`.
+
+The CLI importer accepts one already-normalized product CSV. `IMPORT_USER_ID` is required for attribution; `IMPORT_TENANT_ID`, `IMPORT_TENANT_NAME`, and `IMPORT_TENANT_SLUG` can override its tenant request context. Sortly recognition and review belong to the web Smart Import flow, not this CLI.
+
+## Frontend (`frontend`)
 
 ```bash
-# Full rebuild
-pnpm install && pnpm build
+pnpm dev
+pnpm build
+pnpm build:infisical         # build through the configured Infisical launcher
+pnpm start                   # run the built SSR server
 
-# Pre-commit check
-pnpm lint && pnpm test && pnpm build
+pnpm validate                # type-check + lint + format check
+pnpm type-check
+pnpm lint
+pnpm lint:fix
+pnpm format:check
+pnpm check                   # rewrite formatting and apply lint fixes
 
-# Update shared types after backend changes
-pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+pnpm test:unit
+pnpm test:unit:watch
+pnpm test:e2e
+pnpm test:e2e:ui
+pnpm test:e2e:headed
 ```
+
+## Shared packages (`packages`)
+
+```bash
+pnpm build
+pnpm --filter @stocketfr/types barrels
+pnpm --filter @stocketfr/types build
+pnpm --filter @stocketfr/emails test
+
+pnpm changeset
+pnpm version:packages
+pnpm publish:prepare
+pnpm release
+```
+
+Changesets drive release pull requests and publication to GitHub Packages. Normal publishable work adds a changeset; eligible same-repository pull requests publish immutable snapshots automatically. `version:packages` mutates package versions/changelogs and `release` publishes externally, so they are maintainer/CI operations rather than routine local checks.
+
+## Remote desktop (`remote-desktop`)
+
+```bash
+pnpm dev
+pnpm build
+pnpm test
+pnpm lint
+```
+
+The Tauri release path is experimental and currently needs reconciliation with the SSR frontend output before it can be treated as a supported release command.
+
+## Documentation (`documentation`)
+
+```bash
+node scripts/audit-docs.mjs
+mkdocs serve
+mkdocs build --strict
+```
+
+Use the Python 3.12 virtual-environment setup in the repository README. The
+current Nix shell does not reliably provide `mkdocs-static-i18n`, so it is not
+the reproducible verification path yet. Pull requests run the audit and strict
+build. Merges to `main` repeat the audit and deploy with `mkdocs gh-deploy` in
+GitHub Actions.
+
+## Infrastructure (`infrastructure`)
+
+Infrastructure is intentionally outside the generated application workspace. Use Terraform and Ansible from that repository:
+
+```bash
+terraform fmt -check -recursive
+terraform init
+terraform validate
+terraform plan
+
+ansible-galaxy collection install -r ansible/requirements.yml
+ansible-playbook -i localhost, -c local ansible/site.yml --syntax-check \
+  --extra-vars @ansible/syntax-check-vars.yml
+```
+
+Production apply/destroy operations require protected credentials and review. Do not improvise them from this reference; follow the infrastructure repository runbook and destroy guard.
+
+## GitHub Packages authentication
+
+Package installs require a GitHub token with `read:packages` in the user-level npm configuration:
+
+```ini
+@stocketfr:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Keep the token out of repository files and shell history.

--- a/docs/reference/environment-variables.fr.md
+++ b/docs/reference/environment-variables.fr.md
@@ -1,136 +1,120 @@
 # Variables d'environnement
 
-Référence complète de toutes les variables d'environnement utilisées dans Stocket Inventory.
+Stocket utilise Infisical comme source opérationnelle des secrets. Les fichiers `backend/env.template` et `frontend/env.template` sont des inventaires de référence, pas des fichiers `.env` à valider. Dans chaque application, `pnpm start` passe par la CLI Infisical.
 
-## Backend API
+Ne validez jamais d'identifiants. Les valeurs de production sont rendues par le dépôt infrastructure et doivent être modifiées via le flux de gestion des secrets correspondant.
 
-Emplacement : `backend/.env`
+## API backend
 
-### Base de données
+### Cœur et hôtes
 
-| Variable | Requis | Description | Exemple |
-|----------|--------|-------------|---------|
-| `DATABASE_URL` | Oui* | Chaîne de connexion PostgreSQL complète | `postgresql://postgres:postgres@localhost:5432/stocket_inventory` |
-| `PGHOST` | Oui* | Hôte PostgreSQL | `localhost` |
-| `PGPORT` | Oui* | Port PostgreSQL | `5432` |
-| `PGUSER` | Oui* | Utilisateur PostgreSQL | `postgres` |
-| `PGPASSWORD` | Oui* | Mot de passe PostgreSQL | `postgres` |
-| `PGDATABASE` | Oui* | Nom de la base PostgreSQL | `stocket_inventory` |
+| Variable | Requise | Défaut/référence | Rôle |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Oui | aucun | URL de connexion PostgreSQL. |
+| `NODE_ENV` | Oui | référence : `development` | L'API accepte `development`, `staging` ou `production` ; le worker l'exige aussi. Les tests définissent leur propre contexte. |
+| `PORT` | API : oui | référence : `8080` | Port de l'API, entier de 1 à 65535. |
+| `TENANT_BASE_DOMAIN` | Oui | `stocket.fr` | Domaine parent utilisé pour résoudre les tenants. |
+| `PLATFORM_HOST` | Oui | `app.stocket.fr` | Hôte réservé à la console plateforme. |
+| `RESERVED_TENANT_SLUGS` | Non | liste intégrée | Slugs séparés par des virgules interdits aux tenants. |
+| `CORS_ORIGIN` | Oui | `http://localhost:3000` | Origines non vides séparées par des virgules. `*` est refusé en production (utilisez aussi des origines explicites en staging) ; les origines tenant vérifiées sont autorisées dynamiquement. |
+| `FRONTEND_URL` | Oui | `http://localhost:3000` | Origine(s) utilisées par l'authentification et les liens e-mail. |
 
-*Soit `DATABASE_URL` soit les variables `PG*` individuelles sont requises.
+En développement local, `localhost` est l'hôte plateforme et les tenants utilisent `<slug>.localhost:3000`.
 
-### Authentification
+### Authentification et scripts d'administration explicites
 
-| Variable | Requis | Description | Exemple |
-|----------|--------|-------------|---------|
-| `BETTER_AUTH_SECRET` | Oui | Chaîne aléatoire de 32+ octets pour la signature de session | `<sortie de openssl rand -base64 32>` |
-| `BETTER_AUTH_URL` | Oui | URL du serveur backend pour Better Auth | `http://localhost:8080` |
+| Variable | Requise | Rôle |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | Oui | Secret de signature Better Auth, fort et géré hors tests. |
+| `BETTER_AUTH_URL` | Oui | Origine publique du backend/auth, normalement `http://localhost:8080` en local. |
+| `BETTER_AUTH_COOKIE_DOMAIN` | Non | Surcharge explicite du domaine partagé ; sans elle, auth dérive si possible un suffixe commun auth/frontend. |
+| `RUN_BETTER_AUTH_MIGRATIONS` | Non (garde production) | En production, `true` active SQL commité, préparation des marqueurs, migration/réparation Better Auth et migrations superadmin en attente. Hors production, la séquence s'exécute automatiquement ; le nettoyage des hôtes reste propre au développement. |
+| `SUPERADMIN_EMAIL` | Migration/seed en attente | E-mail utilisé par les migrations de données en attente ou le script explicite. |
+| `SUPERADMIN_NAME` | Migration/seed en attente | Nom d'un compte nouvellement créé. |
+| `SUPERADMIN_PASSWORD` | Migration/seed en attente | Mot de passe en clair alternatif ; préférez le hash. |
+| `SUPERADMIN_PASSWORD_HASH` | Migration/seed en attente | Hash imprimé par `superadmin:hash-password`. |
+| `SUPERADMIN_ROTATE_PASSWORD` | Non | Autorise le seed explicite et la migration `0000` à remplacer le mot de passe ; `0001` force la rotation. |
+| `SUPERADMIN_ALLOW_TENANT_MEMBER` | Non | Doit valoir `true` pour promouvoir volontairement un compte déjà membre d'un tenant. |
 
-### Serveur
+Les valeurs superadmin sont consommées si les marqueurs de migration `0000_seed_platform_superadmin` ou `0001_reconcile_platform_superadmin_password` sont encore en attente ; la migration de réconciliation force la rotation. Elles servent aussi à l'exécution explicite de `src/scripts/seed-superadmin.ts`. Le seed tenant accepte `TENANT_ADMIN_EMAIL`, `TENANT_ADMIN_NAME`, `TENANT_ADMIN_PASSWORD` ou `TENANT_ADMIN_PASSWORD_HASH`, et `TENANT_ADMIN_ROTATE_PASSWORD`. Ciblez un tenant existant avec `TENANT_ADMIN_TENANT_ID` ou `TENANT_ADMIN_TENANT_SLUG` (jamais les deux) ; `TENANT_ADMIN_TENANT_HOSTNAME` définit éventuellement son hôte principal. Sans cible, il choisit l'unique tenant, demande parmi plusieurs, ou crée le tenant par défaut s'il n'en existe aucun. Il remplace les données de démo du tenant choisi.
 
-| Variable | Requis | Défaut | Description |
-|----------|--------|--------|-------------|
-| `PORT` | Non | `8080` | Port du serveur API |
-| `NODE_ENV` | Non | `development` | Mode d'environnement |
-| `CORS_ORIGIN` | Non | `http://localhost:3000` | Origine CORS autorisée |
-| `FRONTEND_URL` | Non | `http://localhost:3000` | URL du frontend pour les redirections |
+### Réglage de la connexion base
 
-### Exemple `.env`
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `DB_SSL` | `false` | Active TLS pour PostgreSQL. |
+| `DB_SSL_REJECT_UNAUTHORIZED` | `true` | Valide le certificat serveur lorsque TLS est actif. |
+| `DB_POOL_MAX` | `20` | Maximum positif par pool ; Better Auth et Drizzle créent chacun leur pool. |
 
-```bash
-# Base de données
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
+### E-mail et journalisation
 
-# Authentification
-BETTER_AUTH_SECRET=<chaîne aléatoire de 32+ octets>
-BETTER_AUTH_URL=http://localhost:8080
+| Variable | Requise | Défaut/référence | Rôle |
+| --- | --- | --- | --- |
+| `RESEND_API_KEY` | Staging/production | vide | Identifiant Resend. En développement/test, les e-mails sont journalisés. |
+| `EMAIL_FROM` | Staging/production | référence template : `Stocket <no-reply@mail.stocket.fr>` | Identité explicite. Le fallback développement/test est `Stocket <onboarding@resend.dev>`. |
+| `LOG_FORMAT` | Non | `text` | `text` ou `json` ; l'infrastructure utilise `json`. |
+| `LOG_LEVEL` | Non | défaut runtime | Seuil de logs Effect. |
+| `LOG_SQL` | Non | `off` | `off`, `summary` ou `full` ; évitez full autour de données sensibles. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Non | `http://localhost:4318/v1/traces` | Endpoint HTTP OTLP des traces. |
 
-# Serveur
-PORT=8080
-NODE_ENV=development
-CORS_ORIGIN=http://localhost:3000
-FRONTEND_URL=http://localhost:3000
-```
+### Stockage objet
 
-## Frontend Web
+Ces six réglages sont requis au démarrage de l'API et du worker dans la composition globale actuelle, même si la fonctionnalité immédiate n'utilise ni photo ni import.
 
-Emplacement : `frontend/.env`
+| Variable | Référence locale | Rôle |
+| --- | --- | --- |
+| `S3_ENDPOINT` | `http://localhost:9000` | Endpoint compatible S3. |
+| `S3_REGION` | `us-east-1` | Région du bucket. |
+| `S3_ACCESS_KEY_ID` | `minio` | Clé d'accès. |
+| `S3_SECRET_ACCESS_KEY` | `minio123` | Clé secrète. |
+| `S3_BUCKET` | `stocket-local` | Bucket existant. |
+| `S3_FORCE_PATH_STYLE` | `true` | Requis pour MinIO local ; généralement false en hébergé. |
 
-### API
+### Smart Import
 
-| Variable | Requis | Description | Exemple |
-|----------|--------|-------------|---------|
-| `VITE_API_BASE_URL` | Oui | URL de l'API backend | `http://localhost:8080/api/v1` |
+| Variable | Défaut | Rôle |
+| --- | --- | --- |
+| `PRODUCT_IMPORT_LLM_ENABLED` | `true` | Active la couche optionnelle de propositions IA. |
+| `OPENAI_API_KEY` | vide | Identifiant fournisseur. Vide, les propositions déterministes prennent le relais. |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Base d'une API compatible OpenAI. |
+| `PRODUCT_IMPORT_LLM_MODEL` | `gpt-5-mini` | Modèle de proposition. |
+| `PRODUCT_IMPORT_LLM_TIMEOUT_MS` | `15000` | Délai positif en millisecondes. |
 
-### Monitoring
+### Worker de tâches
 
-| Variable | Requis | Description | Exemple |
-|----------|--------|-------------|---------|
-| `VITE_SENTRY_DSN` | Non | DSN Sentry pour le suivi des erreurs | `https://xxx@sentry.io/xxx` |
-| `SENTRY_AUTH_TOKEN` | Non | Token d'authentification Sentry pour les source maps | `sntrys_xxx...` |
+L'API place les tâches durables dans PostgreSQL ; `pnpm start:worker` les exécute séparément. Le worker n'utilise pas auth, mais son graphe importe actuellement cette configuration avec empressement. Il exige donc `NODE_ENV`, `TENANT_BASE_DOMAIN`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` et `FRONTEND_URL` en plus de la base, du stockage et des tâches (plus l'e-mail de staging/production). `PLATFORM_HOST` n'est pas requis par le worker. Gardez les valeurs partagées alignées jusqu'à suppression de ce couplage.
 
-### Exemple `.env`
+| Variable | Défaut | Contrainte |
+| --- | ---: | --- |
+| `BACKGROUND_TASK_CONCURRENCY` | `4` | 1 à 32 tâches. |
+| `BACKGROUND_TASK_LEASE_MS` | `60000` | Durée de bail positive. |
+| `BACKGROUND_TASK_HEARTBEAT_MS` | `15000` | Doit être inférieure au bail. |
+| `BACKGROUND_TASK_POLL_MS` | `1000` | Intervalle d'attente positif. |
+| `BACKGROUND_TASK_RECOVERY_MS` | `30000` | Intervalle positif de récupération. |
+| `BACKGROUND_TASK_RETRY_DELAY_MS` | `30000` | Délai de nouvel essai positif. |
+| `BACKGROUND_TASK_PROGRESS_THROTTLE_MS` | `500` | Limitation positive des écritures de progression. |
 
-```bash
-# API
-VITE_API_BASE_URL=http://localhost:8080/api/v1
+## Runtime SSR frontend
 
-# Monitoring (optionnel)
-VITE_SENTRY_DSN=<dsn sentry>
-SENTRY_AUTH_TOKEN=<token auth sentry>
-```
+| Variable | Requise | Défaut/référence | Rôle |
+| --- | --- | --- | --- |
+| `INTERNAL_API_ORIGIN` | Oui | `http://localhost:8080` | Origine serveur-à-serveur pour le SSR et le proxy Vite. Le navigateur appelle toujours `/api/v1` sur la même origine. |
+| `WEB_URL` | Oui | `http://localhost:3000` | Origine web canonique. |
+| `TENANT_BASE_DOMAIN` | Oui | `stocket.fr` | Doit correspondre au modèle d'hôtes du backend. |
+| `PLATFORM_HOST` | Oui | `app.stocket.fr` | Doit correspondre à l'hôte plateforme backend. |
+| `TRUSTED_PROXY` | Non | vide | `1` uniquement derrière un proxy de confiance qui fixe les en-têtes forwarded. |
+| `PORT` | Non | `3000` | Port du serveur SSR de production. |
+| `HOST` | Non | `127.0.0.1` | Adresse d'écoute du serveur SSR. |
+| `VITE_CSP_NONCE` | Non | vide | Nonce optionnel de build compilé via `import.meta.env` et transmis au routeur. |
 
-## Configuration des fichiers d'environnement
+Le chemin actuel des requêtes n'utilise pas `VITE_API_BASE_URL`.
 
-**Backend :**
+## Réglages réservés aux tests
 
-```bash
-cp backend/.env.template backend/.env
-```
+- Les tests d'intégration backend utilisent `TEST_DATABASE_URL` s'il est fourni.
+- Le smoke test optionnel contre un vrai MinIO ne s'exécute qu'avec `RUN_MINIO_STORAGE_SMOKE=true` et un service accessible.
+- La requête de seed E2E envoie `x-e2e-seed-secret`. Le développement l'autorise sans secret configuré ; les autres environnements hors production exigent un `E2E_SEED_SECRET` correspondant ; la production désactive toujours l'endpoint.
+- Le seed E2E backend reconnaît `E2E_DATABASE_URL`, `E2E_TENANT_SLUG`, `E2E_TENANT_NAME`, `E2E_TENANT_HOSTNAME` et `E2E_USER_EMAIL`.
+- Les tests frontend utilisent `E2E_FRONTEND_ORIGIN` (référence : `http://e2e.localhost:3000`) et les variables définies par Playwright et le workflow CI.
 
-**Frontend :**
-
-```bash
-echo "VITE_API_BASE_URL=http://localhost:8080/api/v1" > frontend/.env
-```
-
-!!!tip "Infisical CLI"
-    Les deux dépôts disposent d'un `justfile` avec une tâche `env` utilisant Infisical CLI :
-    ```bash
-    cd backend && just env
-    cd frontend && just env
-    ```
-    Ceci exécute `infisical export --env=dev --format=dotenv > .env` pour injecter les secrets depuis Infisical.
-
-## Secrets CI/CD
-
-Secrets GitHub Actions requis pour la CI/CD :
-
-| Secret | Description |
-|--------|-------------|
-| `BETTER_AUTH_SECRET` | Secret Better Auth pour les tests CI |
-
-## Déploiement de la documentation
-
-La documentation est déployée via GitHub Pages :
-
-- **URL du site :** https://stocketfr.github.io/documentation/
-- **Dépôt :** https://github.com/stocketfr/documentation
-
-## Considérations de production
-
-### Sécurité
-
-- Ne jamais committer les fichiers `.env`
-- Utiliser la gestion de secrets en production
-- Faire une rotation des clés régulièrement
-
-### Better Auth
-
-- Utiliser un `BETTER_AUTH_SECRET` fort et unique en production (32+ octets aléatoires)
-- Définir `BETTER_AUTH_URL` vers l'URL de votre backend de production
-
-### Base de données
-
-- Utiliser le connection pooling en production
-- Activer SSL pour les connexions à la base de données
+Les identifiants de test et valeurs de seed ne doivent jamais être réutilisés en environnement déployé.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,136 +1,120 @@
 # Environment Variables
 
-Complete reference of all environment variables used in Stocket Inventory.
+Stocket uses Infisical as the operational source of secrets. The `backend/env.template` and `frontend/env.template` files are reference inventories; they are not intended to become committed `.env` files. `pnpm start` in each application runs through the Infisical CLI.
+
+Never commit credentials. Production values are rendered by the infrastructure repository and must be changed through the corresponding secret-management workflow.
 
 ## Backend API
 
-Location: `backend/.env`
+### Core and hosts
 
-### Database
+| Variable | Required | Default/reference | Purpose |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Yes | none | PostgreSQL connection URL. |
+| `NODE_ENV` | Yes | reference: `development` | API accepts `development`, `staging`, or `production`; the worker also requires it. Test runners set their own test-like context. |
+| `PORT` | API: yes | reference: `8080` | API listen port, integer from 1 to 65535. |
+| `TENANT_BASE_DOMAIN` | Yes | `stocket.fr` | Parent domain used to resolve tenant hosts. |
+| `PLATFORM_HOST` | Yes | `app.stocket.fr` | Host reserved for the platform console. |
+| `RESERVED_TENANT_SLUGS` | No | built-in list | Comma-separated slugs that cannot become tenants. |
+| `CORS_ORIGIN` | Yes | `http://localhost:3000` | Non-empty comma-separated browser origins. `*` is rejected in production (use explicit origins in staging too); verified tenant origins are also allowed dynamically. |
+| `FRONTEND_URL` | Yes | `http://localhost:3000` | One or more comma-separated web origins used by auth and email links. |
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `DATABASE_URL` | Yes* | Full PostgreSQL connection string | `postgresql://postgres:postgres@localhost:5432/stocket_inventory` |
-| `PGHOST` | Yes* | PostgreSQL host | `localhost` |
-| `PGPORT` | Yes* | PostgreSQL port | `5432` |
-| `PGUSER` | Yes* | PostgreSQL user | `postgres` |
-| `PGPASSWORD` | Yes* | PostgreSQL password | `postgres` |
-| `PGDATABASE` | Yes* | PostgreSQL database name | `stocket_inventory` |
+In local development, `localhost` is the platform host and tenants use `<slug>.localhost:3000`.
 
-*Either `DATABASE_URL` or individual `PG*` variables are required.
+### Authentication and explicit administration scripts
 
-### Authentication
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | Yes | Better Auth signing secret. Use a strong managed value outside tests. |
+| `BETTER_AUTH_URL` | Yes | Public backend/auth origin, normally `http://localhost:8080` locally. |
+| `BETTER_AUTH_COOKIE_DOMAIN` | No | Explicit shared cookie-domain override; without it, auth derives a shared auth/frontend suffix when possible. |
+| `RUN_BETTER_AUTH_MIGRATIONS` | No (production gate) | In production, `true` enables committed SQL, data-marker preparation, Better Auth migration/repair, and pending superadmin data migrations. Non-production runs the sequence automatically; hostname cleanup is development-only. |
+| `SUPERADMIN_EMAIL` | Pending migration/seed | Platform administrator email for pending startup data migrations or the explicit seed script. |
+| `SUPERADMIN_NAME` | Pending migration/seed | Display name for a newly created account. |
+| `SUPERADMIN_PASSWORD` | Pending migration/seed | Plain password alternative; prefer the hash setting. |
+| `SUPERADMIN_PASSWORD_HASH` | Pending migration/seed | Hash printed by `superadmin:hash-password`. |
+| `SUPERADMIN_ROTATE_PASSWORD` | No | Lets explicit seed and migration `0000` replace an existing credential password; migration `0001` forces rotation regardless. |
+| `SUPERADMIN_ALLOW_TENANT_MEMBER` | No | Must be `true` to deliberately promote an account that already has a tenant membership. |
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `BETTER_AUTH_SECRET` | Yes | Random 32+ byte string for session signing | `<output of openssl rand -base64 32>` |
-| `BETTER_AUTH_URL` | Yes | Backend server URL for Better Auth | `http://localhost:8080` |
+The superadmin values are consumed when startup data-migration markers `0000_seed_platform_superadmin` or `0001_reconcile_platform_superadmin_password` are still pending; the reconcile migration forces password rotation. They are also consumed by an explicit `src/scripts/seed-superadmin.ts` run. The workspace tenant seed accepts `TENANT_ADMIN_EMAIL`, `TENANT_ADMIN_NAME`, `TENANT_ADMIN_PASSWORD` or `TENANT_ADMIN_PASSWORD_HASH`, and `TENANT_ADMIN_ROTATE_PASSWORD`. Select an existing target with either `TENANT_ADMIN_TENANT_ID` or `TENANT_ADMIN_TENANT_SLUG` (never both); `TENANT_ADMIN_TENANT_HOSTNAME` optionally sets its primary hostname. Without a target it chooses the only tenant, prompts among several, or creates the default tenant when none exist. It replaces demo data for the selected tenant.
 
-### Server
+### Database connection tuning
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `PORT` | No | `8080` | API server port |
-| `NODE_ENV` | No | `development` | Environment mode |
-| `CORS_ORIGIN` | No | `http://localhost:3000` | Allowed CORS origin |
-| `FRONTEND_URL` | No | `http://localhost:3000` | Frontend URL for redirects |
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DB_SSL` | `false` | Enables PostgreSQL TLS. |
+| `DB_SSL_REJECT_UNAUTHORIZED` | `true` | Validates the server certificate when TLS is enabled. |
+| `DB_POOL_MAX` | `20` | Positive maximum per connection pool; Better Auth and Drizzle each create a pool. |
 
-### Example `.env`
+### Email and logging
 
-```bash
-# Database
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stocket_inventory
+| Variable | Required | Default/reference | Purpose |
+| --- | --- | --- | --- |
+| `RESEND_API_KEY` | Staging/production | empty | Resend credential. In development/test, mail is logged instead. |
+| `EMAIL_FROM` | Staging/production | template reference: `Stocket <no-reply@mail.stocket.fr>` | Explicit sender identity. Development/test fallback is `Stocket <onboarding@resend.dev>`. |
+| `LOG_FORMAT` | No | `text` | `text` or `json`; infrastructure uses `json`. |
+| `LOG_LEVEL` | No | runtime default | Effect log threshold. |
+| `LOG_SQL` | No | `off` | `off`, `summary`, or `full`. Avoid full SQL around sensitive data. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | `http://localhost:4318/v1/traces` | OTLP HTTP trace endpoint. |
 
-# Authentication
-BETTER_AUTH_SECRET=<random 32+ byte string>
-BETTER_AUTH_URL=http://localhost:8080
+### Object storage
 
-# Server
-PORT=8080
-NODE_ENV=development
-CORS_ORIGIN=http://localhost:3000
-FRONTEND_URL=http://localhost:3000
-```
+All six settings are startup requirements for both API and worker in the current global layer composition, even when the immediate feature does not use photos/imports.
 
-## Frontend Web
+| Variable | Local reference | Purpose |
+| --- | --- | --- |
+| `S3_ENDPOINT` | `http://localhost:9000` | S3-compatible endpoint. |
+| `S3_REGION` | `us-east-1` | Bucket region. |
+| `S3_ACCESS_KEY_ID` | `minio` | Access key. |
+| `S3_SECRET_ACCESS_KEY` | `minio123` | Secret key. |
+| `S3_BUCKET` | `stocket-local` | Existing bucket name. |
+| `S3_FORCE_PATH_STYLE` | `true` | Required for local MinIO; normally false for hosted object storage. |
 
-Location: `frontend/.env`
+### Smart Import
 
-### API
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PRODUCT_IMPORT_LLM_ENABLED` | `true` | Enables the optional AI proposal layer. |
+| `OPENAI_API_KEY` | empty | Provider credential. Empty uses deterministic fallback proposals. |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API base URL. |
+| `PRODUCT_IMPORT_LLM_MODEL` | `gpt-5-mini` | Proposal model. |
+| `PRODUCT_IMPORT_LLM_TIMEOUT_MS` | `15000` | Positive request timeout in milliseconds. |
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `VITE_API_BASE_URL` | Yes | Backend API URL | `http://localhost:8080/api/v1` |
+### Background task worker
 
-### Monitoring
+The API enqueues durable tasks in PostgreSQL; `pnpm start:worker` executes them separately. The worker does not use auth, but its current entry graph eagerly imports shared auth configuration. It therefore needs `NODE_ENV`, `TENANT_BASE_DOMAIN`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `FRONTEND_URL` in addition to database, storage, and task settings (plus staging/production email requirements). `PLATFORM_HOST` is not a worker requirement. Keep shared values aligned until that import coupling is removed.
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `VITE_SENTRY_DSN` | No | Sentry DSN for error tracking | `https://xxx@sentry.io/xxx` |
-| `SENTRY_AUTH_TOKEN` | No | Sentry auth token for source maps | `sntrys_xxx...` |
+| Variable | Default | Constraint |
+| --- | ---: | --- |
+| `BACKGROUND_TASK_CONCURRENCY` | `4` | 1–32 tasks. |
+| `BACKGROUND_TASK_LEASE_MS` | `60000` | Positive lease duration. |
+| `BACKGROUND_TASK_HEARTBEAT_MS` | `15000` | Must be shorter than the lease. |
+| `BACKGROUND_TASK_POLL_MS` | `1000` | Positive idle poll interval. |
+| `BACKGROUND_TASK_RECOVERY_MS` | `30000` | Positive abandoned-task recovery interval. |
+| `BACKGROUND_TASK_RETRY_DELAY_MS` | `30000` | Positive retry delay. |
+| `BACKGROUND_TASK_PROGRESS_THROTTLE_MS` | `500` | Positive progress-write throttle. |
 
-### Example `.env`
+## Frontend SSR runtime
 
-```bash
-# API
-VITE_API_BASE_URL=http://localhost:8080/api/v1
+| Variable | Required | Default/reference | Purpose |
+| --- | --- | --- | --- |
+| `INTERNAL_API_ORIGIN` | Yes | `http://localhost:8080` | Server-to-server API origin used by SSR and the Vite proxy. Browsers still call same-origin `/api/v1`. |
+| `WEB_URL` | Yes | `http://localhost:3000` | Canonical web origin. |
+| `TENANT_BASE_DOMAIN` | Yes | `stocket.fr` | Must match the backend host model. |
+| `PLATFORM_HOST` | Yes | `app.stocket.fr` | Must match the backend platform host. |
+| `TRUSTED_PROXY` | No | empty | Set to `1` only behind a trusted proxy that sets forwarded host/protocol headers. |
+| `PORT` | No | `3000` | Production SSR listen port. |
+| `HOST` | No | `127.0.0.1` | Production SSR bind address. |
+| `VITE_CSP_NONCE` | No | empty | Optional build-time nonce compiled through `import.meta.env` and forwarded into the router. |
 
-# Monitoring (optional)
-VITE_SENTRY_DSN=<sentry dsn>
-SENTRY_AUTH_TOKEN=<sentry auth token>
-```
+There is no `VITE_API_BASE_URL` in the current request path.
 
-## Setting Up Environment Files
+## Test-only settings
 
-**Backend:**
+- Backend integration tests use `TEST_DATABASE_URL` when supplied.
+- The optional real-MinIO storage smoke suite runs only with `RUN_MINIO_STORAGE_SMOKE=true` and a reachable service.
+- The E2E seed request sends `x-e2e-seed-secret`. Development permits the seed without a configured secret; other non-production environments require a configured matching `E2E_SEED_SECRET`; production always disables the endpoint.
+- Backend E2E seeding recognizes `E2E_DATABASE_URL`, `E2E_TENANT_SLUG`, `E2E_TENANT_NAME`, `E2E_TENANT_HOSTNAME`, and `E2E_USER_EMAIL`.
+- Frontend tests use `E2E_FRONTEND_ORIGIN` (reference: `http://e2e.localhost:3000`) plus the variables defined by its Playwright setup and CI workflow.
 
-```bash
-cp backend/.env.template backend/.env
-```
-
-**Frontend:**
-
-```bash
-echo "VITE_API_BASE_URL=http://localhost:8080/api/v1" > frontend/.env
-```
-
-!!!tip "Infisical CLI"
-    Both repos have a `justfile` with a `env` task that uses Infisical CLI:
-    ```bash
-    cd backend && just env
-    cd frontend && just env
-    ```
-    This runs `infisical export --env=dev --format=dotenv > .env` to populate secrets from Infisical.
-
-## CI/CD Secrets
-
-GitHub Actions secrets required for CI/CD:
-
-| Secret | Description |
-|--------|-------------|
-| `BETTER_AUTH_SECRET` | Better Auth secret for CI tests |
-
-## Documentation Deployment
-
-Documentation is deployed via GitHub Pages:
-
-- **Site URL:** https://stocketfr.github.io/documentation/
-- **Repo:** https://github.com/stocketfr/documentation
-
-## Production Considerations
-
-### Security
-
-- Never commit `.env` files
-- Use secrets management in production
-- Rotate keys regularly
-
-### Better Auth
-
-- Use a strong, unique `BETTER_AUTH_SECRET` in production (32+ random bytes)
-- Set `BETTER_AUTH_URL` to your production backend URL
-
-### Database
-
-- Use connection pooling in production
-- Enable SSL for database connections
+Test credentials and seed-only values must not be reused in deployed environments.

--- a/docs/reference/index.fr.md
+++ b/docs/reference/index.fr.md
@@ -1,28 +1,27 @@
 # Référence
 
-Documentation de référence technique pour Stocket Inventory.
+Cette section rassemble les réglages d'exécution, les commandes des dépôts et les diagnostics rapides.
 
-## Contenu
+## Référence d'exécution
 
-- [Variables d'environnement](environment-variables.md) - Toutes les options de configuration
-- [Commandes CLI](cli-commands.md) - Commandes disponibles en ligne de commande
-- [Dépannage](troubleshooting.md) - Problèmes courants et solutions
+- [Variables d'environnement](environment-variables.md) décrit les réglages du backend, du worker, du web, du stockage et des tests.
+- [Commandes CLI](cli-commands.md) répertorie les commandes par dépôt. Exécutez-les depuis le dépôt indiqué sauf mention contraire.
+- [Dépannage](troubleshooting.md) couvre les problèmes les plus courants de l'espace de travail local.
 
-## Liens rapides
+## API et contrats
 
-### Documentation API
+Les routes applicatives sont sous `/api/v1`, préfixe qui comprend surfaces tenant, plateforme/superadmin, opérationnelles et de test hors production. Better Auth est sous `/api/auth`. Swagger UI sur `/docs` ne décrit actuellement que la santé. Les routeurs montés sont la vérité runtime et leurs schémas `@stocketfr/types` correspondants définissent les payloads. Tout schéma exporté n'est pas monté : fulfillment reste par exemple un prototype.
 
-L'API est documentée via Swagger UI :
+Les applications installent les paquets publiés depuis GitHub Packages :
 
-- **Local :** http://localhost:8080/api/docs
-- **OpenAPI JSON :** http://localhost:8080/api/docs-json
-
-### Types partagés
-
-Les interfaces/enums DTO partagés vivent dans `packages/types` :
-
-```bash
-pnpm --filter @stocket/types build
+```json
+{
+  "dependencies": {
+    "@stocket/types": "npm:@stocketfr/types@1.8.0"
+  }
+}
 ```
 
-Les types sont dans `packages/types/src/`.
+`@stocket/types` est l'alias côté consommateur. Dans le dépôt packages, les commandes utilisent le nom publié, par exemple `pnpm --filter @stocketfr/types build`.
+
+Pour les responsabilités et frontières d'exécution de chaque dépôt et module, consultez la [carte des projets et modules](../development/project-map.md).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,28 +1,27 @@
 # Reference
 
-Technical reference documentation for Stocket Inventory.
+Use this section when you need the exact runtime settings, repository commands, or a quick diagnosis.
 
-## Contents
+## Runtime reference
 
-- [Environment Variables](environment-variables.md) - All configuration options
-- [CLI Commands](cli-commands.md) - Available command line commands
-- [Troubleshooting](troubleshooting.md) - Common issues and solutions
+- [Environment variables](environment-variables.md) lists the backend, worker, web, storage, and test settings.
+- [CLI commands](cli-commands.md) lists commands by repository. Run them from the named repository unless stated otherwise.
+- [Troubleshooting](troubleshooting.md) covers the failures most often seen in the local workspace.
 
-## Quick Links
+## API and contracts
 
-### API Documentation
+Application routes are served below `/api/v1`; that prefix includes tenant, platform/superadmin, operational, and non-production test surfaces. Better Auth is below `/api/auth`. Swagger UI at `/docs` currently describes only health. Mounted backend routers are the runtime source of truth, and their matching `@stocketfr/types` schemas define payload contracts. Not every exported schema is mounted—for example, fulfillment remains a prototype.
 
-The API is documented via Swagger UI:
+Applications install the published packages through GitHub Packages:
 
-- **Local:** http://localhost:8080/api/docs
-- **OpenAPI JSON:** http://localhost:8080/api/docs-json
-
-### Shared Types
-
-Shared DTO interfaces/enums live in `packages/types`:
-
-```bash
-pnpm --filter @stocket/types build
+```json
+{
+  "dependencies": {
+    "@stocket/types": "npm:@stocketfr/types@1.8.0"
+  }
+}
 ```
 
-Types are authored in `packages/types/src/`.
+`@stocket/types` is the local consumer alias. Commands inside the packages repository must use the publisher name, for example `pnpm --filter @stocketfr/types build`.
+
+For the ownership and runtime boundary of every repository and module, see the [project and module map](../development/project-map.md).

--- a/docs/reference/troubleshooting.fr.md
+++ b/docs/reference/troubleshooting.fr.md
@@ -1,243 +1,138 @@
 # Dépannage
 
-Solutions aux problèmes courants lors du travail avec Stocket Inventory.
+Commencez par le processus qui possède la frontière défaillante. Le contrôleur d'espace coordonne les dépôts, mais backend, worker, frontend, PostgreSQL et MinIO conservent leurs propres logs et états de santé.
 
-## Environnement de développement
+## Bootstrap n'installe pas `@stocketfr/*`
 
-### Le shell Nix ne démarre pas
+Les paquets partagés sont hébergés dans GitHub Packages.
 
-**Symptôme :** `nix develop` échoue ou se bloque
+1. Créez ou renouvelez un token GitHub avec `read:packages`.
+2. Configurez le registre `@stocketfr` et le token dans la configuration npm utilisateur.
+3. Relancez `pnpm install` dans le dépôt concerné ou `./meta/scripts/bootstrap`.
 
-**Solutions :**
+Ne placez pas le token dans un `.npmrc` du dépôt.
 
-1. Vérifier l'installation de Nix :
-   ```bash
-   nix --version
-   ```
+## Mauvaise version de Node ou du gestionnaire
 
-2. S'assurer que les flakes sont activés dans votre configuration Nix (`~/.config/nix/nix.conf`) :
-   ```
-   experimental-features = nix-command flakes
-   ```
-
-3. Essayer d'entrer dans le shell depuis le répertoire du dépôt spécifique :
-   ```bash
-   cd backend && nix develop
-   ```
-
-### Les services Docker ne démarrent pas
-
-**Symptôme :** `docker compose -f meta/docker-compose.yml up -d` échoue
-
-**Solutions :**
-
-1. Vérifier que Docker est en cours d'exécution :
-   ```bash
-   docker info
-   ```
-
-2. Vérifier les conflits de ports :
-   ```bash
-   lsof -i :5432
-   ```
-
-3. Réinitialiser les conteneurs Docker :
-   ```bash
-   docker compose -f meta/docker-compose.yml down -v
-   docker compose -f meta/docker-compose.yml up -d
-   ```
-
-### Port déjà utilisé
-
-**Symptôme :** Erreur "Address already in use"
-
-**Solutions :**
+Le backend et le frontend ciblent Node.js 22 et pnpm 10.28. Les autres dépôts
+conservent leurs propres versions ; certains workflows des paquets et du desktop
+utilisent encore Node.js 20. Vérifiez le dépôt propriétaire avant de les modifier :
 
 ```bash
-# Trouver le processus utilisant le port
-lsof -i :8080  # ou :3000, :5432
-
-# Tuer le processus
-kill -9 <PID>
+node --version
+pnpm --version
 ```
 
-### Les dépendances ne s'installent pas
+Entrez dans le shell Nix du dépôt ou activez Corepack si nécessaire. Bun n'est pas le runtime backend.
 
-**Symptôme :** `pnpm install` échoue
+## PostgreSQL ou MinIO ne démarre pas
 
-**Solutions :**
-
-1. Vider le cache pnpm :
-   ```bash
-   pnpm store prune
-   rm -rf node_modules
-   pnpm install
-   ```
-
-2. Vérifier la version de Node.js :
-   ```bash
-   node --version  # Doit être 20+
-   ```
-
-## Problèmes de base de données
-
-### Impossible de se connecter à PostgreSQL
-
-**Symptôme :** Erreurs de connexion refusée
-
-**Solutions :**
-
-1. Vérifier si PostgreSQL est en cours d'exécution :
-   ```bash
-   pg_isready -h localhost -p 5432
-   ```
-
-2. Démarrer PostgreSQL via Docker Compose :
-   ```bash
-   docker compose -f meta/docker-compose.yml up -d
-   ```
-
-3. Vérifier les variables d'environnement dans `backend/.env`
-
-### Erreurs de migration ou de schéma
-
-**Symptôme :** Erreurs Drizzle ORM concernant des tables ou colonnes manquantes
-
-**Solutions :**
-
-1. Redémarrer le serveur API — les changements de schéma sont appliqués automatiquement en développement :
-   ```bash
-   cd backend && pnpm start
-   ```
-
-2. Vérifier que la base de données existe :
-   ```bash
-   psql -h localhost -U postgres -c '\l'
-   ```
-
-3. Vérifier les définitions de schéma dans `backend/src/effect/platform/db/schema.ts`
-
-## Problèmes API
-
-### Erreurs d'authentification Better Auth
-
-**Symptôme :** Erreurs 401 Unauthorized
-
-**Solutions :**
-
-1. Vérifier que `BETTER_AUTH_SECRET` est défini dans `backend/.env` (doit être 32+ octets aléatoires)
-2. Vérifier que `BETTER_AUTH_URL` est correctement défini (ex : `http://localhost:8080`)
-3. Vérifier que le token est envoyé :
-   ```bash
-   # La requête doit inclure :
-   # Authorization: Bearer <token>
-   ```
-4. Essayer de régénérer le secret :
-   ```bash
-   openssl rand -base64 32
-   ```
-   Mettre à jour `BETTER_AUTH_SECRET` dans `backend/.env` et redémarrer le serveur.
-
-### Échec du build des types partagés
-
-**Symptôme :** Le build de `@stocket/types` échoue
-
-**Solutions :**
-
-1. Build l'API d'abord :
-   ```bash
-   pnpm --filter @stocket/api build
-   ```
-
-2. Vérifier les erreurs TypeScript :
-   ```bash
-   pnpm --filter @stocket/api type-check
-   ```
-
-## Problèmes Frontend
-
-### Erreurs de types du client API
-
-**Symptôme :** Erreurs TypeScript dans les hooks écrits à la main ou les types partagés
-
-**Solutions :**
-
-1. Rebuild des types partagés après les changements API :
-   ```bash
-   pnpm --filter @stocket/types barrels
-   pnpm --filter @stocket/types build
-   ```
-
-### Erreurs d'hydratation
-
-**Symptôme :** Avertissements de mismatch d'hydratation React
-
-**Solutions :**
-
-1. S'assurer que le rendu client/serveur correspond
-2. Éviter le code navigateur au niveau module côté SSR
-3. Reporter les APIs navigateur dans des effets ou guards
-
-### Les traductions ne fonctionnent pas
-
-**Symptôme :** Clés de traduction affichées au lieu du texte
-
-**Solutions :**
-
-1. Vérifier que les fichiers de locale existent dans `frontend/src/locales/`
-2. Vérifier la configuration i18n
-3. Vérifier le préfixe de langue dans l'URL
-
-## Problèmes de build
-
-### Erreurs TypeScript
-
-**Symptôme :** Le build échoue avec des erreurs de type
-
-**Solutions :**
+`./meta/scripts/dev` tente de démarrer les deux services lorsque Docker est disponible.
 
 ```bash
-# Vérifier un module spécifique
-pnpm --filter @stocket/api type-check
-pnpm --filter @stocket/web type-check
+docker compose -f meta/docker-compose.yml ps
+docker compose -f meta/docker-compose.yml logs postgres minio minio-init
 ```
 
-### Erreurs ESLint
+Vérifiez les ports 5432, 9000 et 9001, puis que l'initialisation du bucket est terminée avant de diagnostiquer les photos/imports.
 
-**Symptôme :** La commande lint échoue
+!!! danger
+    `docker compose down -v` supprime les volumes PostgreSQL et les objets locaux. Ne l'utilisez pas comme simple redémarrage.
 
-**Solutions :**
+## L'API ou le worker échoue pendant l'initialisation du stockage
+
+Le layer de stockage global vérifie le bucket au démarrage : un stockage invalide
+ou inaccessible empêche normalement l'API et le worker de démarrer. Toutes les
+valeurs `S3_*` doivent être présentes, l'endpoint doit être une URL valide et le
+bucket doit déjà exister. MinIO local exige normalement
+`S3_FORCE_PATH_STYLE=true`. Comparez Infisical à `backend/env.template` ;
+modifier un `.env` local ne change pas `pnpm start` sans modification volontaire
+du lanceur.
+
+## Loggle signale un script frontend absent
+
+Le `meta/.loggle.toml` actuel invoque `@stocket/web dev:workspace`, mais ce
+script n'existe pas dans le dépôt frontend. Lorsque Loggle est installé,
+démarrez PostgreSQL et MinIO via `meta/docker-compose.yml`, puis
+`pnpm start:workspace` dans `backend` et `pnpm dev` dans `frontend`. Le lanceur
+direct de meta utilise déjà le bon script, mais `./meta/scripts/dev` choisit
+automatiquement Loggle lorsqu'il est installé et qu'aucun processus optionnel
+n'est demandé.
+
+## Une route tenant redirige ou renvoie « tenant introuvable »
+
+- Utilisez `http://localhost:3000` pour la console plateforme.
+- Utilisez `http://<slug>.localhost:3000` pour un tenant.
+- Vérifiez le slug dans la console plateforme. Créez-y un tenant manquant ; le seed cible des tenants existants et ne crée que le tenant par défaut lorsque la base n'en contient aucun.
+- Vérifiez que l'utilisateur connecté est membre du tenant. L'inscription publique ne provisionne pas actuellement cette appartenance.
+- Alignez `TENANT_BASE_DOMAIN` et `PLATFORM_HOST` entre frontend et backend.
+
+## Les cookies de connexion échouent via SSR ou proxy
+
+Le navigateur appelle `/api/auth` et `/api/v1` sur la même origine ; le SSR transmet cookie, hôte et protocole à `INTERNAL_API_ORIGIN`.
+
+- Vérifiez que `INTERNAL_API_ORIGIN` atteint le backend depuis le frontend.
+- Définissez `TRUSTED_PROXY=1` uniquement derrière un proxy de confiance qui fournit les en-têtes forwarded.
+- Vérifiez ensemble `BETTER_AUTH_URL`, `FRONTEND_URL`, CORS et le domaine de cookie éventuel.
+- N'ajoutez pas `VITE_API_BASE_URL`, inutilisé dans l'architecture actuelle.
+
+## Smart Import reste en attente
+
+L'API ne fait qu'enregistrer la tâche durable dans PostgreSQL. Lancez le worker séparé :
 
 ```bash
-# Auto-corriger ce qui est possible
-pnpm --filter @stocket/api lint --fix
-pnpm --filter @stocket/web lint:fix
+cd backend
+pnpm start:worker
 ```
 
-## Problèmes CI/CD
+Inspectez ensuite les logs API et worker, `BACKGROUND_TASK_*`, PostgreSQL et S3/MinIO. L'absence de `OPENAI_API_KEY` n'est pas une erreur : l'import utilise alors des propositions déterministes.
 
-### GitHub Actions échoue
+## Inventaire et mouvements divergent
 
-**Symptôme :** Les vérifications CI échouent
+Les lignes d'inventaire et le registre des mouvements sont actuellement indépendants. Un mouvement ne modifie pas l'inventaire et un ajustement d'inventaire ne crée pas de mouvement. Corrigez la ligne d'inventaire et ajoutez séparément l'écriture de registre nécessaire.
 
-**Solutions :**
+## Une zone enfant disparaît après suppression du parent
 
-1. Exécuter les vérifications localement d'abord :
-   ```bash
-   pnpm lint && pnpm test && pnpm build
-   ```
+Ne supprimez pas une zone parent tant qu'elle a des enfants. La relation actuelle ne propage pas la suppression et ne réaffecte pas les descendants ; ils peuvent devenir invisibles dans l'arbre. Réaffectez ou supprimez tous les enfants d'abord. L'inventaire lié perd son affectation de zone.
 
-2. Vérifier que les secrets sont configurés dans GitHub
+## La validation frontend échoue
 
-3. Vider le cache GitHub Actions si nécessaire
+Isolez la commande :
 
-## Obtenir plus d'aide
+```bash
+cd frontend
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+```
 
-Si vous êtes toujours bloqué :
+L'application utilise Oxlint. L'existence du paquet publié `@stocketfr/eslint-config` ne signifie pas que les applications exécutent actuellement ESLint.
 
-1. Consultez les [issues existantes](https://github.com/stocketfr/documentation/issues)
-2. Recherchez les messages d'erreur en ligne
-3. Ouvrez une nouvelle issue avec :
-    - Message d'erreur
-    - Étapes pour reproduire
-    - Détails de l'environnement
+## Les vérifications backend échouent
+
+```bash
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+pnpm test:integration
+```
+
+Les tests d'intégration exigent PostgreSQL et utilisent `TEST_DATABASE_URL` s'il est défini. Séparez d'abord les échecs unitaires et d'intégration.
+
+## La documentation API semble incomplète
+
+Swagger UI se trouve sur `http://localhost:8080/docs`, pas `/api/docs`, et ne
+documente actuellement que la santé. Les routeurs backend montés définissent les
+endpoints actifs ; leurs schémas `@stocketfr/types` correspondants définissent
+les payloads. Tout schéma exporté n'est pas forcément monté : fulfillment reste
+par exemple un prototype non monté.
+
+## Une page française retombe en anglais
+
+Le site utilise la localisation par suffixe (`page.fr.md`) avec repli anglais. Vérifiez le suffixe, le sélecteur de langue et la présence de la page dans la navigation `mkdocs.yml`.
+
+## Toujours bloqué
+
+Notez la commande, le dépôt et la révision, les versions Node/pnpm, les logs utiles et un résumé d'environnement expurgé. Ouvrez l'issue dans le dépôt propriétaire ; le dépôt documentation ne sert qu'aux défauts documentaires.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,241 +1,138 @@
 # Troubleshooting
 
-Solutions to common issues when working with Stocket Inventory.
+Start with the process that owns the failing boundary. The workspace controller only coordinates repositories; backend, worker, frontend, PostgreSQL, and MinIO still have separate logs and health.
 
-## Development Environment
+## Bootstrap cannot install `@stocketfr/*`
 
-### Nix shell won't start
+The shared packages are hosted on GitHub Packages.
 
-**Symptom:** `nix develop` fails or hangs
+1. Create or refresh a GitHub token with `read:packages`.
+2. Configure the `@stocketfr` registry and token in your user-level npm configuration.
+3. Run `pnpm install` again in the failing repository or rerun `./meta/scripts/bootstrap`.
 
-**Solutions:**
+Do not put the token in a repository `.npmrc`.
 
-1. Check Nix installation:
-   ```bash
-   nix --version
-   ```
+## Wrong Node or package manager
 
-2. Ensure flakes are enabled in your Nix config (`~/.config/nix/nix.conf`):
-   ```
-   experimental-features = nix-command flakes
-   ```
-
-3. Try entering the shell from the specific repo directory:
-   ```bash
-   cd backend && nix develop
-   ```
-
-### Docker services won't start
-
-**Symptom:** `docker compose -f meta/docker-compose.yml up -d` fails
-
-**Solutions:**
-
-1. Check Docker is running:
-   ```bash
-   docker info
-   ```
-
-2. Check for port conflicts:
-   ```bash
-   lsof -i :5432
-   ```
-
-3. Reset Docker containers:
-   ```bash
-   docker compose -f meta/docker-compose.yml down -v
-   docker compose -f meta/docker-compose.yml up -d
-   ```
-
-### Port already in use
-
-**Symptom:** "Address already in use" error
-
-**Solutions:**
+Backend and frontend target Node.js 22 and pnpm 10.28. Other repositories have
+their own checked-in tool versions; some package and remote-desktop workflows
+still use Node.js 20. Check the owning repository before changing versions:
 
 ```bash
-# Find process using the port
-lsof -i :8080  # or :3000, :5432
-
-# Kill the process
-kill -9 <PID>
+node --version
+pnpm --version
 ```
 
-### Dependencies won't install
+Enter the repository's Nix shell or enable Corepack if your versions differ. Bun is not the backend runtime.
 
-**Symptom:** `pnpm install` fails
+## PostgreSQL or MinIO does not start
 
-**Solutions:**
-
-1. Clear pnpm cache:
-   ```bash
-   pnpm store prune
-   rm -rf node_modules
-   pnpm install
-   ```
-
-2. Check Node.js version:
-   ```bash
-   node --version  # Should be 20+
-   ```
-
-## Database Issues
-
-### Cannot connect to PostgreSQL
-
-**Symptom:** Connection refused errors
-
-**Solutions:**
-
-1. Check if PostgreSQL is running:
-   ```bash
-   pg_isready -h localhost -p 5432
-   ```
-
-2. Start PostgreSQL via Docker Compose:
-   ```bash
-   docker compose -f meta/docker-compose.yml up -d
-   ```
-
-3. Check environment variables in `backend/.env`
-
-### Migration or schema errors
-
-**Symptom:** Drizzle ORM errors about missing tables or columns
-
-**Solutions:**
-
-1. Restart the API server — schema changes are applied automatically in development:
-   ```bash
-   cd backend && pnpm start
-   ```
-
-2. Check database exists:
-   ```bash
-   psql -h localhost -U postgres -c '\l'
-   ```
-
-3. Check schema definitions in `backend/src/effect/platform/db/schema.ts`
-
-## API Issues
-
-### Better Auth authentication errors
-
-**Symptom:** 401 Unauthorized errors
-
-**Solutions:**
-
-1. Verify `BETTER_AUTH_SECRET` is set in `backend/.env` (must be 32+ random bytes)
-2. Verify `BETTER_AUTH_URL` is set correctly (e.g., `http://localhost:8080`)
-3. Check session cookie is being sent (Better Auth uses cookie-based sessions)
-4. Try regenerating the secret:
-   ```bash
-   openssl rand -base64 32
-   ```
-   Update `BETTER_AUTH_SECRET` in `backend/.env` and restart the server.
-
-### Shared types build fails
-
-**Symptom:** `@stocket/types` build fails
-
-**Solutions:**
-
-1. Build the API first:
-   ```bash
-   pnpm --filter @stocket/api build
-   ```
-
-2. Check for TypeScript errors:
-   ```bash
-   pnpm --filter @stocket/api type-check
-   ```
-
-## Frontend Issues
-
-### API client type errors
-
-**Symptom:** TypeScript errors in handwritten hooks or shared types
-
-**Solutions:**
-
-1. Rebuild shared types after API changes:
-   ```bash
-   pnpm --filter @stocket/types barrels
-   pnpm --filter @stocket/types build
-   ```
-
-### Hydration errors
-
-**Symptom:** React hydration mismatch warnings
-
-**Solutions:**
-
-1. Ensure client/server rendering matches
-2. Avoid browser-only code at module scope during SSR
-3. Defer browser APIs to effects or guards
-
-### Translation not working
-
-**Symptom:** Translation keys shown instead of text
-
-**Solutions:**
-
-1. Check locale files exist in `frontend/src/locales/`
-2. Verify i18n configuration
-3. Check language prefix in URL
-
-## Build Issues
-
-### TypeScript errors
-
-**Symptom:** Build fails with type errors
-
-**Solutions:**
+`./meta/scripts/dev` attempts to start both services automatically when Docker is available.
 
 ```bash
-# Check specific module
-pnpm --filter @stocket/api type-check
-pnpm --filter @stocket/web type-check
+docker compose -f meta/docker-compose.yml ps
+docker compose -f meta/docker-compose.yml logs postgres minio minio-init
 ```
 
-### Lint errors
+Check that ports 5432, 9000, and 9001 are free. Verify the local bucket initializer completed before debugging photo/import failures.
 
-**Symptom:** Lint command fails
+!!! danger
+    `docker compose down -v` deletes the local PostgreSQL volume and object-storage data. Do not use it as a routine restart command.
 
-**Solutions:**
+## API or worker fails during storage startup
+
+The globally composed storage layer checks the bucket during startup, so invalid
+or inaccessible storage normally prevents both the API and worker from
+starting. All `S3_*` values must be present, the endpoint must be a valid URL,
+and the configured bucket must already exist. Local MinIO normally needs
+`S3_FORCE_PATH_STYLE=true`. Compare Infisical with `backend/env.template`;
+editing a local `.env` will not change `pnpm start` unless you deliberately
+changed the launcher.
+
+## Loggle reports a missing frontend script
+
+The current `meta/.loggle.toml` invokes `@stocket/web dev:workspace`, but the
+frontend repository does not define that script. When Loggle is installed,
+start PostgreSQL and MinIO from `meta/docker-compose.yml`, then run
+`pnpm start:workspace` in `backend` and `pnpm dev` in `frontend`. The direct
+meta runner already uses the valid frontend script, but `./meta/scripts/dev`
+selects Loggle automatically when it is installed and no optional processes
+were requested.
+
+## Tenant route redirects or returns “tenant not found”
+
+- Use `http://localhost:3000` for the platform console.
+- Use `http://<slug>.localhost:3000` for a tenant.
+- Confirm the slug exists in the platform console. Create a missing tenant there; the workspace seed targets existing tenants and only creates the default tenant when the database has none.
+- Confirm the signed-in user has a membership in that tenant. Public account creation alone does not currently provision tenant membership.
+- Keep `TENANT_BASE_DOMAIN` and `PLATFORM_HOST` aligned between frontend and backend.
+
+## Login cookies fail through SSR or a proxy
+
+The browser uses same-origin `/api/auth` and `/api/v1`; the SSR process forwards cookie, host, and protocol to `INTERNAL_API_ORIGIN`.
+
+- Confirm `INTERNAL_API_ORIGIN` points to the backend from the frontend process.
+- Set `TRUSTED_PROXY=1` only when a trusted reverse proxy supplies `x-forwarded-host` and `x-forwarded-proto`.
+- Check `BETTER_AUTH_URL`, `FRONTEND_URL`, CORS origins, and any cookie domain together.
+- Do not add `VITE_API_BASE_URL`; it is not used by the current architecture.
+
+## Smart Import stays queued
+
+The API only enqueues the durable PostgreSQL task. Start the separate worker:
 
 ```bash
-# Backend (oxlint) — auto-fix
-pnpm --filter @stocket/api lint:fix
-
-# Frontend (ESLint) — auto-fix
-pnpm --filter @stocket/web lint:fix
+cd backend
+pnpm start:worker
 ```
 
-## CI/CD Issues
+Then inspect both API and worker logs. Validate `BACKGROUND_TASK_*`, PostgreSQL, and S3/MinIO. An absent `OPENAI_API_KEY` is not itself a failure—the importer falls back to deterministic proposals.
 
-### GitHub Actions failing
+## Inventory and movement totals disagree
 
-**Symptom:** CI checks fail
+Inventory rows and the stock-movement ledger are currently independent. Recording a movement does not change inventory, and adjusting inventory does not add a movement. Correct the inventory row directly and record any required ledger entry separately; avoid assuming one is an automatic reconciliation of the other.
 
-**Solutions:**
+## A child area disappeared after deleting its parent
 
-1. Run checks locally first:
-   ```bash
-   pnpm lint && pnpm test && pnpm build
-   ```
+Do not delete a parent area while it still has children. The current database relation does not cascade or reparent descendants; they can become unreachable in the tree. Reparent or delete every child first. Inventory that referenced the deleted area loses its area assignment.
 
-2. Check secrets are configured in GitHub
+## Frontend validation fails
 
-3. Clear GitHub Actions cache if needed
+Run the checks independently to isolate the failure:
 
-## Getting More Help
+```bash
+cd frontend
+pnpm type-check
+pnpm lint
+pnpm format:check
+pnpm test:unit
+```
 
-If you're still stuck:
+The active application lint command uses Oxlint. The separately published `@stocketfr/eslint-config` package does not mean the applications currently run ESLint.
 
-1. Check [existing issues](https://github.com/stocketfr/documentation/issues)
-2. Search error messages online
-3. Open a new issue with:
-    - Error message
-    - Steps to reproduce
-    - Environment details
+## Backend checks fail
+
+```bash
+cd backend
+pnpm type-check
+pnpm lint
+pnpm test
+pnpm test:integration
+```
+
+Integration tests need a reachable PostgreSQL database and use `TEST_DATABASE_URL` when set. Keep unit and integration failures separate before changing configuration.
+
+## API documentation looks incomplete
+
+Swagger UI is at `http://localhost:8080/docs`, not `/api/docs`, and currently
+documents only health. Mounted backend routers determine the live endpoints;
+their matching `@stocketfr/types` schemas define payloads. Do not treat every
+exported schema as a mounted route—for example, fulfillment remains an
+unmounted prototype.
+
+## French page falls back to English
+
+The site uses suffix localization (`page.fr.md`) and falls back to English when a French file is absent. If a translation exists but is not selected, verify the suffix, the current locale selector, and that the page is present in `mkdocs.yml` navigation.
+
+## Still blocked
+
+Capture the failing command, repository name and revision, Node/pnpm versions, relevant process logs, and a redacted environment summary. Open an issue in the repository that owns the failure; use the documentation repository only for documentation defects.

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -1,112 +1,109 @@
 # Feuille de route
 
-Cette feuille de route présente les fonctionnalités et améliorations planifiées pour Stocket Inventory. Les éléments sont suivis en tant que [GitHub Issues](https://github.com/stocketfr/meta/issues).
+Cette page sépare les capacités implémentées dans les dépôts actuels des lacunes connues et des idées qui nécessitent encore une décision produit. Ce n'est pas un calendrier de release et aucune date de livraison n'est attribuée. Les issues et pull requests du dépôt responsable d'un changement sont les sources de vérité pour le travail actif.
 
 !!! info "Contribuer"
-    Intéressé à contribuer ? Consultez nos [directives de contribution](contributing/guidelines.md) et choisissez une issue à traiter !
+    Lisez les [directives de contribution](contributing/guidelines.md) avant de prendre en charge un élément. Stocket est un projet multi-dépôts ; l'implémentation et la documentation peuvent donc nécessiter des pull requests liées.
 
-## En cours
+## Socle livré
 
-### Recherche & Analytique
+### Inventaire et workflows métier
 
-| Description | Priorité |
-|-------------|----------|
-| Implémenter l'API de recherche et filtrage avancé | Haute |
-| Construire l'interface de recherche avancée avec filtres | Haute |
-| Créer un tableau de bord avec analytiques d'inventaire | Moyenne |
-| Implémenter les rapports d'inventaire et fonctions d'export | Moyenne |
+| Capacité | Périmètre actuel |
+| --- | --- |
+| Catalogue de produits | Produits, catégories imbriquées, SKU, prix, seuils de réapprovisionnement, photos, filtres et import de produits en masse |
+| Emplacements et zones | Emplacements propres au tenant avec zones de stockage imbriquées et types d'emplacement pour le suivi opérationnel du stock |
+| Inventaire | Quantités par produit et emplacement, données de batch/lot et d'expiration, synthèses des stocks faibles et expirations |
+| Mouvements de stock | Registre manuel immuable à côté des ajustements ; les deux stockages ne se mettent pas à jour automatiquement |
+| Fiches métier | Fiches clients, fournisseurs et commandes avec transitions de statut de commande validées |
+| Import intelligent | Tâches d'import durables, suivi de progression, entrées compatibles CSV/Sortly et mapping assisté optionnel des champs |
+| Notifications | Enregistrements et préférences persistants, ainsi qu'un pipeline planifié d'e-mails de stock faible |
 
-### Inventaire avancé
+Le suivi du statut des commandes est implémenté. Un workflow complet d'exécution pour le picking, le packing et l'expédition n'est pas monté comme module produit actif et figure dans les lacunes connues ci-dessous.
 
-| Description | Priorité |
-|-------------|----------|
-| Ajouter les alertes de stock bas et notifications | Haute |
-| Ajouter les opérations en masse pour la gestion d'inventaire | Moyenne |
+### Identité, tenants et administration
 
-### Expérience utilisateur
+| Capacité | Périmètre actuel |
+| --- | --- |
+| Authentification | Sessions Better Auth, récupération de mot de passe et routage par hôte tenant |
+| Autorisation | Rôles personnalisés, permissions par ressource, protection des routes et droits de fonctionnalités par tenant |
+| Console plateforme | Création, liste, accès et suppression des tenants, affectation des offres et dérogations de fonctionnalités par tenant |
+| Audit et branding | Métadonnées d'audit au mieux pour certaines mutations, nom/logos tenant, thèmes personnels et préférences de langue |
+| Langues | Traductions de l'application en anglais, français et allemand |
 
-| Description | Priorité |
-|-------------|----------|
-| Ajouter le support de scan code-barres/QR | Moyenne |
-| Créer le guide de démarrage et données d'exemple | Moyenne |
+### Application web et PWA
 
-### Infrastructure & Opérations
+| Capacité | Périmètre actuel |
+| --- | --- |
+| Client web | Application SSR TanStack Start avec React 19, TanStack Router et TanStack Query |
+| Tableau de bord | Synthèses des produits, emplacements, inventaire, stocks faibles, mouvements et commandes |
+| Scan | Saisie QR par caméra dans le navigateur avec saisie manuelle de secours |
+| Shell PWA | Manifest web, icônes, cache runtime des ressources statiques récupérées et page de repli hors ligne |
+| Qualité | Tests unitaires et couverture Playwright full-stack avec le backend, PostgreSQL et un stockage compatible S3 |
 
-| Description | Priorité |
-|-------------|----------|
-| Ajouter l'infrastructure de logging et monitoring | Haute |
-| Mettre en place la stratégie de backup et récupération | Haute |
+!!! warning "Le shell PWA n'est pas un mode données hors ligne"
+    Le service worker exclut les requêtes `/api/` de son cache. Aucun inventaire local hors ligne, file de mutations, mécanisme de résolution des conflits ou synchronisation des données en arrière-plan n'est livré. L'expérience hors ligne actuelle se limite aux ressources statiques en cache et à une page de repli.
 
-## Terminé
+### Fondations partagées d'ingénierie et d'exploitation
 
-Ces fonctionnalités ont été implémentées :
+| Capacité | Périmètre actuel |
+| --- | --- |
+| Packages partagés | Packages versionnés `@stocketfr/types`, `@stocketfr/emails`, TypeScript et lint publiés avec Changesets |
+| Workspace local | Bootstrap `meta`, overlay pnpm partagé, PostgreSQL, MinIO et orchestration optionnelle des processus avec Loggle |
+| Code d'infrastructure | Terraform et Ansible pour Hetzner, Caddy, PostgreSQL, les conteneurs applicatifs, Cloudflare R2, Datadog et la protection contre la destruction de la production |
+| Récupération | Sauvegardes PostgreSQL nocturnes hors serveur vers un bucket R2 séparé, contrôles de rétention et documentation de restauration |
+| Intégration continue | Validation propre à chaque dépôt pour le backend, le frontend, les packages, l'infrastructure, le desktop et la documentation |
+| Documentation | Site MkDocs bilingue avec builds stricts sur les pull requests et publication GitHub Pages |
 
-### Modules principaux
+Le code d'infrastructure et les runbooks décrivent une topologie exploitable ; leur présence ne signifie pas que chaque révision applicative est automatiquement publiée ou déployée.
 
-| Description | Statut |
-|-------------|--------|
-| CRUD Produits | :white_check_mark: Fait |
-| CRUD Catégories | :white_check_mark: Fait |
-| CRUD Emplacements | :white_check_mark: Fait |
-| CRUD Zones | :white_check_mark: Fait |
-| Gestion d'inventaire | :white_check_mark: Fait |
-| Mouvements de stock | :white_check_mark: Fait |
-| Gestion des commandes (DRAFT, CONFIRMED, SOURCING, PICKING, PACKED, SHIPPED, DELIVERED, CANCELLED, ON_HOLD) | :white_check_mark: Fait |
-| Module clients | :white_check_mark: Fait |
-| Module fournisseurs | :white_check_mark: Fait |
-| Journalisation d'audit | :white_check_mark: Fait |
-| Gestion des photos | :white_check_mark: Fait |
+## Lacunes connues et prochaines décisions
 
-### Authentification & Autorisation
+Ces éléments sont des frontières concrètes de l'implémentation actuelle. Leur ordre ne constitue pas un engagement de livraison.
 
-| Description | Statut |
-|-------------|--------|
-| Authentification Better Auth | :white_check_mark: Fait |
-| Système de rôles/permissions (PermissionGuard + @RequirePermission) | :white_check_mark: Fait |
-| Gestion des utilisateurs (admin) | :white_check_mark: Fait |
+| Domaine | Frontière actuelle | Résultat encore nécessaire |
+| --- | --- | --- |
+| Données et synchronisation hors ligne | Shell PWA et page de repli hors ligne uniquement | Définir le stockage local, les lectures hors ligne, la mise en file des écritures, la gestion des conflits et la resynchronisation sécurisée |
+| Recherche et reporting | Filtres par ressource et synthèses du tableau de bord | Recherche plus large entre ressources, filtres réutilisables, génération de rapports et exports pris en charge |
+| Opérations d'inventaire en masse | L'import de produits existe ; les changements d'inventaire restent des workflows ciblés | Concevoir des ajustements et transferts en masse vérifiables avec validation, auditabilité et gestion claire des échecs |
+| Expérience de notification | Les préférences backend et le pipeline de livraison des stocks faibles existent | Compléter les contrôles utilisateur, l'historique des notifications et les workflows d'exploitation de la livraison |
+| Fulfillment | Les commandes et transitions de statut existent ; le code de fulfillment n'est pas monté | Définir et livrer des workflows pris en charge de picking, packing, expédition et suivi avant de les documenter comme disponibles |
+| Description de l'API | Les endpoints typés de santé exposent un OpenAPI généré ; la couverture de l'API produit est incomplète | Migrer les routes restantes vers la description d'API typée et publier un contrat exact |
+| Distribution de l'application | La CI construit/teste ; un chemin manuel soumis à des gardes a déployé ponctuellement le `main` courant, sans CD automatique persistant ni workflow autonome de rollback | Définir le chemin de distribution répétable pris en charge, les contrôles de rollout et la responsabilité du rollback |
+| Packaging desktop | Un client Tauri et un workflow de release séparé existent | Réconcilier le packaging desktop avec le build frontend actuel et définir le comportement de mise à jour et de version pris en charge |
 
-### Frontend & API
+## Envisagé, non engagé
 
-| Description | Statut |
-|-------------|--------|
-| API REST HATEOAS | :white_check_mark: Fait |
-| Frontend TanStack Start (React 19) | :white_check_mark: Fait |
-| Personnalisation/branding | :white_check_mark: Fait |
-| i18n (anglais, français, allemand) | :white_check_mark: Fait |
+Les idées suivantes ne sont pas des promesses produit actives et n'ont aucune date attribuée :
 
-### Infrastructure & Qualité
+- Applications mobiles natives ; aucun dépôt d'application mobile actuel n'est présent dans `meta/repos.yaml` ni dans le checkout assemblé
+- Commande directe auprès des fournisseurs et intégrations fournisseurs externes
+- Prévision de la demande et recommandations automatiques de réapprovisionnement
 
-| Description | Statut |
-|-------------|--------|
-| Support Docker (docker-compose) | :white_check_mark: Fait |
-| CI/CD (GitHub Actions par dépôt) | :white_check_mark: Fait |
-| Tests E2E (Playwright) | :white_check_mark: Fait |
-| Site de documentation (MkDocs, GitHub Pages) | :white_check_mark: Fait |
-| Outils de qualité de code et linting | :white_check_mark: Fait |
+Une idée ne doit devenir un travail suivi qu'après définition de son résultat utilisateur, de son dépôt responsable, de ses implications de sécurité et de données, et de ses critères d'acceptation.
 
-## Considérations futures
+## Statut des releases et du déploiement
 
-Fonctionnalités en considération pour les versions futures :
-
-- **PWA** - Application Web Progressive avec support hors ligne
-- **Support multi-yacht** - Gérer l'inventaire sur plusieurs navires
-- **Intégration fournisseurs** - Commande directe auprès des fournisseurs
-- **Prédictions IA** - Suggestions de réapprovisionnement automatiques
-- **Applications mobiles natives** - Applications iOS et Android
-- **Sync offline-first** - Capacité offline complète avec synchronisation
+| Projet | Comportement actuel après un merge |
+| --- | --- |
+| Backend et frontend | La CI valide après merge ; le rollout de production de juillet 2026 a utilisé des workflows manuels temporaires soumis à des gardes, pas un CD automatique persistant |
+| Packages | Changesets maintient une pull request de release ; le merge de cette pull request de versions publie les packages stables et les releases GitHub |
+| Documentation | Un push sur `main` publie le site MkDocs sur GitHub Pages |
+| Infrastructure | Le plan est automatique pour les pull requests ; l'application en production nécessite une option explicite du workflow et un environnement protégé |
+| Client desktop | Un workflow tag/dispatch séparé existe, mais ses hypothèses dépôt/build sont obsolètes et le packaging reste non vérifié |
+| Landing page | La propriété du site statique est séparée du flux de release de l'application |
 
 ## Dépôts
 
-| Dépôt | Description | Lien |
-|-------|-------------|------|
-| meta | Orchestration du workspace et scripts | [GitHub](https://github.com/stocketfr/meta) |
-| backend | Serveur API Effect.ts (Bun) | [GitHub](https://github.com/stocketfr/backend) |
-| frontend | Application web TanStack Start | [GitHub](https://github.com/stocketfr/frontend) |
-| packages | Types partagés et utilitaires | [GitHub](https://github.com/stocketfr/packages) |
-| documentation | Site de documentation MkDocs | [GitHub](https://github.com/stocketfr/documentation) |
-| remote-desktop | Outils de bureau à distance | [GitHub](https://github.com/stocketfr/remote-desktop) |
-| landing | Page d'accueil | [GitHub](https://github.com/stocketfr/landing) |
+| Dépôt | Responsabilité actuelle | Lien |
+| --- | --- | --- |
+| `meta` | Manifest du workspace multi-dépôts, bootstrap et orchestration locale | [GitHub](https://github.com/stocketfr/meta) |
+| `backend` | API Effect sous Node.js 22 et worker persistant de tâches en arrière-plan | [GitHub](https://github.com/stocketfr/backend) |
+| `frontend` | Application web SSR TanStack Start et shell PWA | [GitHub](https://github.com/stocketfr/frontend) |
+| `packages` | Contrats partagés, modèles d'e-mails et configuration TypeScript/lint | [GitHub](https://github.com/stocketfr/packages) |
+| `infrastructure` | Terraform, Ansible, topologie de production, monitoring et récupération | [GitHub](https://github.com/stocketfr/infrastructure) |
+| `remote-desktop` | Shell client desktop Tauri 2 et workflow de packaging | [GitHub](https://github.com/stocketfr/remote-desktop) |
+| `documentation` | Documentation MkDocs en anglais et français | [GitHub](https://github.com/stocketfr/documentation) |
+| `landing` | Site marketing public statique | [GitHub](https://github.com/stocketfr/landing) |
 
----
-
-*Dernière mise à jour : Février 2026*
+Consultez la [carte des projets](development/project-map.md) pour le modèle détaillé des responsabilités et dépendances.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,112 +1,109 @@
 # Roadmap
 
-This roadmap outlines planned features and improvements for Stocket Inventory. Items are tracked as [GitHub Issues](https://github.com/stocketfr/meta/issues).
+This page separates capabilities implemented in the current repositories from known gaps and ideas that still require a product decision. It is not a release schedule and assigns no delivery dates. Issues and pull requests in the repository that owns a change are the source of truth for active work.
 
 !!! info "Contributing"
-    Interested in contributing? Check our [contribution guidelines](contributing/guidelines.md) and pick an issue to work on!
+    Read the [contribution guidelines](contributing/guidelines.md) before taking on an item. Stocket is a multi-repository project, so implementation and documentation work may require linked pull requests.
 
-## In Progress
+## Shipped baseline
 
-### Search & Analytics
+### Inventory and business workflows
 
-| Description | Priority |
-|-------------|----------|
-| Implement advanced search and filtering API | High |
-| Build advanced search UI with filters | High |
-| Create dashboard with inventory analytics | Medium |
-| Implement inventory reporting and export features | Medium |
+| Capability | Current scope |
+| --- | --- |
+| Product catalogue | Products, nested categories, SKUs, prices, reorder points, photos, filtering, and bulk product import |
+| Locations and areas | Tenant-scoped locations with nested storage areas and location types for operational stock tracking |
+| Inventory | Quantities by product and location, batch/lot and expiry data, low-stock and expiry summaries |
+| Stock movements | Manual immutable ledger beside inventory adjustments; the two stores do not update one another automatically |
+| Business records | Client, supplier, and order records with validated order-status transitions |
+| Smart import | Durable import tasks, progress reporting, CSV/Sortly-compatible input, and optional assisted field mapping |
+| Notifications | Persisted notification records and preferences plus a scheduled low-stock email pipeline |
 
-### Advanced Inventory
+Order status tracking is implemented. A complete fulfillment execution workflow for picking, packing, and shipping is not mounted as a live product module and is listed under known gaps below.
 
-| Description | Priority |
-|-------------|----------|
-| Add low stock alerts and notifications | High |
-| Add bulk operations for inventory management | Medium |
+### Identity, tenancy, and administration
 
-### User Experience
+| Capability | Current scope |
+| --- | --- |
+| Authentication | Better Auth sessions, password recovery, and tenant-aware host routing |
+| Authorization | Custom roles, resource permissions, route protection, and tenant feature entitlements |
+| Platform console | Tenant creation, listing, access, deletion, plan assignment, and per-tenant feature overrides |
+| Audit and branding | Best-effort audit metadata for selected mutations, tenant naming/logos, personal theme settings, and locale preferences |
+| Languages | English, French, and German application translations |
 
-| Description | Priority |
-|-------------|----------|
-| Add barcode/QR code scanning support | Medium |
-| Create getting started guide and seed data | Medium |
+### Web application and PWA
 
-### Infrastructure & Operations
+| Capability | Current scope |
+| --- | --- |
+| Web client | TanStack Start SSR application with React 19, TanStack Router, and TanStack Query |
+| Dashboard | Product, location, inventory, low-stock, movement, and order summaries |
+| Scanning | Browser camera QR input with a manual-entry fallback |
+| PWA shell | Web manifest, install icons, runtime caching of fetched static assets, and an offline fallback page |
+| Quality | Unit tests plus full-stack Playwright coverage against the backend, PostgreSQL, and S3-compatible storage |
 
-| Description | Priority |
-|-------------|----------|
-| Add logging and monitoring infrastructure | High |
-| Set up database backup and recovery strategy | High |
+!!! warning "PWA shell is not offline data"
+    The service worker excludes `/api/` requests from its cache. There is no shipped offline inventory database, mutation queue, conflict resolution, or background data synchronization. The current offline experience is limited to cached static resources and a fallback page.
 
-## Completed
+### Shared engineering and operations foundations
 
-These features have been implemented:
+| Capability | Current scope |
+| --- | --- |
+| Shared packages | Versioned `@stocketfr/types`, `@stocketfr/emails`, TypeScript, and lint packages published through Changesets |
+| Local workspace | `meta` bootstrap, a shared pnpm overlay, PostgreSQL, MinIO, and optional Loggle process orchestration |
+| Infrastructure code | Terraform and Ansible for Hetzner, Caddy, PostgreSQL, app containers, Cloudflare R2, Datadog, and production destroy protection |
+| Recovery | Nightly off-box PostgreSQL backups to a separately owned R2 bucket, retention controls, and restore documentation |
+| Continuous integration | Repository-specific validation for backend, frontend, packages, infrastructure, desktop, and documentation |
+| Documentation | Bilingual MkDocs site with strict pull-request builds and GitHub Pages publication |
 
-### Core Modules
+Infrastructure code and runbooks describe an operable topology; their presence does not mean every application revision is automatically published or deployed.
 
-| Description | Status |
-|-------------|--------|
-| Products CRUD | :white_check_mark: Done |
-| Categories CRUD | :white_check_mark: Done |
-| Locations CRUD | :white_check_mark: Done |
-| Areas CRUD | :white_check_mark: Done |
-| Inventory management | :white_check_mark: Done |
-| Stock Movements | :white_check_mark: Done |
-| Orders management (DRAFT, CONFIRMED, SOURCING, PICKING, PACKED, SHIPPED, DELIVERED, CANCELLED, ON_HOLD) | :white_check_mark: Done |
-| Clients module | :white_check_mark: Done |
-| Suppliers module | :white_check_mark: Done |
-| Audit logging | :white_check_mark: Done |
-| Photos management | :white_check_mark: Done |
+## Known gaps and next decisions
 
-### Authentication & Authorization
+These are concrete boundaries in the current implementation. Their order is not a delivery commitment.
 
-| Description | Status |
-|-------------|--------|
-| Better Auth authentication | :white_check_mark: Done |
-| Roles/Permissions system (requirePermission) | :white_check_mark: Done |
-| Users management (admin) | :white_check_mark: Done |
+| Area | Current boundary | Outcome still needed |
+| --- | --- | --- |
+| Offline data and sync | PWA shell and offline fallback only | Define local data storage, offline reads, queued writes, conflict handling, and secure resynchronization |
+| Search and reporting | Resource-level filters and dashboard summaries | Broader cross-resource search, reusable filters, report generation, and supported exports |
+| Bulk inventory work | Product import exists; inventory changes remain focused workflows | Design reviewed bulk adjustments and transfers with validation, auditability, and clear failure handling |
+| Notification experience | Backend preferences and low-stock delivery pipeline exist | Complete user-facing controls, notification history, and delivery-operability workflows |
+| Fulfillment | Orders and status transitions exist; fulfillment source is not mounted | Define and ship supported picking, packing, dispatch, and shipment workflows before documenting them as available |
+| API description | Typed health endpoints expose generated OpenAPI; product API coverage is incomplete | Migrate remaining routes into the typed API description and publish an accurate contract |
+| Application distribution | CI builds/tests; a guarded manual one-off deployed the current `main`, but there is no persistent automatic CD or standalone rollback workflow | Define the supported repeatable distribution path, rollout controls, and rollback ownership |
+| Desktop packaging | A Tauri client and separate release workflow exist | Reconcile desktop packaging with the current frontend build and define supported update/version behavior |
 
-### Frontend & API
+## Considered, not committed
 
-| Description | Status |
-|-------------|--------|
-| HATEOAS REST API | :white_check_mark: Done |
-| TanStack Start frontend (React 19) | :white_check_mark: Done |
-| Branding/customization | :white_check_mark: Done |
-| i18n (English, French, German) | :white_check_mark: Done |
+The following ideas are not active product promises and have no assigned dates:
 
-### Infrastructure & Quality
+- Native mobile applications; there is no current mobile application repository in `meta/repos.yaml` or the assembled checkout
+- Direct supplier ordering and external supplier integrations
+- Demand forecasting and automated reorder recommendations
 
-| Description | Status |
-|-------------|--------|
-| Docker support (docker-compose) | :white_check_mark: Done |
-| CI/CD (per-repo GitHub Actions) | :white_check_mark: Done |
-| E2E testing (Playwright) | :white_check_mark: Done |
-| Documentation site (MkDocs, GitHub Pages) | :white_check_mark: Done |
-| Code quality tools and linting | :white_check_mark: Done |
+An idea should move into tracked work only after its user outcome, owning repository, security and data implications, and acceptance criteria are defined.
 
-## Future Considerations
+## Release and deployment status
 
-Features under consideration for future releases:
-
-- **PWA** - Progressive Web App with offline support
-- **Multi-yacht support** - Manage inventory across multiple vessels
-- **Supplier integration** - Direct ordering from suppliers
-- **AI-powered predictions** - Automatic reorder suggestions
-- **Mobile native apps** - iOS and Android applications
-- **Offline-first sync** - Full offline capability with sync
+| Project | Current behavior after merge |
+| --- | --- |
+| Backend and frontend | CI validates after merge; the July 2026 production rollout used temporary guarded manual workflows, not persistent automatic CD |
+| Packages | Changesets maintains a release pull request; merging that version pull request publishes stable packages and GitHub releases |
+| Documentation | A push to `main` publishes the MkDocs site to GitHub Pages |
+| Infrastructure | Planning is automatic for pull requests; production apply requires an explicit workflow input and protected environment |
+| Remote desktop | A separate tag/dispatch workflow exists, but its repository/build assumptions are stale and the packaging path is currently unverified |
+| Landing | Static site ownership is separate from the application release flow |
 
 ## Repositories
 
-| Repository | Description | Link |
-|------------|-------------|------|
-| meta | Workspace orchestration and scripts | [GitHub](https://github.com/stocketfr/meta) |
-| backend | Effect.ts API server (Bun) | [GitHub](https://github.com/stocketfr/backend) |
-| frontend | TanStack Start web application | [GitHub](https://github.com/stocketfr/frontend) |
-| packages | Shared types and utilities | [GitHub](https://github.com/stocketfr/packages) |
-| documentation | MkDocs documentation site | [GitHub](https://github.com/stocketfr/documentation) |
-| remote-desktop | Remote desktop tooling | [GitHub](https://github.com/stocketfr/remote-desktop) |
-| landing | Landing page | [GitHub](https://github.com/stocketfr/landing) |
+| Repository | Current responsibility | Link |
+| --- | --- | --- |
+| `meta` | Multi-repository workspace manifest, bootstrap, and local orchestration | [GitHub](https://github.com/stocketfr/meta) |
+| `backend` | Node.js 22 Effect API and persisted background-task worker | [GitHub](https://github.com/stocketfr/backend) |
+| `frontend` | TanStack Start SSR web application and PWA shell | [GitHub](https://github.com/stocketfr/frontend) |
+| `packages` | Shared contracts, email templates, and TypeScript/lint configuration | [GitHub](https://github.com/stocketfr/packages) |
+| `infrastructure` | Terraform, Ansible, production topology, monitoring, and recovery | [GitHub](https://github.com/stocketfr/infrastructure) |
+| `remote-desktop` | Tauri 2 desktop client shell and packaging workflow | [GitHub](https://github.com/stocketfr/remote-desktop) |
+| `documentation` | English/French MkDocs documentation | [GitHub](https://github.com/stocketfr/documentation) |
+| `landing` | Static public marketing site | [GitHub](https://github.com/stocketfr/landing) |
 
----
-
-*Last updated: February 2026*
+See the [project map](development/project-map.md) for the detailed ownership and dependency model.

--- a/docs/user-guide/areas.fr.md
+++ b/docs/user-guide/areas.fr.md
@@ -1,103 +1,23 @@
-# Gestion des Zones
+# Zones
 
-Les zones représentent des espaces spécifiques, des étagères ou des bacs au sein d'un Emplacement. Elles fournissent un suivi granulaire du placement pour les articles d'inventaire.
+Les zones sont des subdivisions imbriquées d'un emplacement, par exemple `Pont 1 → Chambre froide → Bac A`. Ouvrez une carte d'emplacement puis son arbre.
 
-## Comprendre les Zones
+## Utiliser l'arbre
 
-Les zones sont hiérarchiques et appartiennent toujours à un Emplacement :
+- Développez ou repliez les branches.
+- Créez une zone racine ou une enfant du parent sélectionné.
+- Modifiez nom, code/description facultatifs, état actif ou parent.
+- Supprimez une zone après avoir traité ses descendants.
 
-```
-Emplacement : Entrepôt Miami
-├── Zone : Zone A
-│   ├── Zone : Étagère A1
-│   ├── Zone : Étagère A2
-│   └── Zone : Étagère A3
-├── Zone : Zone B
-│   └── Zone : Étagère B1
-└── Zone : Stockage Froid
-    ├── Zone : Réfrigérateur 1
-    └── Zone : Congélateur
-```
+Le parent doit appartenir au même emplacement et les cycles sont refusés. Le code est un repère physique facultatif.
 
-!!! info "Les Zones sont Optionnelles"
-    L'inventaire peut être suivi uniquement au niveau de l'Emplacement. Les zones ajoutent de la précision lorsque vous avez besoin de savoir exactement où les articles sont placés.
+## Avertissement sur la suppression d'un parent
 
-## Affichage des Zones
+!!! danger
+    Réaffectez ou supprimez chaque enfant avant son parent. La relation actuelle en base ne propage pas la suppression aux zones enfants. Supprimer uniquement le parent laisse des descendants qui pointent vers un parent absent et disparaissent de l'arbre construit depuis la racine.
 
-Accédez à **Emplacements** → sélectionnez un emplacement → **Voir les Zones** pour voir toutes les zones au sein de cet emplacement.
+Les lignes d'inventaire associées à la zone supprimée conservent l'emplacement mais perdent la zone. Contrôlez l'Inventaire après toute suppression.
 
-La liste des zones affiche :
+Le texte de confirmation actuel peut laisser croire à une cascade ; il ne reflète pas ce comportement. Suivez ce guide jusqu'à correction du produit.
 
-- **Nom** - Identifiant de la zone
-- **Code** - Code court pour référence rapide
-- **Parent** - Zone parente (si imbriquée)
-- **Statut** - Actif ou inactif
-
-!!! tip "Vue Hiérarchique"
-    Basculez entre la liste plate et la vue arborescente pour voir la hiérarchie des zones.
-
-## Création d'une Zone
-
-1. Sélectionnez un emplacement
-2. Cliquez sur le bouton **Créer une Zone**
-3. Remplissez les champs obligatoires :
-   - **Nom** - Nom de la zone (ex. : "Étagère A1")
-   - **Code** - Identifiant court (ex. : "A1")
-   - **Parent** - Zone parente pour l'imbrication (optionnel)
-
-### Champs de la Zone
-
-| Champ | Requis | Description |
-|-------|--------|-------------|
-| Nom | Oui | Nom d'affichage de la zone |
-| Emplacement | Oui | Emplacement parent (rempli automatiquement) |
-| Zone Parente | Non | Zone parente pour la hiérarchie |
-| Code | Non | Code identifiant court |
-| Description | Non | Détails supplémentaires |
-| Est Actif | Non | Disponibilité de la zone (par défaut vrai) |
-
-## Création de Zones Imbriquées
-
-Pour créer une hiérarchie :
-
-1. Créez d'abord la zone parente (ex. : "Zone A")
-2. Créez les zones enfants avec le parent sélectionné (ex. : "Étagère A1" → Parent : "Zone A")
-3. Continuez l'imbrication aussi profondément que nécessaire
-
-```mermaid
-graph TD
-    L[Entrepôt Miami] --> A[Zone A]
-    L --> B[Zone B]
-    L --> C[Stockage Froid]
-    A --> A1[Étagère A1]
-    A --> A2[Étagère A2]
-    C --> R1[Réfrigérateur 1]
-    C --> F[Congélateur]
-```
-
-## Modification des Zones
-
-1. Cliquez sur une zone pour ouvrir le formulaire de modification
-2. Modifiez les champs selon vos besoins
-3. Cliquez sur **Enregistrer** pour appliquer les modifications
-
-!!! warning "Déplacement des Zones"
-    Changer le parent d'une zone déplacera également tous ses enfants. La zone doit rester au sein du même emplacement.
-
-## Suppression des Zones
-
-Lorsque vous supprimez une zone :
-
-- **Les zones enfants sont également supprimées** (suppression en cascade)
-- **Les enregistrements d'inventaire perdent leur référence de zone** (mise à null)
-- L'inventaire reste au niveau de l'emplacement
-
-!!! danger "Suppression en Cascade"
-    Supprimer "Zone A" supprimera également "Étagère A1", "Étagère A2" et toutes les autres zones imbriquées.
-
-## Bonnes Pratiques
-
-1. **Utilisez un nommage cohérent** - "Étagère A1" et non "etagere-a1" ou "ETAGERE A1"
-2. **Utilisez des codes pour une recherche rapide** - Des codes courts comme "A1", "B2", "SF" aident lors des inventaires
-3. **N'imbriquez pas trop** - 2-3 niveaux suffisent généralement (Zone → Étagère → Bac)
-4. **Reflétez l'agencement physique** - La structure des zones doit correspondre à l'agencement réel du stockage
+L'accès aux zones hérite de `LOCATIONS.READ`/`LOCATIONS.WRITE`.

--- a/docs/user-guide/areas.md
+++ b/docs/user-guide/areas.md
@@ -1,103 +1,23 @@
-# Managing Areas
+# Areas
 
-Areas represent specific zones, shelves, or bins within a Location. They provide granular placement tracking for inventory items.
+Areas are nested subdivisions inside one location—for example `Deck 1 → Cold Room → Bin A`. Open a location card and use its area tree.
 
-## Understanding Areas
+## Work with the tree
 
-Areas are hierarchical and always belong to a Location:
+- Expand or collapse branches.
+- Create a root area or a child below a selected parent.
+- Edit the name, optional code and description, active state, or parent.
+- Delete an area after resolving its descendants.
 
-```
-Location: Miami Warehouse
-├── Area: Zone A
-│   ├── Area: Shelf A1
-│   ├── Area: Shelf A2
-│   └── Area: Shelf A3
-├── Area: Zone B
-│   └── Area: Shelf B1
-└── Area: Cold Storage
-    ├── Area: Refrigerator 1
-    └── Area: Freezer
-```
+A parent must belong to the same location. The application rejects cycles. Codes are optional labels for physical navigation.
 
-!!! info "Areas are Optional"
-    Inventory can be tracked at just the Location level. Areas add precision when you need to know exactly where items are placed.
+## Parent deletion warning
 
-## Viewing Areas
+!!! danger
+    Reparent or delete every child before deleting a parent area. The current database relation does not cascade child areas. Deleting only the parent leaves descendants pointing at a missing parent, so they disappear from the root-based tree.
 
-Navigate to **Locations** → select a location → **View Areas** to see all areas within that location.
+Inventory rows assigned to a deleted area keep their location but their area becomes unassigned. Review Inventory after any area deletion.
 
-The area list displays:
+The current confirmation text can imply cascading deletion; it does not reflect the database behavior above. Follow this guide until that product issue is fixed.
 
-- **Name** - Area identifier
-- **Code** - Short code for quick reference
-- **Parent** - Parent area (if nested)
-- **Status** - Active or inactive
-
-!!! tip "Hierarchical View"
-    Toggle between flat list and tree view to see the area hierarchy.
-
-## Creating an Area
-
-1. Select a location
-2. Click the **Create Area** button
-3. Fill in the required fields:
-   - **Name** - Area name (e.g., "Shelf A1")
-   - **Code** - Short identifier (e.g., "A1")
-   - **Parent** - Parent area for nesting (optional)
-
-### Area Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Name | Yes | Area display name |
-| Location | Yes | Parent location (auto-filled) |
-| Parent Area | No | Parent area for hierarchy |
-| Code | No | Short identifier code |
-| Description | No | Additional details |
-| Is Active | No | Area availability (defaults to true) |
-
-## Creating Nested Areas
-
-To create a hierarchy:
-
-1. Create the parent area first (e.g., "Zone A")
-2. Create child areas with the parent selected (e.g., "Shelf A1" → Parent: "Zone A")
-3. Continue nesting as deep as needed
-
-```mermaid
-graph TD
-    L[Miami Warehouse] --> A[Zone A]
-    L --> B[Zone B]
-    L --> C[Cold Storage]
-    A --> A1[Shelf A1]
-    A --> A2[Shelf A2]
-    C --> R1[Refrigerator 1]
-    C --> F[Freezer]
-```
-
-## Editing Areas
-
-1. Click on an area to open the edit form
-2. Modify the fields as needed
-3. Click **Save** to apply changes
-
-!!! warning "Moving Areas"
-    Changing an area's parent will move all its children as well. The area must stay within the same location.
-
-## Deleting Areas
-
-When you delete an area:
-
-- **Child areas are also deleted** (cascade delete)
-- **Inventory records lose their area reference** (set to null)
-- The inventory remains at the location level
-
-!!! danger "Cascade Delete"
-    Deleting "Zone A" will also delete "Shelf A1", "Shelf A2", and all other nested areas.
-
-## Best Practices
-
-1. **Use consistent naming** - "Shelf A1" not "shelf-a1" or "SHELF A1"
-2. **Use codes for quick lookup** - Short codes like "A1", "B2", "CS" help during inventory counts
-3. **Don't over-nest** - 2-3 levels is usually sufficient (Zone → Shelf → Bin)
-4. **Match physical layout** - Area structure should reflect the actual storage layout
+Area access inherits `LOCATIONS.READ`/`LOCATIONS.WRITE`.

--- a/docs/user-guide/audit-logs.fr.md
+++ b/docs/user-guide/audit-logs.fr.md
@@ -1,103 +1,17 @@
-# Journaux d'Audit
+# Journaux d'audit
 
-Le journal d'audit suit toutes les modifications apportées au système, fournissant un historique complet pour la responsabilité et le dépannage.
+Ouvrez **Administration → Journaux d'audit** (`/audit-logs`) pour consulter les mutations tenant enregistrées. `AUDIT_LOGS.READ` est requis ; l'accès n'est pas figé sur le rôle Admin, même si celui-ci le reçoit par défaut.
 
-!!! warning "Permission Administrateur Requise"
-    La consultation des journaux d'audit nécessite la permission administrateur. Seuls les utilisateurs ayant le rôle administrateur peuvent accéder à la section des journaux d'audit.
+## Tableau actuel
 
-## Consultation des Journaux d'Audit
+Le tableau affiche action, type d'entité, ID tronqué, utilisateur/nom si disponible et horodatage. La page filtre actuellement par une action et un type. Elle n'expose pas les filtres utilisateur, date ou ID pourtant disponibles à un niveau inférieur.
 
-Accédez aux **Journaux d'Audit** pour voir l'historique complet des modifications.
+Le contrat de filtre comprend Création, Mise à jour, Suppression, Restauration, Ajout de photo, Changement de statut et Ajustement, ainsi que produits/catégories/fournisseurs/emplacements/zones/clients/inventaire/rôles/mouvements/commandes/lignes/photos. Toutes les combinaisons ne sont pas émises : utilisateurs, marque, photos, notifications, tâches et actions superadmin ne vont pas dans cet audit tenant ; superadmin possède un audit plateforme séparé.
 
-Chaque entrée de journal inclut :
+## Limites actuelles
 
-- **Horodatage** - Quand la modification a eu lieu
-- **Utilisateur** - Qui a effectué la modification
-- **Action** - Type d'action (Créer, Modifier, Supprimer, Restaurer)
-- **Type d'Entité** - Ce qui a été modifié (Produit, Catégorie, etc.)
-- **ID de l'Entité** - L'élément spécifique modifié
-- **Modifications** - Valeurs avant/après
+L'interface n'affiche ni diff avant/après, IP, agent utilisateur, contexte de requête ou tiroir de détail. Les écritures tenant actuelles fixent changements et agent utilisateur à null.
 
-## Filtrage des Journaux
+Les écritures d'audit sont actuellement des effets asynchrones au mieux, pas dans la même transaction que la mutation métier. Une modification réussie peut donc ne pas avoir de ligne d'audit si l'insertion séparée échoue. Pour les garanties forensiques ou de conformité, appuyez-vous aussi sur les sauvegardes et données métier.
 
-Filtrez les journaux d'audit par :
-
-- **Type d'Entité** - Produits, Catégories, Commandes, etc.
-- **Action** - Créer, Modifier, Supprimer, Restaurer
-- **Utilisateur** - Utilisateur spécifique
-- **Période** - Plage de dates
-- **ID de l'Entité** - Élément spécifique
-
-## Comprendre les Modifications
-
-Pour les actions de modification, le journal affiche :
-
-```json
-{
-  "before": {
-    "name": "Ancien Nom du Produit",
-    "price": 100
-  },
-  "after": {
-    "name": "Nouveau Nom du Produit",
-    "price": 150
-  }
-}
-```
-
-## Types d'Actions
-
-| Action | Description |
-|--------|-------------|
-| CREATE | Nouvel élément créé |
-| UPDATE | Élément existant modifié |
-| DELETE | Élément supprimé temporairement |
-| RESTORE | Élément supprimé restauré |
-| ADJUST_QUANTITY | Quantité d'inventaire modifiée |
-| ADD_PHOTO | Photo ajoutée à l'élément |
-| STATUS_CHANGE | Champ de statut modifié |
-
-## Types d'Entités
-
-| Entité | Description |
-|--------|-------------|
-| PRODUCT | Produits d'inventaire |
-| CATEGORY | Catégories de produits |
-| SUPPLIER | Fiches fournisseurs |
-| ORDER | Commandes clients |
-| ORDER_ITEM | Articles de commande |
-| INVENTORY | Quantités en stock |
-| LOCATION | Emplacements de stockage |
-| STOCK_MOVEMENT | Mouvements de stock entre emplacements |
-| PHOTO | Images de produits |
-| AREA | Zones au sein des emplacements |
-| CLIENT | Fiches clients |
-| ROLE | Rôles utilisateurs |
-
-## Informations de Contexte
-
-Chaque journal d'audit inclut le contexte :
-
-- **Adresse IP** - Origine de la requête
-- **User Agent** - Informations navigateur/client
-- **ID Utilisateur** - Utilisateur authentifié
-
-## Cas d'Utilisation
-
-### Dépannage
-
-1. Trouver quand un produit a été modifié pour la dernière fois
-2. Voir qui a changé un prix
-3. Suivre les ajustements d'inventaire
-
-### Conformité
-
-1. Démontrer le suivi des modifications
-2. Fournir une piste d'audit pour les auditeurs
-3. Répondre aux exigences réglementaires
-
-### Récupération
-
-1. Identifier les modifications accidentelles
-2. Comprendre ce qui a été changé
-3. Restaurer manuellement les valeurs précédentes si nécessaire
+Le comportement de suppression varie selon le module ; une action `Delete` ne signifie pas que l'entité est restaurable.

--- a/docs/user-guide/audit-logs.md
+++ b/docs/user-guide/audit-logs.md
@@ -1,103 +1,17 @@
 # Audit Logs
 
-The audit log tracks all changes made to the system, providing a complete history for accountability and troubleshooting.
+Open **Admin → Audit Logs** (`/audit-logs`) to inspect recorded tenant mutations. Access needs `AUDIT_LOGS.READ`; it is not hard-coded to the Admin role, although Admin receives it by default.
 
-!!! warning "Admin Permission Required"
-    Viewing audit logs requires admin permission. Only users with the admin role can access the audit logs section.
+## Current table
 
-## Viewing Audit Logs
+The table shows action, entity type, a truncated entity ID, user/name when available, and timestamp. The page currently filters by one action and one entity type. It does not expose user, date, or entity-ID filters even though lower-level query support is broader.
 
-Navigate to **Audit Logs** to see the complete change history.
+The filter contract includes Create, Update, Delete, Restore, Add Photo, Status Change, and Adjust Quantity, plus product/category/supplier/location/area/client/inventory/role/movement/order/item/photo entities. Not every enum combination is emitted: users, branding, photos, notifications, tasks, and superadmin actions are not written to this tenant audit stream; superadmin uses a separate platform audit.
 
-Each log entry includes:
+## Current limits
 
-- **Timestamp** - When the change occurred
-- **User** - Who made the change
-- **Action** - Type of action (Create, Update, Delete, Restore)
-- **Entity Type** - What was changed (Product, Category, etc.)
-- **Entity ID** - The specific item changed
-- **Changes** - Before/after values
+The UI does not show before/after diffs, IP address, user agent, request context, or a detail drawer. Current tenant audit writes set changes and user agent to null.
 
-## Filtering Logs
+Audit writes are currently best-effort asynchronous effects, not part of the same database transaction as the domain mutation. A successful business change can therefore exist without a corresponding audit row if that separate insert fails. Use application/database backups and domain records—not this screen alone—for forensic or compliance guarantees.
 
-Filter audit logs by:
-
-- **Entity Type** - Products, Categories, Orders, etc.
-- **Action** - Create, Update, Delete, Restore
-- **User** - Specific user
-- **Date Range** - Time period
-- **Entity ID** - Specific item
-
-## Understanding Changes
-
-For update actions, the log shows:
-
-```json
-{
-  "before": {
-    "name": "Old Product Name",
-    "price": 100
-  },
-  "after": {
-    "name": "New Product Name",
-    "price": 150
-  }
-}
-```
-
-## Action Types
-
-| Action | Description |
-|--------|-------------|
-| CREATE | New item created |
-| UPDATE | Existing item modified |
-| DELETE | Item soft-deleted |
-| RESTORE | Deleted item restored |
-| ADJUST_QUANTITY | Inventory quantity changed |
-| ADD_PHOTO | Photo added to item |
-| STATUS_CHANGE | Status field changed |
-
-## Entity Types
-
-| Entity | Description |
-|--------|-------------|
-| PRODUCT | Inventory products |
-| CATEGORY | Product categories |
-| SUPPLIER | Supplier records |
-| ORDER | Client orders |
-| ORDER_ITEM | Order line items |
-| INVENTORY | Stock quantities |
-| LOCATION | Storage locations |
-| STOCK_MOVEMENT | Stock movements between locations |
-| PHOTO | Product images |
-| AREA | Zones within locations |
-| CLIENT | Client records |
-| ROLE | User roles |
-
-## Context Information
-
-Each audit log includes context:
-
-- **IP Address** - Origin of the request
-- **User Agent** - Browser/client information
-- **User ID** - Authenticated user
-
-## Use Cases
-
-### Troubleshooting
-
-1. Find when a product was last modified
-2. See who changed a price
-3. Track inventory adjustments
-
-### Compliance
-
-1. Demonstrate change tracking
-2. Provide audit trail for auditors
-3. Meet regulatory requirements
-
-### Recovery
-
-1. Identify accidental changes
-2. Understand what was changed
-3. Restore previous values manually if needed
+Deletion behavior varies by module; an audit `Delete` action does not imply every entity is restorable.

--- a/docs/user-guide/authentication.fr.md
+++ b/docs/user-guide/authentication.fr.md
@@ -1,0 +1,25 @@
+# Authentification et récupération du compte
+
+## Connexion
+
+Ouvrez l'hôte de votre tenant et saisissez e-mail et mot de passe sur `/login`. Stocket signale une adresse non vérifiée et permet de renvoyer le message. Des bandeaux confirment la vérification ou la réinitialisation au retour.
+
+Une visite non authentifiée d'une route protégée redirige vers la connexion. Le compte connecté doit également être membre de ce tenant.
+
+## Invitation et premier accès
+
+Les administrateurs tenant créent normalement les utilisateurs dans **Administration → Utilisateurs** et leur attribuent un ou plusieurs rôles. Un lien d'accueil/réinitialisation permet de définir le mot de passe. Les liens de vérification expirent après 24 heures et ne connectent pas automatiquement l'utilisateur.
+
+La page publique `/signup` crée un compte d'authentification mais aucune appartenance. Aucune UI admin tenant ne permet ensuite de rattacher ce compte, et recréer le même e-mail échoue. Le rattachement est donc une opération hors bande de plateforme/opérateur, pas l'onboarding normal.
+
+## Mot de passe oublié
+
+1. Choisissez **Mot de passe oublié** depuis la connexion.
+2. Envoyez l'adresse du compte. La réponse reste volontairement identique que l'adresse existe ou non.
+3. Suivez le lien reçu vers `/reset-password` et définissez un nouveau mot de passe.
+
+La réinitialisation révoque les sessions existantes. Reconnectez chaque appareil.
+
+## Actions de sécurité
+
+Ban/réactivation s'applique au compte global dans tous les tenants. La révocation ferme aussi toutes les sessions globalement. La suppression depuis un tenant retire ses rôles/appartenance et ne supprime le compte global qu'après sa dernière appartenance. L'utilisateur se déconnecte depuis **Paramètres → Compte**.

--- a/docs/user-guide/authentication.md
+++ b/docs/user-guide/authentication.md
@@ -1,0 +1,25 @@
+# Authentication and Account Recovery
+
+## Sign in
+
+Open your tenant host and enter your email and password on `/login`. Stocket warns when the address is not verified and can resend the verification message. Success and reset banners appear when you return from those flows.
+
+An unauthenticated visit to a protected tenant route redirects to login. A signed-in account must also have a membership in that tenant.
+
+## Invitations and first access
+
+Tenant administrators normally create users from **Admin → Users** and give them one or more roles. A welcome/reset link lets the new user set a password. Verification links expire after 24 hours and do not automatically sign the user in.
+
+The public `/signup` page can create an authentication account, but it does not currently create a tenant membership. There is no tenant-admin UI to attach that self-signed account afterward, and trying to create the same email again fails. Treat membership provisioning as an out-of-band platform/operator action, not normal onboarding.
+
+## Forgotten password
+
+1. Choose **Forgot password** on the login page.
+2. Submit the account email. The response is intentionally the same whether the address exists or not.
+3. Follow the emailed link to `/reset-password` and choose a new password.
+
+A successful reset revokes existing sessions. Sign in again on each device.
+
+## Security actions
+
+A ban/unban applies to the global account across all tenant memberships. Session revocation also ends all sessions globally. Deleting from a tenant removes that tenant's roles/membership and deletes the global account only after its final membership is gone. Users can sign out from **Settings → Account**.

--- a/docs/user-guide/branding.fr.md
+++ b/docs/user-guide/branding.fr.md
@@ -1,0 +1,21 @@
+# Personnalisation du tenant
+
+La marque fait partie des **Paramètres**. La lecture exige `SETTINGS.READ`, l'enregistrement `SETTINGS.WRITE`.
+
+L'endpoint de lecture n'est public qu'après résolution de l'hôte vers un tenant vérifié. Les changements de marque ne créent actuellement pas d'événement dans l'audit tenant.
+
+## Champs et effets
+
+| Champ | Comportement actuel |
+| --- | --- |
+| Nom de l'application | Définit le libellé/monogramme de marque et le titre du document. |
+| Slogan | Définit la description des métadonnées ; il n'est pas affiché comme sous-titre. |
+| URL du logo | Change le logo de la barre latérale. Connexion/inscription/récupération gardent le logo Stocket intégré. |
+| URL du favicon | Change l'icône du navigateur. |
+| Couleur principale | Est enregistrée, mais pas appliquée au thème visible par le provider actuel. |
+
+En environnement déployé, utilisez des URL HTTPS publiquement accessibles. Contrôlez la barre latérale et le favicon après enregistrement. La lecture peut rester en cache jusqu'à cinq minutes ; les autres sessions ne se mettent donc pas toujours à jour immédiatement.
+
+Le formulaire actuel ne semble pas désactivé pour un utilisateur en lecture seule, mais le serveur refuse l'enregistrement sans `SETTINGS.WRITE`.
+
+Pour thème personnel, langue, compte et PWA, consultez [Paramètres](settings.md).

--- a/docs/user-guide/branding.md
+++ b/docs/user-guide/branding.md
@@ -1,39 +1,21 @@
-# Branding & Customization
+# Tenant Branding
 
-Customize the look and feel of your Stocket instance with branding settings.
+Branding is part of **Settings**. Reading it needs `SETTINGS.READ`; saving changes needs `SETTINGS.WRITE`.
 
-## Branding Settings
+The read endpoint is public only after the request hostname has resolved to a verified tenant. Branding changes are not currently emitted to the tenant audit log.
 
-The branding configuration controls how the application appears to all users:
+## Fields and effects
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **App Name** | Application title shown in the header and browser tab | Stocket |
-| **Tagline** | Subtitle shown below the app name | — |
-| **Logo URL** | URL to the logo image displayed in the header | — |
-| **Favicon URL** | URL to the browser tab icon | — |
-| **Primary Color** | Main accent color used throughout the UI | — |
+| Field | Current behavior |
+| --- | --- |
+| App name | Sets the sidebar brand label/monogram and browser document title. |
+| Tagline | Sets metadata description; it is not rendered as a visible subtitle. |
+| Logo URL | Changes the sidebar logo. Login/signup/recovery pages keep the built-in Stocket mark. |
+| Favicon URL | Changes the browser icon. |
+| Primary color | Is persisted, but the current branding provider does not apply it to the visible theme. |
 
-!!! info "No Authentication Required to Read"
-    Branding settings are publicly readable so the login page can display your custom branding. Updating settings requires the **Settings: Write** permission.
+Use publicly reachable HTTPS asset URLs in deployed environments. Preview the sidebar and favicon after saving. Reads may be cached for up to five minutes, so other sessions do not always update immediately.
 
-## Updating Branding
+The current form is not visually disabled for a read-only Settings user, but the server rejects an attempted update without `SETTINGS.WRITE`.
 
-1. Navigate to **Settings**
-2. Find the **Branding** section
-3. Update the fields as needed:
-   - Enter your **App Name** (e.g., your company name)
-   - Add a **Tagline** (e.g., "Yacht Provisioning Management")
-   - Provide a **Logo URL** for your company logo
-   - Provide a **Favicon URL** for the browser tab icon
-   - Choose a **Primary Color** to match your brand
-4. Click **Save**
-
-Changes take effect immediately for all users.
-
-## Best Practices
-
-1. **Use a square logo** — Works best across header sizes and responsive layouts
-2. **Keep the app name short** — Long names may truncate on mobile devices
-3. **Test your color choice** — Ensure sufficient contrast with white text for accessibility
-4. **Host images reliably** — Use a CDN or stable URL for logo and favicon to avoid broken images
+For personal theme, language, account, and PWA behavior, see [Settings](settings.md).

--- a/docs/user-guide/categories.fr.md
+++ b/docs/user-guide/categories.fr.md
@@ -1,80 +1,21 @@
-# Gestion des Catégories
+# Catégories
 
-Les catégories aident à organiser vos produits dans une structure hiérarchique pour une navigation et un filtrage faciles.
+Les catégories organisent les produits en hiérarchie. Le frontend actuel n'a pas de route Catégories distincte ; l'arbre est intégré dans **Inventaire → Produits**.
 
-## Hiérarchie des Catégories
+## Naviguer et filtrer
 
-Les catégories peuvent être imbriquées pour créer une structure arborescente :
+Sélectionnez un dossier pour filtrer les produits. Le résultat inclut les catégories descendantes. Parcourez une branche ou revenez au niveau racine pour tous les produits.
 
-```
-Fournitures de Cuisine
-├── Alimentation & Boissons
-│   ├── Produits Frais
-│   └── Produits Secs
-├── Ustensiles de Cuisine
-└── Couverts
+## Créer
 
-Salle des Machines
-├── Pièces Détachées
-├── Lubrifiants
-└── Outils
-```
+Depuis la page Produits, créez une catégorie racine ou une enfant de la catégorie sélectionnée.
 
-## Affichage des Catégories
+- Le **nom** est obligatoire et unique parmi les catégories sœurs.
+- La **description** est facultative.
+- Le **parent** est facultatif pour une catégorie racine.
 
-L'arborescence des catégories est affichée dans la barre latérale lors de la consultation des produits. Cliquez sur une catégorie pour :
+Le frontend ne permet actuellement que de lister et créer. Il n'expose ni renommage, ni réaffectation, ni suppression. Choisissez donc un nom et un parent stables.
 
-- Voir les produits de cette catégorie
-- Voir les produits de toutes les sous-catégories
-- Développer/réduire les catégories enfants
+La suppression existe au niveau API mais n'est pas un flux utilisateur documenté : des produits peuvent la bloquer et la suppression d'un parent pourrait orpheliner ses enfants dans le modèle actuel.
 
-## Création d'une Catégorie
-
-1. Accédez aux **Catégories** ou cliquez sur **Gérer les Catégories**
-2. Cliquez sur **Créer une Catégorie**
-3. Remplissez les champs :
-   - **Nom** - Nom de la catégorie (requis)
-   - **Description** - Description optionnelle
-   - **Catégorie Parente** - Sélectionnez pour créer une sous-catégorie
-4. Cliquez sur **Enregistrer**
-
-!!! tip "Noms des Catégories"
-    Utilisez des noms clairs et descriptifs. Les noms de catégories doivent être uniques au sein du même niveau parent.
-
-## Modification des Catégories
-
-1. Cliquez sur le bouton de modification d'une catégorie
-2. Modifiez le nom, la description ou le parent
-3. Cliquez sur **Enregistrer**
-
-!!! warning "Changement de Parents"
-    Déplacer une catégorie vers un nouveau parent déplacera également toutes ses sous-catégories. Le système empêche les références circulaires (une catégorie ne peut pas être son propre ancêtre).
-
-## Suppression des Catégories
-
-La suppression d'une catégorie est soumise aux contraintes suivantes :
-
-- **Si des produits existent dans la catégorie**, la suppression **échouera**. Vous devez réassigner ou supprimer tous les produits de la catégorie avant de la supprimer.
-- **Les sous-catégories** verront leur référence parente mise à null (elles deviennent des catégories de premier niveau).
-
-!!! danger "Suppression de Catégorie"
-    Vous ne pouvez pas supprimer une catégorie qui contient encore des produits. L'API renverra une erreur. Déplacez ou supprimez d'abord tous les produits de la catégorie, puis supprimez la catégorie.
-
-## Bonnes Pratiques
-
-### Organisation des Catégories
-
-1. **Gardez-le peu profond** - Visez 2-3 niveaux d'imbrication
-2. **Soyez cohérent** - Utilisez des modèles de nommage similaires
-3. **Planifiez à l'avance** - Considérez la croissance future
-
-### Exemple de Structure
-
-Pour un inventaire d'approvisionnement de yacht :
-
-- **Cuisine** - Fournitures de cuisine et de table
-- **Entretien** - Linge, produits de nettoyage
-- **Sécurité** - Équipements de sécurité, premiers secours
-- **Salle des Machines** - Fournitures techniques
-- **Commodités Invités** - Articles de toilette, articles de luxe
-- **Pont** - Équipements extérieurs
+La lecture de l'arbre exige `PRODUCTS.READ`, la création `PRODUCTS.WRITE`.

--- a/docs/user-guide/categories.md
+++ b/docs/user-guide/categories.md
@@ -1,80 +1,21 @@
-# Managing Categories
+# Categories
 
-Categories help organize your products into a hierarchical structure for easy navigation and filtering.
+Categories organize products as a hierarchy. There is no separate Categories route in the current frontend; the category tree is embedded in **Inventory → Products**.
 
-## Category Hierarchy
+## Navigate and filter
 
-Categories can be nested to create a tree structure:
+Select a category folder to filter products. The result includes products in descendant categories. Move through the tree to focus on a branch or return to the top level for all products.
 
-```
-Galley Supplies
-├── Food & Beverages
-│   ├── Fresh Produce
-│   └── Dry Goods
-├── Cookware
-└── Utensils
+## Create
 
-Engine Room
-├── Spare Parts
-├── Lubricants
-└── Tools
-```
+From the Products page, create either a top-level category or a child of the selected category.
 
-## Viewing Categories
+- **Name** is required and must be unique among siblings.
+- **Description** is optional.
+- **Parent** is optional for a root category.
 
-The category tree is displayed in the sidebar when viewing products. Click on a category to:
+The frontend currently supports listing and creating categories only. It does not expose category rename, reparent, or deletion controls. Use stable names and choose the parent carefully.
 
-- View products in that category
-- See products in all subcategories
-- Expand/collapse child categories
+Category deletion exists at the API layer but is intentionally not documented as a user workflow: products can block it, and deleting a parent could orphan child categories in the current data model.
 
-## Creating a Category
-
-1. Navigate to **Categories** or click **Manage Categories**
-2. Click **Create Category**
-3. Fill in the fields:
-   - **Name** - Category name (required)
-   - **Description** - Optional description
-   - **Parent Category** - Select to create a subcategory
-4. Click **Save**
-
-!!! tip "Category Names"
-    Use clear, descriptive names. Category names must be unique within the same parent level.
-
-## Editing Categories
-
-1. Click the edit button on a category
-2. Modify the name, description, or parent
-3. Click **Save**
-
-!!! warning "Changing Parents"
-    Moving a category to a new parent will also move all its subcategories. The system prevents circular references (a category cannot be its own ancestor).
-
-## Deleting Categories
-
-Category deletion is subject to the following constraints:
-
-- **If products exist in the category**, the deletion will **fail**. You must reassign or remove all products from the category before deleting it.
-- **Subcategories** will have their parent reference set to null (they become top-level categories).
-
-!!! danger "Category Deletion"
-    You cannot delete a category that still contains products. The API will return an error. Move or delete all products in the category first, then delete the category.
-
-## Best Practices
-
-### Organizing Categories
-
-1. **Keep it shallow** - Aim for 2-3 levels of nesting
-2. **Be consistent** - Use similar naming patterns
-3. **Plan ahead** - Consider future growth
-
-### Example Structure
-
-For a yacht provisioning inventory:
-
-- **Galley** - Kitchen and dining supplies
-- **Housekeeping** - Linens, cleaning supplies
-- **Safety** - Safety equipment, first aid
-- **Engine Room** - Technical supplies
-- **Guest Amenities** - Toiletries, luxury items
-- **Deck** - Outdoor equipment
+Viewing the catalogue tree needs `PRODUCTS.READ`; category creation needs `PRODUCTS.WRITE`.

--- a/docs/user-guide/clients.fr.md
+++ b/docs/user-guide/clients.fr.md
@@ -1,0 +1,21 @@
+# Clients
+
+Les clients sont les comptes sélectionnés lors de la création des commandes. Ouvrez **Opérations → Clients** (`/clients`).
+
+## Parcourir
+
+La recherche couvre société/e-mail et un filtre couvre le statut. Les cartes affichent société, statut, yacht, contact, e-mail, téléphone et limite de crédit, avec actions de modification, statut et suppression. Il n'existe pas de page de détail ou d'historique des commandes du client.
+
+## Créer ou modifier
+
+Nom de société, personne de contact et e-mail valide sont obligatoires. Sont facultatifs : yacht, téléphone, adresses de facturation/livraison par défaut, statut, conditions de paiement, limite de crédit et notes.
+
+Actif, Suspendu et Inactif sont actuellement des métadonnées ; ils n'empêchent pas la sélection dans une nouvelle commande. Le formulaire charge au plus les 100 premiers clients et n'a pas de recherche client : vérifiez la fiche choisie.
+
+Choisir le client d'une commande ne recopie pas actuellement son adresse de livraison ni son yacht ; saisissez-les explicitement.
+
+## Supprimer
+
+Un client ne peut pas être supprimé tant qu'une commande le référence, même terminée ou annulée. Changer le statut ne retire pas ce lien. Préférez Inactif si l'historique doit rester.
+
+La lecture exige `CLIENTS.READ`, les modifications `CLIENTS.WRITE`.

--- a/docs/user-guide/clients.md
+++ b/docs/user-guide/clients.md
@@ -1,74 +1,21 @@
-# Managing Clients
+# Clients
 
-Clients represent the customers you provision for — typically yacht owners, management companies, or charter operators.
+Clients are the customer accounts selected when creating orders. Open **Operations → Clients** (`/clients`).
 
-## Understanding Clients
+## Browse
 
-Each client record stores contact details, billing information, and delivery preferences. Clients are linked to orders, allowing you to track provisioning history per customer.
+The card list can search company name/email and filter account status. Cards show company, status, yacht, contact, email, phone, and credit limit, with edit, status, and delete actions. There is no separate client detail or order-history page.
 
-### Client Statuses
+## Create or edit
 
-| Status | Description |
-|--------|-------------|
-| **ACTIVE** | Client is in good standing and can place orders |
-| **SUSPENDED** | Client is temporarily suspended (e.g., overdue payments) |
-| **INACTIVE** | Client is no longer active |
+Company name, contact person, and valid email are required. Optional fields are yacht name, phone, billing address, default delivery address, account status, payment terms, credit limit, and notes.
 
-## Viewing Clients
+Statuses are Active, Suspended, and Inactive metadata. They do not currently prevent selection in a new order. The order form loads at most the first 100 clients and has no client search, so use deliberate naming and confirm the selected record.
 
-Navigate to **Clients** from the sidebar to see all client records.
+Selecting a client while creating an order does not currently copy the client's delivery address or yacht into the order form; enter those values explicitly.
 
-The client list displays:
+## Delete
 
-- **Company Name** - Client organization
-- **Yacht Name** - Associated yacht
-- **Contact Person** - Primary contact
-- **Email** - Contact email address
-- **Status** - Account status (Active, Suspended, Inactive)
+A client cannot be deleted while any order references it, including completed or cancelled orders. Changing the order status does not remove the reference. Prefer Inactive when history must remain.
 
-!!! tip "Filtering Clients"
-    Use the search bar to find clients by name, yacht, or email. Filter by status to show only active or suspended clients.
-
-## Creating a Client
-
-1. Click the **Create Client** button
-2. Fill in the client details
-3. Click **Save**
-
-### Client Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Company Name | Yes | Client company or organization name |
-| Yacht Name | No | Name of the yacht being provisioned |
-| Contact Person | No | Primary point of contact |
-| Email | No | Contact email (must be unique) |
-| Phone | No | Contact phone number |
-| Billing Address | No | Address for invoicing |
-| Default Delivery Address | No | Default shipping destination |
-| Account Status | No | ACTIVE, SUSPENDED, or INACTIVE (defaults to ACTIVE) |
-| Payment Terms | No | Payment terms (e.g., "Net 30") |
-| Credit Limit | No | Maximum credit allowed |
-| Notes | No | Additional notes about the client |
-
-## Editing Clients
-
-1. Click on a client row to open the edit form
-2. Modify the fields as needed
-3. Click **Save** to apply changes
-
-!!! warning "Deleting Clients"
-    Deleting a client will **fail** if they have associated orders. You must cancel or complete all orders before deleting a client record.
-
-## Linking Clients to Orders
-
-When creating an order, you select a client from the client list. This links the order to the client and auto-populates the delivery address and yacht name from the client record.
-
-See [Order Processing](orders.md) for details on creating orders.
-
-## Best Practices
-
-1. **Keep yacht names updated** - Yachts may change names between seasons
-2. **Use status fields** - Suspend clients with payment issues rather than deleting them
-3. **Set default delivery addresses** - Saves time when creating repeat orders
-4. **Add payment terms** - Helps track credit and billing expectations
+Viewing needs `CLIENTS.READ`; changes need `CLIENTS.WRITE`.

--- a/docs/user-guide/dashboard.fr.md
+++ b/docs/user-guide/dashboard.fr.md
@@ -1,0 +1,15 @@
+# Tableau de bord
+
+La racine du tenant (`/`) fournit un résumé opérationnel :
+
+- nombres de produits, emplacements, lignes d'inventaire et stocks faibles ;
+- produits en stock faible ;
+- mouvements de stock récents ;
+- liste limitée des commandes actives/en attente ;
+- graphique du stock par emplacement.
+
+Le tableau exige `DASHBOARD.READ`. Ses cartes dépendent aussi des API Produits, Emplacements, Inventaire, Mouvements et Commandes. Selon les permissions du rôle et l'activation des Commandes, certaines données peuvent être indisponibles. La carte filtre les 10 premières commandes renvoyées selon les statuts actifs et en affiche au plus cinq : ce n'est pas un total de commandes.
+
+Un stock est faible lorsque la quantité est inférieure ou égale au seuil de réapprovisionnement du produit. Le graphique actuel s'appuie sur le résultat limité des stocks faibles : ce n'est ni une valorisation ni un rapport exhaustif.
+
+Utilisez les pages de chaque module pour les listes et filtres de référence ; le tableau est une vue de signal rapide.

--- a/docs/user-guide/dashboard.md
+++ b/docs/user-guide/dashboard.md
@@ -1,0 +1,15 @@
+# Dashboard
+
+The tenant root (`/`) provides an operational summary:
+
+- product, location, inventory, and low-stock counts;
+- low-stock products;
+- recent stock-movement ledger entries;
+- a limited list of active/pending orders;
+- a stock-by-location chart.
+
+The dashboard requires `DASHBOARD.READ`. Its cards also depend on the underlying Products, Locations, Inventory, Stock Movements, and Orders APIs. Depending on role permissions and whether Orders is enabled for the tenant, some data can be unavailable. The order card filters the first 10 returned orders to active statuses and displays at most five, so it is not an order total.
+
+Low stock means an inventory quantity is at or below the product's reorder point. The current location chart is derived from the limited low-stock result, so it is not a complete valuation or all-stock report.
+
+Use the module pages for authoritative lists and filters; the dashboard is a quick signal surface.

--- a/docs/user-guide/index.fr.md
+++ b/docs/user-guide/index.fr.md
@@ -1,76 +1,42 @@
-# Guide Utilisateur
+# Guide utilisateur
 
-Ce guide couvre l'utilisation de toutes les fonctionnalités du système Stocket Inventory.
+Stocket est une application d'inventaire multi-tenant fondée sur les hôtes. Ouvrez `https://<tenant>.stocket.fr` pour un espace tenant ; les administrateurs plateforme utilisent l'hôte dédié. En local : `http://<slug>.localhost:3000` et `http://localhost:3000`.
 
-## Aperçu
+## Navigation principale
 
-Stocket Inventory est un système de gestion d'inventaire pour l'approvisionnement des yachts, conçu pour gérer les articles de luxe, le linge, les cosmétiques et les commodités auprès de multiples fournisseurs.
+- **Tableau de bord** — compteurs, stock faible, mouvements, commandes et graphique par emplacement.
+- **Inventaire** — Produits, Emplacements et lignes d'Inventaire actuelles.
+- **Opérations** — Clients, Fournisseurs, Commandes et registre des Mouvements.
+- **Administration** — Journaux d'audit, Utilisateurs et Rôles selon vos permissions.
+- **Paramètres** — apparence, langue, compte et personnalisation du tenant.
 
-## Fonctionnalités Principales
+La plupart des liens groupés suivent permissions et fonctionnalités. Paramètres reste toujours visible, et le fallback sans rôle peut montrer Dashboard/Paramètres alors que la garde stricte redirige ; la visibilité n'est pas une garantie d'autorisation. `Ctrl+B` ou `Cmd+B` masque/affiche la barre. Il n'existe pas de recherche globale.
 
-### Produits
+## Ordre de configuration conseillé
 
-Gérez vos articles d'inventaire avec des informations détaillées incluant SKUs, prix, spécifications physiques et liens fournisseurs.
+1. Un administrateur plateforme crée le tenant et son premier administrateur.
+2. L'administrateur tenant configure les [utilisateurs et rôles](users-roles.md) et les [paramètres](settings.md).
+3. Créez les [catégories et produits](products.md), puis les [emplacements et zones](locations.md).
+4. Ajoutez l'[inventaire](inventory.md), les clients et fournisseurs.
+5. Utilisez les [commandes](orders.md) et le [registre des mouvements](stock-movements.md) selon votre flux.
 
-[:octicons-arrow-right-24: Produits](products.md)
+## Frontière importante du modèle
 
-### Catégories
+Inventaire et mouvements sont actuellement séparés. Ajouter ou ajuster une ligne d'inventaire ne crée pas de mouvement, et enregistrer un mouvement ne modifie pas l'inventaire. Un transfert exige donc des mises à jour explicites à la source et à la destination, plus éventuellement une écriture de registre.
 
-Organisez les produits dans une structure de catégories hiérarchique avec imbrication illimitée.
+## Navigateur et fonctionnement hors ligne
 
-[:octicons-arrow-right-24: Catégories](categories.md)
+Stocket peut être installé comme PWA. Le service worker précharge page de secours, manifeste et icônes et peut mettre en cache les ressources statiques récupérées. Les pages applicatives réussies et les données API ne sont ni stockées ni synchronisées pour un usage hors ligne. Toute opération exige une connexion.
 
-### Fournisseurs
+Le scanner utilise `BarcodeDetector` natif et n'accepte actuellement que les résultats QR. Sa disponibilité dépend du navigateur, de l'appareil, des permissions et d'un contexte sécurisé.
 
-Gérez les fiches fournisseurs, les coordonnées et associez les fournisseurs aux produits.
+## Aide par tâche
 
-### Clients
-
-Suivez les informations clients pour les commandes d'approvisionnement des yachts.
-
-### Emplacements
-
-Gérez les entrepôts, les locaux fournisseurs, les yachts clients et les articles en transit.
-
-[:octicons-arrow-right-24: Emplacements](locations.md)
-
-### Zones
-
-Définissez des zones, étagères et emplacements au sein des localisations pour un suivi précis de l'inventaire.
-
-[:octicons-arrow-right-24: Zones](areas.md)
-
-### Inventaire
-
-Suivez les quantités en stock à travers les emplacements avec numéros de lot et dates d'expiration.
-
-[:octicons-arrow-right-24: Inventaire](inventory.md)
-
-### Mouvements de Stock
-
-Suivez les mouvements de stock entre emplacements pour une traçabilité complète de l'inventaire.
-
-### Commandes
-
-Suivez les commandes d'approvisionnement des yachts tout au long de leur cycle de vie complet, du brouillon à la livraison.
-
-[:octicons-arrow-right-24: Commandes](orders.md)
-
-### Rôles & Utilisateurs
-
-Gérez les comptes utilisateurs et le contrôle d'accès basé sur les rôles.
-
-### Journaux d'Audit
-
-Consultez l'historique complet des modifications avec les différences avant/après et le suivi des utilisateurs.
-
-[:octicons-arrow-right-24: Journaux d'Audit](audit-logs.md)
-
-## Astuces Rapides
-
-!!! tip "Raccourcis Clavier"
-    - `Ctrl/Cmd + K` - Ouvrir la recherche
-    - `Ctrl/Cmd + B` - Basculer la barre latérale
-
-!!! tip "Scan QR"
-    Utilisez le bouton de code QR à côté des champs SKU pour scanner les codes-barres avec votre caméra.
+- [Authentification et récupération](authentication.md)
+- [Tableau de bord](dashboard.md)
+- [Produits et Smart Import](products.md)
+- [Emplacements, zones et inventaire](locations.md)
+- [Clients](clients.md) et [fournisseurs](suppliers.md)
+- [Commandes](orders.md) et [mouvements](stock-movements.md)
+- [Utilisateurs et rôles](users-roles.md), [audit](audit-logs.md) et [paramètres](settings.md)
+- [Administration plateforme](platform-administration.md)

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,90 +1,42 @@
 # User Guide
 
-This guide covers how to use all features of the Stocket Inventory system.
+Stocket is a host-based, multi-tenant inventory application. Open `https://<tenant>.stocket.fr` for a tenant workspace; platform administrators use the dedicated platform host. In local development those addresses are `http://<slug>.localhost:3000` and `http://localhost:3000`.
 
-## Overview
+## Main navigation
 
-Stocket Inventory is a yacht provisioning inventory management system designed for managing luxury goods, linens, cosmetics, and amenities across multiple suppliers.
+- **Dashboard** — operational counts, low-stock items, movements, orders, and a location chart.
+- **Inventory** — Products, Locations, and current Inventory rows.
+- **Operations** — Clients, Suppliers, Orders, and the Stock Movements ledger.
+- **Admin** — Audit Logs, Users, and Roles when your permissions allow them.
+- **Settings** — appearance, language, account actions, and tenant branding.
 
-## Core Features
+Most grouped sidebar links follow your permissions and tenant feature entitlements. Settings is always shown, and a no-role fallback can expose Dashboard/Settings links even when the stricter route guard redirects; link visibility is not an authorization guarantee. `Ctrl+B` or `Cmd+B` toggles the sidebar. There is no global command search.
 
-### Products
+## Suggested setup order
 
-Manage your inventory items with detailed information including SKUs, pricing, physical specifications, and supplier links.
+1. A platform administrator creates the tenant and its first administrator.
+2. The tenant administrator configures [users and roles](users-roles.md) and [branding/settings](settings.md).
+3. Create [categories and products](products.md), then [locations and areas](locations.md).
+4. Add [inventory](inventory.md), clients, and suppliers.
+5. Use [orders](orders.md) and the [stock-movement ledger](stock-movements.md) as required by your workflow.
 
-[:octicons-arrow-right-24: Products](products.md)
+## Important model boundary
 
-### Categories
+Inventory and stock movements are separate today. Adding or adjusting an inventory row does not create a movement, and recording a movement does not change inventory. A transfer therefore needs explicit inventory updates at the source and destination, plus an optional ledger entry for traceability.
 
-Organize products in a hierarchical category structure with unlimited nesting.
+## Browser and offline behavior
 
-[:octicons-arrow-right-24: Categories](categories.md)
+Stocket is installable as a PWA in supported browsers. Its service worker precaches the offline fallback, manifest, and brand icons and can cache fetched static assets. Successful application pages and API data are not stored or synchronized for offline use. Use a network connection for every data operation.
 
-### Suppliers
+The camera scanner uses the browser's native `BarcodeDetector` and currently accepts QR-code results. Availability depends on the browser, device, permission, and secure context.
 
-Manage supplier records, contact information, and link suppliers to products with pricing and lead times.
+## Help by task
 
-[:octicons-arrow-right-24: Suppliers](suppliers.md)
-
-### Clients
-
-Track client information, yacht details, and delivery preferences for provisioning orders.
-
-[:octicons-arrow-right-24: Clients](clients.md)
-
-### Locations
-
-Manage warehouses, supplier facilities, client yachts, and items in transit.
-
-[:octicons-arrow-right-24: Locations](locations.md)
-
-### Areas
-
-Define zones, shelves, and bins within locations for precise inventory placement.
-
-[:octicons-arrow-right-24: Areas](areas.md)
-
-### Inventory
-
-Track stock quantities across locations with batch numbers and expiry dates.
-
-[:octicons-arrow-right-24: Inventory](inventory.md)
-
-### Stock Movements
-
-Track stock movements between locations for full inventory traceability — purchases, sales, transfers, waste, and corrections.
-
-[:octicons-arrow-right-24: Stock Movements](stock-movements.md)
-
-### Orders
-
-Track yacht provisioning orders through their complete lifecycle from draft to delivery.
-
-[:octicons-arrow-right-24: Orders](orders.md)
-
-### Users & Roles
-
-Manage user accounts, assign roles, and control access with granular permissions.
-
-[:octicons-arrow-right-24: Users & Roles](users-roles.md)
-
-### Branding
-
-Customize the application name, logo, colors, and tagline.
-
-[:octicons-arrow-right-24: Branding](branding.md)
-
-### Audit Logs
-
-View complete change history with before/after diffs and user tracking.
-
-[:octicons-arrow-right-24: Audit Logs](audit-logs.md)
-
-## Quick Tips
-
-!!! tip "Keyboard Shortcuts"
-    - `Ctrl/Cmd + K` - Open search
-    - `Ctrl/Cmd + B` - Toggle sidebar
-
-!!! tip "QR Scanning"
-    Use the QR code button next to SKU fields to scan barcodes with your camera.
+- [Authentication and account recovery](authentication.md)
+- [Dashboard](dashboard.md)
+- [Products and Smart Import](products.md)
+- [Locations, areas, and inventory](locations.md)
+- [Clients](clients.md) and [suppliers](suppliers.md)
+- [Orders](orders.md) and [stock movements](stock-movements.md)
+- [Users and roles](users-roles.md), [audit logs](audit-logs.md), and [settings](settings.md)
+- [Platform administration](platform-administration.md)

--- a/docs/user-guide/inventory.fr.md
+++ b/docs/user-guide/inventory.fr.md
@@ -1,132 +1,29 @@
-# Gestion de l'Inventaire
+# Inventaire
 
-L'inventaire suit la quantité de produits à des emplacements et zones spécifiques. Il répond à la question : "Combien de ce produit se trouvent à cet endroit ?"
+L'inventaire est la quantité actuelle d'un produit dans un emplacement et éventuellement une zone. Ouvrez **Inventaire → Inventaire** (`/inventory`). Le service refuse normalement une combinaison produit/emplacement/zone dupliquée ; il s'agit d'un contrôle applicatif, pas d'une contrainte d'unicité en base.
 
-## Comprendre le Modèle d'Inventaire
+## Parcourir et filtrer
 
-```mermaid
-graph LR
-    P[Produit] --> I[Inventaire]
-    L[Emplacement] --> I
-    A[Zone] -.-> I
-    I --> Q[Quantité]
-```
+Le tableau paginé affiche produit/SKU, emplacement/zone, quantité, lot, expiration/statut et actions. Coût unitaire et date de réception sont disponibles en création/édition, pas comme colonnes. Filtrez par recherche, emplacement, zone, stock faible ou expiration. Les filtres restent dans l'URL.
 
-- **Produit** - Ce qu'est l'article (depuis le catalogue)
-- **Emplacement** - Où les articles sont stockés (entrepôt, fournisseur, etc.)
-- **Zone** - Placement spécifique optionnel (étagère, bac)
-- **Quantité** - Combien se trouvent à cet emplacement/zone
+- **Stock faible** : quantité inférieure ou égale au seuil produit.
+- **Expire bientôt** : date au plus tard dans 30 jours ; le filtre inclut aussi les lignes déjà expirées.
 
-!!! info "Un Enregistrement Par Combinaison"
-    Chaque combinaison unique de Produit + Emplacement + Zone possède un seul enregistrement d'inventaire. Utilisez le endpoint d'ajustement pour modifier les quantités.
+## Ajouter ou modifier une ligne
 
-## Affichage de l'Inventaire
+Choisissez produit et emplacement, puis éventuellement la zone. Saisissez une quantité entière non négative et, au besoin, lot, date d'expiration, coût unitaire et date de réception.
 
-Accédez à la section **Inventaire** depuis la barre latérale.
+La modification peut déplacer la ligne et fixer une quantité absolue. La suppression retire la ligne d'inventaire.
 
-La liste d'inventaire affiche :
+## Ajustement rapide
 
-- **Produit** - SKU et nom
-- **Emplacement** - Où se trouve l'inventaire
-- **Zone** - Placement spécifique (si défini)
-- **Quantité** - Niveau de stock actuel
-- **Expiration** - Date d'expiration (pour les périssables)
+**Ajuster** applique un delta entier positif ou négatif, sans pouvoir passer sous zéro. Le dialogue actuel ne demande aucun motif.
 
-### Filtrage de l'Inventaire
+## L'inventaire n'est pas le registre des mouvements
 
-Filtrez l'inventaire par :
+!!! warning
+    Créer, modifier, ajuster ou supprimer l'inventaire ne crée aucun mouvement. Enregistrer un mouvement ne change pas non plus l'inventaire.
 
-- **Produit** - Recherche par SKU ou nom
-- **Emplacement** - Filtrer par emplacement
-- **Zone** - Filtrer par zone
-- **Stock Bas** - Afficher les articles sous le point de réapprovisionnement
-- **Expiration Proche** - Afficher les articles expirant dans les 30 jours
+Pour un transfert physique, décrémentez la source puis créez ou incrémentez la destination. Ajoutez séparément un mouvement `INTERNAL_TRANSFER` si votre procédure exige une trace. Vérifiez les deux côtés.
 
-## Ajout d'Inventaire
-
-1. Cliquez sur le bouton **Ajouter de l'Inventaire**
-2. Sélectionnez un produit
-3. Sélectionnez un emplacement
-4. Sélectionnez optionnellement une zone au sein de cet emplacement
-5. Saisissez la quantité et les détails optionnels
-
-### Champs de l'Inventaire
-
-| Champ | Requis | Description |
-|-------|--------|-------------|
-| Produit | Oui | Produit du catalogue |
-| Emplacement | Oui | Emplacement de stockage |
-| Zone | Non | Zone spécifique au sein de l'emplacement |
-| Quantité | Oui | Nombre d'articles |
-| Numéro de Lot | Non | Numéro de lot ou de série |
-| Date d'Expiration | Non | Date d'expiration |
-| Coût Unitaire | Non | Coût d'achat |
-| Date de Réception | Non | Date de réception de l'inventaire |
-
-!!! warning "Prévention des Doublons"
-    Vous ne pouvez pas créer deux enregistrements d'inventaire pour le même produit au même emplacement/zone. Mettez à jour l'enregistrement existant à la place.
-
-## Ajustement des Quantités
-
-Utilisez la fonctionnalité **Ajuster** pour ajouter ou retirer de l'inventaire :
-
-1. Cliquez sur le bouton d'ajustement sur une ligne d'inventaire
-2. Saisissez le montant de l'ajustement :
-   - Nombre positif pour ajouter (ex. : `+50`)
-   - Nombre négatif pour retirer (ex. : `-10`)
-3. Cliquez sur **Ajuster** pour appliquer
-
-!!! tip "Ajustement vs Mise à Jour"
-    Utilisez **Ajuster** pour les modifications incrémentales (réception d'expédition, articles vendus). Utilisez **Mettre à Jour** pour définir une quantité absolue (corrections d'inventaire physique).
-
-## Déplacement d'Inventaire (Mouvements de Stock)
-
-Le module Mouvements de Stock vous permet de suivre et d'enregistrer les transferts d'inventaire entre emplacements :
-
-1. Accédez à **Mouvements de Stock**
-2. Cliquez sur **Créer un Mouvement**
-3. Sélectionnez l'emplacement source et l'emplacement de destination
-4. Sélectionnez le produit et la quantité à transférer
-5. Confirmez le mouvement
-
-Les mouvements de stock fournissent une piste d'audit complète des transferts d'inventaire, facilitant le suivi de l'endroit où le stock a été déplacé et par qui.
-
-## Alertes de Stock Bas
-
-Les produits ont un **point de réapprovisionnement** qui déclenche des alertes de stock bas :
-
-- Défini sur le produit (ex. : point de réapprovisionnement = 10)
-- Lorsque la quantité en inventaire est inférieure ou égale au point de réapprovisionnement, l'article apparaît dans le filtre de stock bas
-- Utilisez ceci pour savoir quand réapprovisionner auprès des fournisseurs
-
-## Suivi des Dates d'Expiration
-
-Pour les articles périssables :
-
-1. Définissez **Est Périssable** sur le produit
-2. Saisissez la **Date d'Expiration** lors de l'ajout d'inventaire
-3. Utilisez le filtre "Expiration Proche" pour voir les articles expirant dans les 30 jours
-
-## Inventaire sur Plusieurs Emplacements
-
-Le même produit peut exister à plusieurs emplacements :
-
-| Produit | Emplacement | Zone | Quantité |
-|---------|-------------|------|----------|
-| PROD-001 | Entrepôt Miami | Étagère A1 | 50 |
-| PROD-001 | Entrepôt Miami | Étagère B2 | 25 |
-| PROD-001 | Fournisseur Monaco | - | 100 |
-| PROD-001 | Yacht Bella | - | 5 |
-
-Cela vous permet de suivre :
-- Le stock en entrepôt par étagère
-- L'inventaire fournisseur
-- Les articles déjà livrés aux clients
-
-## Bonnes Pratiques
-
-1. **Utilisez les zones pour les grandes quantités** - Plus facile de trouver les articles lors de la préparation
-2. **Suivez les numéros de lot** - Aide en cas de rappels ou de problèmes de qualité
-3. **Définissez des points de réapprovisionnement** - Évitez les ruptures de stock
-4. **Inventaires physiques réguliers** - Ajustez les quantités pour correspondre aux comptages physiques
-5. **Suivez les dates d'expiration** - Particulièrement pour les cosmétiques et les consommables
+La lecture exige `INVENTORY.READ`, les modifications `INVENTORY.WRITE`. Les utilisateurs éligibles peuvent recevoir l'[e-mail de stock faible](notifications.md), dédupliqué quotidiennement, sauf désinscription.

--- a/docs/user-guide/inventory.md
+++ b/docs/user-guide/inventory.md
@@ -1,132 +1,29 @@
-# Managing Inventory
+# Inventory
 
-Inventory tracks the quantity of products at specific locations and areas. It answers the question: "How many of this product are at this place?"
+Inventory is the current quantity of a product at a location and optional area. Open **Inventory → Inventory** (`/inventory`). The service rejects a duplicate product/location/area combination during normal creation; this is an application check, not a database uniqueness constraint.
 
-## Understanding the Inventory Model
+## Browse and filter
 
-```mermaid
-graph LR
-    P[Product] --> I[Inventory]
-    L[Location] --> I
-    A[Area] -.-> I
-    I --> Q[Quantity]
-```
+The paginated table shows product/SKU, location/area, quantity, batch, expiry/status, and actions. Cost per unit and received date are available in create/edit, not displayed as table columns. Filter by search, location, area, low stock, or expiring stock. Filters are encoded in the URL so a filtered view can be revisited.
 
-- **Product** - What the item is (from the catalog)
-- **Location** - Where items are stored (warehouse, supplier, etc.)
-- **Area** - Optional specific placement (shelf, bin)
-- **Quantity** - How many are at that location/area
+- **Low stock** means quantity is at or below the product reorder point.
+- **Expiring** currently means expiry is no later than 30 days from now; it also includes already expired rows.
 
-!!! info "One Record Per Combination"
-    Each unique combination of Product + Location + Area has one inventory record. Use the adjust endpoint to change quantities.
+## Add or edit a row
 
-## Viewing Inventory
+Choose the product and location, then optionally an area. Enter a non-negative whole quantity and optional batch number, expiry date, cost per unit, and received date.
 
-Navigate to the **Inventory** section from the sidebar.
+Editing a row can move it to another location/area and set an absolute quantity. Deleting removes that inventory row.
 
-The inventory list displays:
+## Quick adjustment
 
-- **Product** - SKU and name
-- **Location** - Where the inventory is
-- **Area** - Specific placement (if set)
-- **Quantity** - Current stock level
-- **Expiry** - Expiration date (for perishables)
+Use **Adjust** for an integer delta, positive or negative. The resulting quantity cannot fall below zero. The current dialog has no reason field.
 
-### Filtering Inventory
+## Inventory is not the movement ledger
 
-Filter inventory by:
+!!! warning
+    Creating, editing, adjusting, or deleting inventory does not create a stock-movement entry. Recording a stock movement also does not change an inventory row.
 
-- **Product** - Search by SKU or name
-- **Location** - Filter by location
-- **Area** - Filter by area
-- **Low Stock** - Show items below reorder point
-- **Expiring Soon** - Show items expiring within 30 days
+For a physical transfer, decrement the source and create or increment the destination. Add an `INTERNAL_TRANSFER` movement separately if your audit procedure needs a ledger record. Verify both sides before leaving the workflow.
 
-## Adding Inventory
-
-1. Click the **Add Inventory** button
-2. Select a product
-3. Select a location
-4. Optionally select an area within that location
-5. Enter the quantity and optional details
-
-### Inventory Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Product | Yes | Product from catalog |
-| Location | Yes | Storage location |
-| Area | No | Specific area within location |
-| Quantity | Yes | Number of items |
-| Batch Number | No | Batch or lot number |
-| Expiry Date | No | Expiration date |
-| Cost per Unit | No | Purchase cost |
-| Received Date | No | When inventory was received |
-
-!!! warning "Duplicate Prevention"
-    You cannot create two inventory records for the same product at the same location/area. Update the existing record instead.
-
-## Adjusting Quantities
-
-Use the **Adjust** feature to add or remove inventory:
-
-1. Click the adjust button on an inventory row
-2. Enter the adjustment amount:
-   - Positive number to add (e.g., `+50`)
-   - Negative number to remove (e.g., `-10`)
-3. Click **Adjust** to apply
-
-!!! tip "Adjustment vs Update"
-    Use **Adjust** for incremental changes (received shipment, sold items). Use **Update** to set an absolute quantity (stock count corrections).
-
-## Moving Inventory (Stock Movements)
-
-The Stock Movements module allows you to track and record inventory transfers between locations:
-
-1. Navigate to **Stock Movements**
-2. Click **Create Movement**
-3. Select the source location and destination location
-4. Select the product and quantity to transfer
-5. Confirm the movement
-
-Stock movements provide a full audit trail of inventory transfers, making it easy to trace where stock has been moved and by whom.
-
-## Low Stock Alerts
-
-Products have a **reorder point** that triggers low stock alerts:
-
-- Set on the product (e.g., reorder point = 10)
-- When inventory quantity ≤ reorder point, it appears in low stock filter
-- Use this to know when to reorder from suppliers
-
-## Tracking Expiry Dates
-
-For perishable items:
-
-1. Set **Is Perishable** on the product
-2. Enter **Expiry Date** when adding inventory
-3. Use the "Expiring Soon" filter to see items expiring within 30 days
-
-## Inventory at Multiple Locations
-
-The same product can exist at multiple locations:
-
-| Product | Location | Area | Quantity |
-|---------|----------|------|----------|
-| PROD-001 | Miami Warehouse | Shelf A1 | 50 |
-| PROD-001 | Miami Warehouse | Shelf B2 | 25 |
-| PROD-001 | Monaco Supplier | - | 100 |
-| PROD-001 | Yacht Bella | - | 5 |
-
-This lets you track:
-- Warehouse stock by shelf
-- Supplier inventory
-- Items already delivered to clients
-
-## Best Practices
-
-1. **Use areas for large quantities** - Easier to find items during picking
-2. **Track batch numbers** - Helps with recalls or quality issues
-3. **Set reorder points** - Prevent stockouts
-4. **Regular stock counts** - Adjust quantities to match physical counts
-5. **Track expiry dates** - Especially for cosmetics and consumables
+Viewing needs `INVENTORY.READ`; changes need `INVENTORY.WRITE`. Eligible users can receive the daily-deduplicated [low-stock email](notifications.md) unless they opt out.

--- a/docs/user-guide/locations.fr.md
+++ b/docs/user-guide/locations.fr.md
@@ -1,79 +1,28 @@
-# Gestion des Emplacements
+# Emplacements
 
-Les emplacements représentent les lieux physiques où l'inventaire est stocké. Cela inclut les entrepôts, les locaux fournisseurs, les yachts clients et les articles en transit.
+Les emplacements représentent des entrepôts, fournisseurs, biens en transit ou sites clients. Ouvrez **Inventaire → Emplacements** (`/locations`).
 
-## Comprendre les Emplacements
+## Parcourir
 
-Les emplacements sont catégorisés par type :
+Recherchez et filtrez les cartes paginées par type et état actif. Une carte ouvre le détail et la hiérarchie des zones.
 
-| Type | Description | Cas d'utilisation |
-|------|-------------|-------------------|
-| **WAREHOUSE** | Vos installations de stockage | Stockage principal de l'inventaire |
-| **SUPPLIER** | Locaux de stockage des fournisseurs | Suivi du stock fournisseur |
-| **CLIENT** | Yacht ou locaux du client | Articles livrés aux clients |
-| **IN_TRANSIT** | Articles en cours de transport | Suivi des expéditions |
+## Créer ou modifier
 
-## Affichage des Emplacements
+| Champ | Notes |
+| --- | --- |
+| Nom | Obligatoire, 200 caractères maximum. |
+| Type | Entrepôt, Fournisseur, En transit ou Client. |
+| Adresse | Facultative. |
+| Contact | Facultatif. |
+| Téléphone | Facultatif. |
+| Actif | Métadonnée de statut/filtre. Les emplacements inactifs restent sélectionnables dans les formulaires actuels d'inventaire et de mouvement. |
 
-Accédez à la section **Emplacements** depuis la barre latérale pour voir tous les emplacements.
+## Supprimer sans perdre la cohérence
 
-La liste des emplacements affiche :
+Supprimer un emplacement supprime aussi ses zones. Les références d'inventaire peuvent être déplacées ou supprimées. Un mouvement bloque aussi la suppression, mais les mouvements sont immuables sans mise à jour/suppression supportée : conservez et désactivez alors l'emplacement.
 
-- **Nom** - Identifiant de l'emplacement
-- **Type** - Catégorie de l'emplacement
-- **Adresse** - Adresse physique
-- **Contact** - Personne de contact principale
-- **Statut** - Actif ou inactif
+La carte n'affiche pas l'historique complet ; utilisez les filtres d'Inventaire et de Mouvements.
 
-!!! tip "Filtrage des Emplacements"
-    Utilisez le filtre par type pour afficher uniquement les entrepôts, fournisseurs ou autres types d'emplacements.
+Consultez [Zones](areas.md) pour la hiérarchie et la limitation actuelle de suppression des parents.
 
-## Création d'un Emplacement
-
-1. Cliquez sur le bouton **Créer un Emplacement**
-2. Remplissez les champs obligatoires :
-   - **Nom** - Nom de l'emplacement (ex. : "Entrepôt Miami")
-   - **Type** - Sélectionnez le type d'emplacement
-   - **Adresse** - Adresse physique (optionnel)
-
-### Champs de l'Emplacement
-
-| Champ | Requis | Description |
-|-------|--------|-------------|
-| Nom | Oui | Nom d'affichage de l'emplacement |
-| Type | Oui | WAREHOUSE, SUPPLIER, CLIENT ou IN_TRANSIT |
-| Adresse | Non | Adresse physique |
-| Personne de Contact | Non | Nom du contact principal |
-| Téléphone | Non | Numéro de téléphone du contact |
-| Est Actif | Non | Disponibilité de l'emplacement (par défaut vrai) |
-
-## Modification des Emplacements
-
-1. Cliquez sur une ligne d'emplacement pour ouvrir le formulaire de modification
-2. Modifiez les champs selon vos besoins
-3. Cliquez sur **Enregistrer** pour appliquer les modifications
-
-!!! warning "Suppression des Emplacements"
-    La suppression d'un emplacement **échouera** si d'autres entités le référencent (enregistrements d'inventaire, zones, etc.). Vous devez supprimer ou réassigner tous les enregistrements d'inventaire et zones associés avant de supprimer un emplacement.
-
-## Hiérarchie des Emplacements
-
-Les emplacements peuvent contenir des **Zones** pour un suivi plus granulaire du placement :
-
-```
-Entrepôt Miami (Emplacement)
-├── Zone A (Zone)
-│   ├── Étagère A1 (Zone)
-│   └── Étagère A2 (Zone)
-├── Zone B (Zone)
-└── Stockage Froid (Zone)
-```
-
-Voir [Gestion des Zones](areas.md) pour les détails sur la création de zones au sein des emplacements.
-
-## Bonnes Pratiques
-
-1. **Utilisez des noms descriptifs** - Incluez la ville ou l'objectif (ex. : "Fournisseur Monaco - Linge")
-2. **Gardez les coordonnées à jour** - Facilite les réapprovisionnements rapides
-3. **Créez des zones pour les grands emplacements** - Suivez le placement exact au sein des entrepôts
-4. **Utilisez IN_TRANSIT pour les expéditions** - Suivez les articles en déplacement entre emplacements
+La lecture des emplacements/zones exige `LOCATIONS.READ`, les changements `LOCATIONS.WRITE`.

--- a/docs/user-guide/locations.md
+++ b/docs/user-guide/locations.md
@@ -1,79 +1,28 @@
-# Managing Locations
+# Locations
 
-Locations represent physical places where inventory is stored. This includes warehouses, supplier facilities, client yachts, and items in transit.
+Locations represent warehouses, suppliers, goods in transit, or client sites. Open **Inventory → Locations** (`/locations`).
 
-## Understanding Locations
+## Browse
 
-Locations are categorized by type:
+Search and filter the paginated cards by type and active status. Select a card to open its detail page and manage the area's hierarchy.
 
-| Type | Description | Use Case |
-|------|-------------|----------|
-| **WAREHOUSE** | Your storage facilities | Main inventory storage |
-| **SUPPLIER** | Vendor storage locations | Track supplier stock |
-| **CLIENT** | Yacht or client premises | Items delivered to clients |
-| **IN_TRANSIT** | Items being transported | Track shipments |
+## Create or edit
 
-## Viewing Locations
+| Field | Notes |
+| --- | --- |
+| Name | Required, up to 200 characters. |
+| Type | Warehouse, Supplier, In Transit, or Client. |
+| Address | Optional. |
+| Contact person | Optional. |
+| Phone | Optional. |
+| Active | Status/filter metadata. Inactive locations remain selectable in current inventory and movement forms. |
 
-Navigate to the **Locations** section from the sidebar to see all locations.
+## Delete safely
 
-The location list displays:
+Deleting a location also deletes its area rows. Inventory references can be moved or deleted first. A stock-movement reference also blocks deletion, but movements are immutable and have no supported update/delete workflow; retain and deactivate that location instead.
 
-- **Name** - Location identifier
-- **Type** - Category of location
-- **Address** - Physical address
-- **Contact** - Primary contact person
-- **Status** - Active or inactive
+The location card does not itself show complete inventory history; use Inventory and Stock Movements with the location filter.
 
-!!! tip "Filtering Locations"
-    Use the type filter to show only warehouses, suppliers, or other location types.
+See [Areas](areas.md) for the hierarchy and its current parent-deletion limitation.
 
-## Creating a Location
-
-1. Click the **Create Location** button
-2. Fill in the required fields:
-   - **Name** - Location name (e.g., "Miami Warehouse")
-   - **Type** - Select location type
-   - **Address** - Physical address (optional)
-
-### Location Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Name | Yes | Location display name |
-| Type | Yes | WAREHOUSE, SUPPLIER, CLIENT, or IN_TRANSIT |
-| Address | No | Physical address |
-| Contact Person | No | Primary contact name |
-| Phone | No | Contact phone number |
-| Is Active | No | Location availability (defaults to true) |
-
-## Editing Locations
-
-1. Click on a location row to open the edit form
-2. Modify the fields as needed
-3. Click **Save** to apply changes
-
-!!! warning "Deleting Locations"
-    Deleting a location will **fail** if other entities reference it (inventory records, areas, etc.). You must remove or reassign all associated inventory records and areas before deleting a location.
-
-## Location Hierarchy
-
-Locations can contain **Areas** for more granular placement tracking:
-
-```
-Miami Warehouse (Location)
-├── Zone A (Area)
-│   ├── Shelf A1 (Area)
-│   └── Shelf A2 (Area)
-├── Zone B (Area)
-└── Cold Storage (Area)
-```
-
-See [Managing Areas](areas.md) for details on creating areas within locations.
-
-## Best Practices
-
-1. **Use descriptive names** - Include city or purpose (e.g., "Monaco Supplier - Linens")
-2. **Keep contact info updated** - Helps with quick reordering
-3. **Create areas for large locations** - Track exact placement within warehouses
-4. **Use IN_TRANSIT for shipments** - Track items moving between locations
+Viewing locations/areas needs `LOCATIONS.READ`; changes need `LOCATIONS.WRITE`.

--- a/docs/user-guide/notifications.fr.md
+++ b/docs/user-guide/notifications.fr.md
@@ -1,0 +1,19 @@
+# Notifications
+
+Stocket envoie actuellement les e-mails transactionnels et les alertes de stock faible. Il n'existe pas encore de page Notifications dans le frontend ; les préférences sont disponibles via l'API tenant authentifiée `/api/v1/notifications/preferences`.
+
+## Catégories
+
+| Catégorie | Comportement actuel |
+| --- | --- |
+| Compte | Vérification, mot de passe et bienvenue. Les messages de compte obligatoires ne peuvent pas être désactivés. |
+| Alertes d'inventaire | E-mail de stock faible. Les utilisateurs avec `INVENTORY.READ` sont éligibles sauf désinscription. |
+| Cycle des commandes | Catégorie réservée ; l'envoi lors des changements de statut n'est pas implémenté aujourd'hui. |
+
+L'e-mail est le seul canal. Les valeurs par défaut sont actives, mais GET ne renvoie que les lignes de préférence stockées au lieu de matérialiser chaque valeur par défaut.
+
+## Scan de stock faible
+
+Le backend vérifie environ chaque minute. Un produit/emplacement au seuil ou en dessous peut générer un e-mail aux utilisateurs éligibles. L'envoi est dédupliqué une fois par utilisateur, produit et emplacement chaque jour.
+
+En développement/test, le transport console journalise les e-mails. Staging et production exigent Resend. Les hooks de compte sont asynchrones : un échec n'annule pas l'action compte. Le stock faible est envoyé par le scan planifié, pas directement par une mutation d'inventaire.

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -1,0 +1,19 @@
+# Notifications
+
+Stocket currently sends transactional email and low-stock alerts. There is no Notifications settings page in the frontend yet; preference management is available through the authenticated tenant API at `/api/v1/notifications/preferences`.
+
+## Categories
+
+| Category | Current behavior |
+| --- | --- |
+| Account | Verification, password reset, and welcome messages. Mandatory account messages cannot be opted out. |
+| Inventory alerts | Low-stock email. Users with `INVENTORY.READ` are eligible unless they opt out. |
+| Order lifecycle | Reserved preference category; order-status email delivery is not implemented today. |
+
+Email is the only notification channel. Defaults are enabled, but the GET response returns stored preference rows rather than synthesizing every default row.
+
+## Low-stock scan
+
+The backend checks roughly once per minute. A product/location at or below its reorder point can generate an email to eligible users. Delivery is deduplicated once per user, product, and location per day.
+
+In development/test, email is logged through the console transport. Staging and production require Resend configuration. Account-email hooks run asynchronously, so a mail failure does not roll back the account action. Low-stock delivery comes from the scheduled scan, not directly from an inventory mutation.

--- a/docs/user-guide/orders.fr.md
+++ b/docs/user-guide/orders.fr.md
@@ -1,16 +1,33 @@
-# Traitement des Commandes
+# Commandes
 
-Suivez les commandes d'approvisionnement des yachts tout au long de leur cycle de vie complet.
+Les commandes suivent les produits demandés par un client et leur livraison. **Opérations → Commandes** (`/orders`) exige la fonctionnalité tenant `ORDERS` et la permission correspondante.
 
-## Flux de Travail des Commandes
+## Parcourir
 
-Les commandes suivent ce cycle de vie :
+Recherchez numéro de commande ou société cliente et filtrez par statut. Le tableau affiche numéro, client, statut, nombre d'articles, total, création et actions. Il n'existe actuellement ni route de détail, kanban, assignation ou historique complet dans le frontend.
+
+## Créer
+
+Une commande commence toujours en **Brouillon**. Indiquez :
+
+- un client ;
+- l'adresse de livraison ;
+- au moins un article avec produit, quantité positive, prix unitaire non négatif et notes facultatives ;
+- éventuellement échéance, yacht et instructions.
+
+Choisir un produit préremplit son prix standard si disponible. Choisir le client ne recopie ni son adresse ni son yacht. Il n'existe pas d'option « enregistrer confirmée ».
+
+## Modifier et supprimer
+
+Les commandes Brouillon et Confirmée peuvent modifier adresse, échéance, yacht et instructions. L'interface actuelle ne change ni client ni lignes. Seul un Brouillon peut être supprimé.
+
+## Cycle des statuts
 
 ```mermaid
 graph LR
     A[Brouillon] --> B[Confirmée]
     B --> C[Approvisionnement]
-    C --> D[Préparation]
+    C --> D[Prélèvement]
     D --> E[Emballée]
     E --> F[Expédiée]
     F --> G[Livrée]
@@ -19,7 +36,7 @@ graph LR
     C --> H
     D --> H
     E --> H
-    B --> I[En Attente]
+    B --> I[En attente]
     C --> I
     D --> I
     E --> I
@@ -30,67 +47,6 @@ graph LR
     I --> E
 ```
 
-### Statuts des Commandes
+Les statuts décrivent uniquement le flux. Aucun endpoint de fulfillment monté ni contrôle explicite des quantités prélevées/emballées n'existe actuellement, et changer le statut ne réserve ni n'ajuste l'inventaire.
 
-| Statut | Description |
-|--------|-------------|
-| Brouillon | La commande est en cours de préparation |
-| Confirmée | La commande est confirmée et le traitement commence |
-| Approvisionnement | Les articles sont en cours d'approvisionnement |
-| Préparation | Les articles sont en cours de préparation |
-| Emballée | Les articles sont emballés et prêts à l'expédition |
-| Expédiée | La commande est en transit |
-| Livrée | La commande a été livrée |
-| Annulée | La commande a été annulée (accessible depuis Brouillon, Confirmée, Approvisionnement, Préparation, Emballée, En Attente) |
-| En Attente | La commande est temporairement suspendue (accessible depuis Confirmée, Approvisionnement, Préparation, Emballée ; peut revenir à ces statuts ou être Annulée) |
-
-### Champs de la Commande
-
-| Champ | Description |
-|-------|-------------|
-| Numéro de Commande | Identifiant unique de la commande |
-| Client | Fiche client associée |
-| Statut | Statut actuel de la commande |
-| Date Limite de Livraison | Date de livraison requise |
-| Adresse de Livraison | Destination d'expédition |
-| Nom du Yacht | Yacht cible pour l'approvisionnement |
-| Instructions Spéciales | Notes de livraison supplémentaires |
-| Montant Total | Total calculé de la commande |
-| Assignée À | Utilisateur responsable de la commande |
-| Créée Par | Utilisateur ayant créé la commande |
-| Confirmée Le | Horodatage de la confirmation |
-| Expédiée Le | Horodatage de l'expédition |
-| Livrée Le | Horodatage de la livraison |
-| ID Tâche Kanban | Lien vers la tâche du tableau kanban |
-
-## Création d'une Commande
-
-1. Accédez aux **Commandes**
-2. Cliquez sur **Créer une Commande**
-3. Remplissez les détails de la commande :
-   - **Client** - Sélectionnez un client dans la liste des clients
-   - **Adresse de Livraison** - Destination d'expédition
-   - **Nom du Yacht** - Yacht cible
-   - **Date Limite de Livraison** - Date de livraison requise
-   - **Instructions Spéciales** - Notes supplémentaires éventuelles
-4. Ajoutez les articles
-5. Enregistrez comme brouillon ou confirmez
-
-## Gestion des Articles de Commande
-
-Chaque commande contient des articles avec :
-
-- Référence produit
-- Quantité commandée
-- Prix unitaire
-- Quantité préparée
-- Quantité emballée
-
-## Historique des Commandes
-
-Toutes les modifications de commande sont suivies dans le journal d'audit :
-
-- Changements de statut
-- Ajouts/suppressions d'articles
-- Modifications de quantité
-- Changements d'affectation
+La lecture exige `ORDERS.READ`; création, modification, statut et suppression exigent `ORDERS.WRITE`.

--- a/docs/user-guide/orders.md
+++ b/docs/user-guide/orders.md
@@ -1,10 +1,27 @@
-# Order Processing
+# Orders
 
-Track yacht provisioning orders through their complete lifecycle.
+Orders track a client's requested products and delivery workflow. **Operations → Orders** (`/orders`) requires both the tenant's `ORDERS` feature and the relevant permission.
 
-## Order Workflow
+## Browse
 
-Orders follow this lifecycle:
+Search order number or client company and filter by status. The table shows order number, client, status, item count, total, creation time, and available actions. There is no separate detail route, kanban, assignee workflow, or full change history in the current frontend.
+
+## Create
+
+A new order always starts as **Draft**. Provide:
+
+- a client;
+- delivery address;
+- at least one item with product, positive quantity, non-negative unit price, and optional notes;
+- optional deadline, yacht name, and special instructions.
+
+Selecting a product prefills its standard price when available. Selecting a client does not copy the client's default address or yacht. There is no “save as confirmed” option.
+
+## Edit and delete
+
+Draft and Confirmed orders can edit delivery address, deadline, yacht, and instructions. The current edit UI does not change the client or line items. Only Draft orders can be deleted.
+
+## Status workflow
 
 ```mermaid
 graph LR
@@ -30,67 +47,6 @@ graph LR
     I --> E
 ```
 
-### Order Statuses
+Status labels describe workflow only. The application does not currently provide mounted fulfillment endpoints or explicit picked/packed quantity controls, and status changes do not reserve or adjust inventory.
 
-| Status | Description |
-|--------|-------------|
-| Draft | Order is being prepared |
-| Confirmed | Order is confirmed and processing begins |
-| Sourcing | Items are being sourced from suppliers |
-| Picking | Items are being picked from inventory |
-| Packed | Items are packed and ready for shipping |
-| Shipped | Order is in transit |
-| Delivered | Order has been delivered |
-| Cancelled | Order was cancelled (reachable from Draft, Confirmed, Sourcing, Picking, Packed, On Hold) |
-| On Hold | Order is temporarily paused (reachable from Confirmed, Sourcing, Picking, Packed; can return to those statuses or be Cancelled) |
-
-### Order Fields
-
-| Field | Description |
-|-------|-------------|
-| Order Number | Unique order identifier |
-| Client | Linked client record |
-| Status | Current order status |
-| Delivery Deadline | Required delivery date |
-| Delivery Address | Shipping destination |
-| Yacht Name | Target yacht for provisioning |
-| Special Instructions | Additional delivery notes |
-| Total Amount | Computed order total |
-| Assigned To | User responsible for the order |
-| Created By | User who created the order |
-| Confirmed At | Timestamp when order was confirmed |
-| Shipped At | Timestamp when order was shipped |
-| Delivered At | Timestamp when order was delivered |
-| Kanban Task ID | Link to kanban board task |
-
-## Creating an Order
-
-1. Navigate to **Orders**
-2. Click **Create Order**
-3. Fill in order details:
-   - **Client** - Select a client from the client list
-   - **Delivery Address** - Shipping destination
-   - **Yacht Name** - Target yacht
-   - **Delivery Deadline** - Required delivery date
-   - **Special Instructions** - Any additional notes
-4. Add line items
-5. Save as draft or confirm
-
-## Managing Order Items
-
-Each order contains line items with:
-
-- Product reference
-- Quantity ordered
-- Unit price
-- Quantity picked
-- Quantity packed
-
-## Order History
-
-All order changes are tracked in the audit log:
-
-- Status changes
-- Item additions/removals
-- Quantity changes
-- Assignment changes
+Viewing needs `ORDERS.READ`; creation, editing, status changes, and deletion need `ORDERS.WRITE`.

--- a/docs/user-guide/platform-administration.fr.md
+++ b/docs/user-guide/platform-administration.fr.md
@@ -1,0 +1,24 @@
+# Administration plateforme
+
+La console plateforme est réservée aux superadministrateurs Stocket, pas aux administrateurs tenant. Elle est accessible sur l'hôte plateforme configuré (`http://localhost:3000` en local). `/platform` sur un hôte tenant redirige vers l'application tenant.
+
+## Tenants
+
+La console liste le nom, le slug, l'hôte principal et la date de création. Elle permet d'ouvrir le tenant ou ses contrôles.
+
+La création exige un nom et un slug unique valide, puis le nom, l'e-mail et le mot de passe du premier administrateur. Un CSV produit optionnel peut démarrer un import pour le nouveau tenant.
+
+## Plans et fonctionnalités
+
+Chaque tenant a un plan : Free, Base, Growth ou Enterprise. Les fonctionnalités effectives héritent du plan et peuvent être forcées manuellement puis remises à la valeur du plan.
+
+- **Commandes** est activé par défaut.
+- **Smart Import** est activé par défaut pour Growth et Enterprise.
+
+Une surcharge reste prioritaire jusqu'à sa suppression. Les changements affectent la navigation et l'autorisation serveur.
+
+## Supprimer un tenant
+
+La suppression efface la plupart des données métier tenant, appartenances, domaines et métadonnées photo, sans retour possible. Elle ne retire pas les lignes de tâches du tenant, le compte Better Auth global ni tout le préfixe objet : l'opérateur doit vérifier et nettoyer séparément les enregistrements/objets S3 résiduels.
+
+Confirmez toujours l'ID, le slug, l'hôte et les besoins de sauvegarde avant suppression.

--- a/docs/user-guide/platform-administration.md
+++ b/docs/user-guide/platform-administration.md
@@ -1,0 +1,24 @@
+# Platform Administration
+
+The platform console is for Stocket superadministrators, not tenant administrators. It is available at the configured platform host (`http://localhost:3000` locally). `/platform` on a tenant host redirects to the tenant application.
+
+## Tenants
+
+The console lists tenant name, slug, primary hostname, and creation time. You can open a tenant or inspect its controls.
+
+Creating a tenant requires a tenant name and valid unique slug plus the first administrator's name, email, and password. An optional product CSV can be attached to start an import for the new tenant.
+
+## Plans and features
+
+Each tenant has one plan: Free, Base, Growth, or Enterprise. Effective features inherit from the plan and can be manually overridden or returned to the plan default.
+
+- **Orders** is enabled by default.
+- **Smart Import** is enabled by default for Growth and Enterprise.
+
+Overrides take precedence until cleared. Changes affect route/sidebar availability as well as server authorization.
+
+## Deleting a tenant
+
+Deletion removes most tenant business records, memberships, domains, and photo metadata and cannot be undone. The current path does not remove the tenant's background-task rows, global Better Auth account, or entire object-storage prefix, so operators must verify and clean residual records/S3 objects separately.
+
+Always confirm the tenant ID, slug, hostname, and backup requirements before deletion.

--- a/docs/user-guide/products.fr.md
+++ b/docs/user-guide/products.fr.md
@@ -1,123 +1,54 @@
-# Gestion des Produits
+# Produits
 
-Les produits sont au cœur du système Stocket Inventory. Chaque produit représente un article dans votre inventaire d'approvisionnement de yacht.
+Les produits sont des fiches catalogue propres au tenant. Ouvrez **Inventaire → Produits** (`/products`) pour parcourir, filtrer, créer, modifier et supprimer logiquement. Une carte ouvre le détail.
 
-## Affichage des Produits
+## Parcourir et filtrer
 
-Accédez à la section **Produits** depuis la barre latérale pour voir tous les produits.
+La grille affiche miniature, nom, SKU, catégorie, état actif, seuil de réapprovisionnement et caractère périssable. La recherche et l'arbre de catégories réduisent la liste ; le filtre catégorie inclut ses descendants.
 
-<!-- ![Liste des Produits](../assets/screenshots/products/product-list.png) -->
+La liste ne propose pas encore de filtre des produits supprimés. Une suppression logique individuelle affiche brièvement **Annuler** ; aucune suppression définitive n'est disponible. Le mode lot change le statut ou supprime les lignes de la page. Une action de restauration existe mais les lignes supprimées ne peuvent actuellement pas être sélectionnées.
 
-La liste des produits affiche :
+## Créer ou modifier
 
-- **SKU** - Identifiant unique du produit
-- **Nom** - Nom du produit
-- **Catégorie** - Catégorie du produit
-- **Prix** - Prix de vente standard
-- **Statut** - Actif ou inactif
+Le formulaire actuel gère :
 
-!!! tip "Filtrage des Produits"
-    Utilisez la barre latérale des catégories pour filtrer les produits par catégorie. Cliquez sur une catégorie pour afficher uniquement les produits de cette catégorie et de ses sous-catégories.
+- SKU, nom et catégorie obligatoires ;
+- unité et code-barres ;
+- coût et prix standards ;
+- seuil de réapprovisionnement ;
+- états actif et périssable ;
+- notes ;
+- plusieurs photos.
 
-## Création d'un Produit
+Le SKU est unique dans le tenant. Le changer ne casse pas les références fondées sur l'ID. Les images JPEG, PNG, WebP et GIF jusqu'à 10 Mio sont validées par contenu et peuvent être supprimées ; l'overhead partage la même limite HTTP de 10 Mio.
 
-1. Cliquez sur le bouton **Créer un Produit**
-2. Remplissez les champs obligatoires :
-   - **SKU** - Identifiant unique (peut être scanné via code QR)
-   - **Nom** - Nom du produit
-   - **Catégorie** - Sélectionnez dans l'arborescence des catégories
+Certains produits créés par import/API affichent des métadonnées supplémentaires dans le détail, par exemple une description ou des attributs physiques. Le formulaire web actuel ne les modifie pas et ne gère ni fournisseur principal ni SKU fournisseur.
 
-<!-- ![Formulaire Produit](../assets/screenshots/products/product-form.png) -->
+La vue `/products/:id` réunit les champs catalogue, statut, prix, seuil/périssable, notes et galerie photo lorsque ces valeurs existent.
 
-### Champs du Produit
+## Scan QR
 
-| Champ | Requis | Description |
-|-------|--------|-------------|
-| SKU | Oui | Unité de gestion de stock unique (max 50 car.) |
-| Nom | Oui | Nom d'affichage du produit (max 200 car.) |
-| Catégorie | Oui | Catégorie du produit |
-| Description | Non | Description détaillée |
-| Volume (ml) | Non | Volume en millilitres |
-| Poids (kg) | Non | Poids en kilogrammes |
-| Dimensions (cm) | Non | Dimensions, ex. : "10x10x5" |
-| Coût Standard | Non | Coût d'achat |
-| Prix Standard | Non | Prix de vente |
-| Pourcentage de Marge | Non | Pourcentage de majoration |
-| Point de Réapprovisionnement | Non | Seuil de stock bas (par défaut 0) |
-| Fournisseur Principal | Non | Lien vers une fiche fournisseur |
-| SKU Fournisseur | Non | SKU utilisé par le fournisseur |
-| Code-barres | Non | Valeur du code-barres, ex. : "0641628607549" |
-| Unité | Non | Unité de mesure, ex. : "unités" |
-| Est Actif | Non | Disponibilité du produit (par défaut vrai) |
-| Est Périssable | Non | Suivi de l'expiration (par défaut faux) |
-| Notes | Non | Notes supplémentaires |
+Le scanner remplit le SKU depuis un QR lorsque le navigateur fournit la caméra et `BarcodeDetector`. Il ne s'agit pas actuellement d'un décodeur général de codes-barres.
 
-### Utilisation du Scanner QR
+## Réapprovisionnement et inventaire
 
-Cliquez sur l'icône de code QR à côté du champ SKU pour scanner un code-barres :
+Le seuil est comparé à la quantité d'inventaire pour signaler le stock faible. Créer un produit ne crée pas de stock ; ajoutez des lignes dans [Inventaire](inventory.md). Désactiver un produit conserve ses données.
 
-<!-- ![Scanner QR](../assets/screenshots/products/qr-scanner.png) -->
+## Smart Import
 
-1. Autorisez l'accès à la caméra lorsque demandé
-2. Pointez la caméra vers le code-barres
-3. Le SKU sera automatiquement rempli
+**Importer des produits** n'apparaît que si le tenant possède `SMART_IMPORT` (par défaut Growth/Enterprise ou surcharge plateforme).
 
-## Modification des Produits
+1. Chargez un CSV normalisé ou un export Sortly.
+2. Ajoutez éventuellement jusqu'à 4 000 caractères d'instructions.
+3. Examinez la proposition structurée. Une couche IA peut participer ; sans clé fournisseur, des règles déterministes prennent le relais.
+4. Résolvez catégories, emplacements, zones/bacs, SKU de variantes dupliqués, photos, emplacements manquants et lignes à revoir.
+5. Ajustez les décisions déverrouillées, levez les blocages et envoyez.
+6. Gardez le worker backend séparé actif pendant le suivi de progression.
 
-1. Cliquez sur une ligne de produit pour ouvrir le formulaire de modification
-2. Modifiez les champs selon vos besoins
-3. Cliquez sur **Enregistrer** pour appliquer les modifications
+La revue affiche confiance, suggestions, blocages, décisions créer/existant/défaut et photos. Le traitement est une tâche PostgreSQL durable et idempotente. Le résultat fournit les nombres créés, mis à jour, ignorés, en erreur et de photos, et peut produire un CSV des erreurs par ligne.
 
-!!! warning "Modifications de SKU"
-    La modification du SKU d'un produit peut affecter les commandes et les enregistrements d'inventaire existants. Soyez prudent lors de la modification des SKUs.
+Il n'existe pas de modèle CSV téléchargeable dans l'interface actuelle. Conservez le CSV source et le résultat : un import ne se restaure pas en une seule opération.
 
-## Opérations en Masse
+## Permissions
 
-Sélectionnez plusieurs produits à l'aide des cases à cocher pour effectuer des actions en masse :
-
-- **Mise à Jour du Statut en Masse** - Activer ou désactiver plusieurs produits
-- **Suppression en Masse** - Supprimer temporairement plusieurs produits
-- **Restauration en Masse** - Restaurer des produits supprimés
-
-### Exécution des Actions en Masse
-
-1. Sélectionnez les produits à l'aide des cases à cocher
-2. Cliquez sur le bouton d'action dans la barre d'outils
-3. Confirmez l'action
-4. Consultez le résumé des résultats
-
-### Import CSV en Masse
-
-Vous pouvez importer plusieurs produits à la fois en utilisant un fichier CSV :
-
-1. Cliquez sur le bouton **Importer** dans la barre d'outils
-2. Téléchargez le modèle CSV pour voir le format attendu
-3. Remplissez les données produit dans le fichier CSV
-4. Téléversez le fichier CSV complété
-5. Vérifiez l'aperçu de l'import et confirmez
-
-!!! tip "Conseils pour l'Import CSV"
-    - Assurez-vous que les SKUs sont uniques et n'existent pas déjà dans le système
-    - Les noms de catégories doivent correspondre exactement aux catégories existantes
-    - Laissez les champs optionnels vides si non applicables
-
-## Suppression et Restauration
-
-Les produits sont supprimés temporairement par défaut, ce qui signifie qu'ils peuvent être restaurés :
-
-1. Supprimez un produit en utilisant le bouton de suppression
-2. Affichez les produits supprimés en basculant le filtre
-3. Cliquez sur **Restaurer** pour récupérer un produit supprimé
-
-!!! info "Suppression Définitive"
-    La suppression définitive d'un produit le retire entièrement de la base de données. Cette action est irréversible.
-
-## Images des Produits
-
-Téléchargez des images pour aider à identifier les produits :
-
-1. Cliquez sur la zone de téléchargement d'image
-2. Sélectionnez un fichier image
-3. L'image sera téléchargée et affichée
-
-Formats supportés : PNG, JPG, WebP
+La consultation exige `PRODUCTS.READ`, les mutations `PRODUCTS.WRITE`. Smart Import exige aussi `LOCATIONS.WRITE`, `INVENTORY.WRITE` et la fonctionnalité tenant. La création de catégorie est intégrée à cette page et suit l'autorisation catalogue correspondante.

--- a/docs/user-guide/products.md
+++ b/docs/user-guide/products.md
@@ -1,123 +1,54 @@
-# Managing Products
+# Products
 
-Products are the core of the Stocket Inventory system. Each product represents an item in your yacht provisioning inventory.
+Products are tenant-scoped catalogue records. Open **Inventory → Products** (`/products`) to browse, filter, create, edit, and soft-delete them. Opening a card shows the product detail page.
 
-## Viewing Products
+## Browse and filter
 
-Navigate to the **Products** section from the sidebar to see all products.
+The card grid shows the thumbnail, name, SKU, category, active state, reorder point, and perishable state. Use search and category navigation to narrow the list. Category filtering includes descendants.
 
-<!-- ![Product List](../assets/screenshots/products/product-list.png) -->
+The list does not currently expose a deleted-products filter. A single soft delete offers a short **Undo** toast; there is no hard-delete action in the UI. Bulk mode can change status or delete selected rows on the current page. Although a restore bulk action exists, deleted rows cannot currently be selected from this list.
 
-The product list displays:
+## Create or edit
 
-- **SKU** - Unique product identifier
-- **Name** - Product name
-- **Category** - Product category
-- **Price** - Standard selling price
-- **Status** - Active or inactive
+The current form supports:
 
-!!! tip "Filtering Products"
-    Use the category sidebar to filter products by category. Click on a category to show only products in that category and its subcategories.
+- required SKU, name, and category;
+- unit and barcode;
+- standard cost and standard price;
+- reorder point;
+- active and perishable flags;
+- notes;
+- multiple photos.
 
-## Creating a Product
+SKUs are unique within the tenant. Changing a SKU does not break ID-based references. The form accepts JPEG, PNG, WebP, and GIF images up to 10 MiB, validates their content, and lets you delete uploaded photos; request overhead shares the same 10 MiB HTTP body cap.
 
-1. Click the **Create Product** button
-2. Fill in the required fields:
-   - **SKU** - Unique identifier (can be scanned via QR code)
-   - **Name** - Product name
-   - **Category** - Select from the category tree
+Some imported/API-created products can display additional metadata on their detail page, such as description or physical attributes. The current web form cannot edit those fields and does not manage a primary supplier or supplier SKU.
 
-<!-- ![Product Form](../assets/screenshots/products/product-form.png) -->
+The `/products/:id` view combines catalogue fields, status, pricing, reorder/perishable information, notes, and a photo gallery when those values exist.
 
-### Product Fields
+## QR scanning
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| SKU | Yes | Unique stock keeping unit (max 50 chars) |
-| Name | Yes | Product display name (max 200 chars) |
-| Category | Yes | Product category |
-| Description | No | Detailed description |
-| Volume (ml) | No | Volume in milliliters |
-| Weight (kg) | No | Weight in kilograms |
-| Dimensions (cm) | No | Dimensions, e.g., "10x10x5" |
-| Standard Cost | No | Purchase cost |
-| Standard Price | No | Selling price |
-| Markup Percentage | No | Markup percentage |
-| Reorder Point | No | Low stock threshold (defaults to 0) |
-| Primary Supplier | No | Link to a supplier record |
-| Supplier SKU | No | SKU used by the supplier |
-| Barcode | No | Barcode value, e.g., "0641628607549" |
-| Unit | No | Unit of measure, e.g., "units" |
-| Is Active | No | Product availability (defaults to true) |
-| Is Perishable | No | Expiration tracking (defaults to false) |
-| Notes | No | Additional notes |
+The scanner can fill the SKU field from a QR code when the browser provides camera access and native `BarcodeDetector` support. It is not a general-purpose barcode decoder in the current UI.
 
-### Using the QR Scanner
+## Reorder and inventory
 
-Click the QR code icon next to the SKU field to scan a barcode:
+The reorder point is compared with inventory quantity to identify low stock. Product creation alone does not create inventory; add rows from [Inventory](inventory.md). Deactivating a product keeps its existing data.
 
-<!-- ![QR Scanner](../assets/screenshots/products/qr-scanner.png) -->
+## Smart Import
 
-1. Allow camera access when prompted
-2. Point camera at the barcode
-3. SKU will be automatically filled
+**Import Products** appears only when the tenant has the `SMART_IMPORT` feature (enabled by default on Growth and Enterprise or by a platform override).
 
-## Editing Products
+1. Upload a normalized CSV or Sortly export.
+2. Optionally add up to 4,000 characters of instructions.
+3. Review the structured proposal. The importer can use an AI proposal layer; without a provider key it uses deterministic rules.
+4. Resolve categories, locations, areas/bins, duplicate variant SKUs, photos, missing locations, and rows marked for review.
+5. Adjust unlocked decisions, resolve blockers, and submit.
+6. Keep the separate backend task worker running while the page polls progress.
 
-1. Click on a product row to open the edit form
-2. Modify the fields as needed
-3. Click **Save** to apply changes
+The review shows confidence, suggestions, blockers, create/existing/default decisions, and photo handling. Processing is a durable PostgreSQL background task with idempotent submission. The result reports created, updated, skipped, error, and photo counts and can provide a row-error CSV.
 
-!!! warning "SKU Changes"
-    Changing a product's SKU may affect existing orders and inventory records. Use caution when modifying SKUs.
+There is no downloadable CSV template in the current UI. Keep the source CSV and the final result because imports cannot be rolled back as one operation.
 
-## Bulk Operations
+## Permissions
 
-Select multiple products using the checkboxes to perform bulk actions:
-
-- **Bulk Status Update** - Activate or deactivate multiple products
-- **Bulk Delete** - Soft delete multiple products
-- **Bulk Restore** - Restore deleted products
-
-### Performing Bulk Actions
-
-1. Select products using checkboxes
-2. Click the action button in the toolbar
-3. Confirm the action
-4. View results summary
-
-### Bulk CSV Import
-
-You can import multiple products at once using a CSV file:
-
-1. Click the **Import** button in the toolbar
-2. Download the CSV template to see the expected format
-3. Fill in the product data in the CSV file
-4. Upload the completed CSV file
-5. Review the import preview and confirm
-
-!!! tip "CSV Import Tips"
-    - Ensure SKUs are unique and not already in the system
-    - Category names must match existing categories exactly
-    - Leave optional fields empty if not applicable
-
-## Soft Delete and Restore
-
-Products are soft-deleted by default, meaning they can be restored:
-
-1. Delete a product using the delete button
-2. View deleted products by toggling the filter
-3. Click **Restore** to bring back a deleted product
-
-!!! info "Hard Delete"
-    Permanently deleting a product removes it from the database entirely. This action cannot be undone.
-
-## Product Images
-
-Upload images to help identify products:
-
-1. Click the image upload area
-2. Select an image file
-3. The image will be uploaded and displayed
-
-Supported formats: PNG, JPG, WebP
+Viewing needs `PRODUCTS.READ`; mutations need `PRODUCTS.WRITE`. Smart Import additionally needs `LOCATIONS.WRITE`, `INVENTORY.WRITE`, and the tenant feature. Category creation is embedded in this page and follows the corresponding catalogue authorization.

--- a/docs/user-guide/settings.fr.md
+++ b/docs/user-guide/settings.fr.md
@@ -1,0 +1,27 @@
+# Paramètres
+
+Ouvrez **Paramètres** pour gérer votre apparence et votre compte, ainsi que la marque du tenant si vous y êtes autorisé.
+
+## Apparence et langue
+
+Les cinq choix sont Stocket clair, Stocket sombre, Clair, Sombre et Système. Système suit la préférence de l'OS avec les thèmes neutres. L'application propose anglais, allemand et français.
+
+## Compte
+
+La section actuelle permet la déconnexion ; elle n'affiche ni ne modifie le profil.
+
+## Personnalisation du tenant
+
+`SETTINGS.READ` permet la consultation ; `SETTINGS.WRITE` est requis pour enregistrer.
+
+| Champ | Effet visible actuel |
+| --- | --- |
+| Nom de l'application | Identité de la barre latérale et titre du document. |
+| Slogan | Description des métadonnées, pas sous-titre visible. |
+| URL du logo | Logo du tenant dans la barre latérale. Les pages d'auth utilisent encore le logo Stocket intégré. |
+| URL du favicon | Icône du navigateur. |
+| Couleur principale | Enregistrée, mais pas encore appliquée au thème visible. |
+
+Les lectures de la marque peuvent rester en cache jusqu'à cinq minutes. Réessayez plus tard si un autre utilisateur ne voit pas immédiatement le changement. Le formulaire semble actuellement modifiable pour un utilisateur en lecture seule, mais le serveur refuse l'enregistrement sans `SETTINGS.WRITE`.
+
+La PWA précharge la page de secours, le manifeste et les icônes, et peut mettre en cache les ressources statiques récupérées. Les pages de navigation réussies et les données API ne sont pas disponibles hors ligne ; toute opération exige une connexion.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -1,0 +1,27 @@
+# Settings
+
+Open **Settings** to control your own appearance and account, plus tenant branding when authorized.
+
+## Appearance and language
+
+The five choices are Stocket Light, Stocket Dark, Light, Dark, and System. System follows the operating-system preference with the neutral light/dark themes. Choose English, German, or French for the application language.
+
+## Account
+
+The current account section provides sign out; it does not display or edit profile details.
+
+## Tenant branding
+
+Users with `SETTINGS.READ` can view branding; updates require `SETTINGS.WRITE`.
+
+| Field | Current visible effect |
+| --- | --- |
+| App name | Sidebar identity and document title. |
+| Tagline | Page metadata description; it is not a visible sidebar subtitle. |
+| Logo URL | Tenant sidebar logo. Authentication pages still use the built-in Stocket mark. |
+| Favicon URL | Browser icon. |
+| Primary color | Stored for the tenant but not yet applied to the visible theme. |
+
+Branding reads can be cached for up to five minutes. Refresh later if another user does not immediately see a change. The current form remains editable-looking for read-only users, but the server rejects updates without `SETTINGS.WRITE`.
+
+The PWA precaches the offline fallback, manifest, and brand icons and can cache fetched static assets. Successful navigation HTML and API data are not available offline; settings and all data operations require a connection.

--- a/docs/user-guide/stock-movements.fr.md
+++ b/docs/user-guide/stock-movements.fr.md
@@ -1,0 +1,29 @@
+# Mouvements de stock
+
+Mouvements (`/stock-movements`) est un registre manuel de traçabilité. Il note pourquoi une quantité s'est déplacée entre emplacements, mais ne représente pas le solde actuel.
+
+## Enregistrer un mouvement
+
+Le formulaire accepte :
+
+- produit et quantité entière positive ;
+- motif ;
+- emplacements source et destination facultatifs ;
+- coût unitaire, référence et notes facultatifs.
+
+L'interface actuelle n'expose pas le lien de commande pourtant prévu dans le DTO.
+
+Motifs : Réception achat, Vente, Perte, Endommagé, Expiré, Correction de comptage, Retour client, Retour fournisseur et Transfert interne.
+
+## Parcourir
+
+Le tableau affiche date, produit/SKU, source → destination, quantité, motif et référence. Filtrez par un motif, produit ou emplacement. Coût, utilisateur, notes, commande et vue détaillée ne sont pas affichés ; aucune exportation/rapport n'est disponible.
+
+## Relation avec l'inventaire
+
+!!! warning
+    Insérer un mouvement n'ajuste pas l'inventaire. Ajuster l'inventaire n'ajoute pas de mouvement.
+
+Pour réception, vente, correction, retour ou transfert, modifiez explicitement les lignes d'inventaire. Un transfert décrémente normalement la source, crée/incrémente la destination, puis ajoute éventuellement un mouvement. Ces étapes ne sont pas atomiques : vérifiez le résultat.
+
+La lecture exige `STOCK_MOVEMENTS.READ`, l'enregistrement `STOCK_MOVEMENTS.WRITE`.

--- a/docs/user-guide/stock-movements.md
+++ b/docs/user-guide/stock-movements.md
@@ -1,104 +1,29 @@
 # Stock Movements
 
-Stock movements provide a complete audit trail of how inventory moves through the system — transfers between locations, purchase receipts, sales, waste, and corrections.
+Stock Movements (`/stock-movements`) is a manual traceability ledger. It records why a quantity moved between locations, but it is not the current inventory balance.
 
-## Understanding Stock Movements
+## Record a movement
 
-Every change to inventory quantity is recorded as a stock movement. This gives you full traceability of where stock came from, where it went, and why.
+The form accepts:
 
-### Movement Reasons
+- product and a positive whole quantity;
+- reason;
+- optional source and destination locations;
+- optional unit cost, reference number, and notes.
 
-| Reason | Description |
-|--------|-------------|
-| **PURCHASE_RECEIVE** | Stock received from a supplier purchase |
-| **SALE** | Stock sold or shipped to a client |
-| **WASTE** | Stock disposed of due to waste |
-| **DAMAGED** | Stock written off as damaged |
-| **EXPIRED** | Stock removed due to expiry |
-| **COUNT_CORRECTION** | Adjustment after a stock count or audit |
-| **RETURN_FROM_CLIENT** | Stock returned by a client |
-| **RETURN_TO_SUPPLIER** | Stock returned to a supplier |
-| **INTERNAL_TRANSFER** | Stock moved between locations |
+The UI does not currently expose the order link supported by the underlying DTO.
 
-## Viewing Stock Movements
+Reasons are Purchase Receive, Sale, Waste, Damaged, Expired, Count Correction, Return from Client, Return to Supplier, and Internal Transfer.
 
-Navigate to **Stock Movements** to see the movement history.
+## Browse
 
-Each movement record includes:
+The table shows date, product/SKU, source → destination, quantity, reason, and reference. Filter by one reason, product, or location. Cost, user, notes, order, and a detail view are not displayed, and there is no export/report action in the current page.
 
-- **Product** - The product that was moved
-- **From Location** - Source location (if applicable)
-- **To Location** - Destination location (if applicable)
-- **Quantity** - Number of units moved
-- **Reason** - Why the movement occurred
-- **Reference Number** - External reference (e.g., PO number, invoice)
-- **User** - Who recorded the movement
-- **Date** - When the movement was recorded
+## Relationship with inventory
 
-### Filtering Movements
+!!! warning
+    A movement insert does not adjust inventory. An inventory adjustment does not add a movement.
 
-Filter stock movements by:
+For a receipt, sale, correction, return, or transfer, update the affected inventory rows explicitly. A transfer normally means decrementing the source and creating/incrementing the destination, then optionally recording one movement. The application does not make those steps atomic, so verify the result.
 
-- **Reason** - Show only transfers, sales, waste, etc.
-- **Product** - All movements for a specific product
-- **Location** - All movements in or out of a location
-
-## Creating a Manual Movement
-
-For movements not triggered automatically (e.g., recording a received shipment):
-
-1. Click **Create Movement**
-2. Select the **Product**
-3. Set **From Location** and/or **To Location**
-4. Enter the **Quantity**
-5. Select the **Reason**
-6. Optionally add a **Reference Number** and **Notes**
-7. Click **Save**
-
-### Movement Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Product | Yes | The product being moved |
-| From Location | No | Source location (null for incoming stock) |
-| To Location | No | Destination location (null for outgoing stock) |
-| Quantity | Yes | Number of units |
-| Reason | Yes | Movement reason (see table above) |
-| Reference Number | No | External reference (PO number, invoice, etc.) |
-| Cost Per Unit | No | Unit cost at time of movement |
-| Order | No | Associated order (for sales/returns) |
-| Notes | No | Additional context |
-
-!!! info "Automatic Movements"
-    When you adjust inventory quantity via the **Adjust Quantity** action on an inventory record, a stock movement is automatically created with the reason you specify. You don't need to create a separate movement manually.
-
-## Movement Directions
-
-Stock movements use **from** and **to** locations to represent direction:
-
-| Scenario | From | To |
-|----------|------|-----|
-| Receive from supplier | — | Warehouse |
-| Ship to client | Warehouse | Client |
-| Internal transfer | Warehouse A | Warehouse B |
-| Write off waste | Warehouse | — |
-| Return from client | Client | Warehouse |
-
-!!! tip "One-Sided Movements"
-    Not all movements have both a from and to location. Receiving stock only needs a destination. Writing off stock only needs a source.
-
-## Stock Movement Reports
-
-Use the filtering capabilities to generate ad-hoc reports:
-
-- **Waste tracking** — Filter by WASTE + DAMAGED + EXPIRED to review losses
-- **Supplier receipts** — Filter by PURCHASE_RECEIVE to see incoming stock
-- **Transfer history** — Filter by INTERNAL_TRANSFER to audit location movements
-- **Product history** — Filter by product to see its full movement trail
-
-## Best Practices
-
-1. **Always provide a reason** - Enables accurate reporting on stock gains and losses
-2. **Use reference numbers** - Link movements to POs, invoices, or delivery notes
-3. **Add notes for corrections** - Explain why a count correction was needed
-4. **Review waste regularly** - Track patterns in damaged/expired stock to reduce losses
+Viewing needs `STOCK_MOVEMENTS.READ`; recording needs `STOCK_MOVEMENTS.WRITE`.

--- a/docs/user-guide/suppliers.fr.md
+++ b/docs/user-guide/suppliers.fr.md
@@ -1,0 +1,19 @@
+# Fournisseurs
+
+Les fournisseurs sont les contacts d'achat du tenant. Ouvrez **Opérations → Fournisseurs** (`/suppliers`).
+
+## Parcourir
+
+Recherchez par nom et filtrez actif/inactif. Les cartes proposent modification et suppression. L'état actif se change dans le formulaire ; il n'existe pas d'interrupteur rapide sur la carte.
+
+## Créer ou modifier
+
+Le nom est obligatoire. Contact, e-mail, téléphone, adresse, site HTTP(S), notes et état actif sont facultatifs.
+
+L'application actuelle n'expose ni lien fournisseur-produit, ni fournisseur principal, SKU fournisseur, historique de prix, commande d'achat ou performance fournisseur. Une modification ici ne met pas à jour un produit.
+
+## Supprimer ou désactiver
+
+La suppression retire la fiche après validation serveur. Désactivez-la si vous devez conserver son contexte opérationnel. Les produits n'ont actuellement pas de relation fournisseur manipulable dans cette interface.
+
+La lecture exige `SUPPLIERS.READ`, les modifications `SUPPLIERS.WRITE`.

--- a/docs/user-guide/suppliers.md
+++ b/docs/user-guide/suppliers.md
@@ -1,70 +1,19 @@
-# Managing Suppliers
+# Suppliers
 
-Suppliers are the vendors who provide products for your inventory. Each supplier record stores contact information and can be linked to specific products with pricing and lead time details.
+Suppliers are tenant master data for purchasing contacts. Open **Operations → Suppliers** (`/suppliers`).
 
-## Viewing Suppliers
+## Browse
 
-Navigate to **Suppliers** from the sidebar to see all supplier records.
+Search by supplier name and filter active/inactive state. Cards expose edit and delete actions. Active state is changed by editing the record; there is no card-level quick toggle.
 
-The supplier list displays:
+## Create or edit
 
-- **Name** - Supplier company name
-- **Contact Person** - Primary contact
-- **Email** - Contact email
-- **Phone** - Contact phone number
-- **Status** - Active or inactive
+Name is required. Contact person, email, phone, address, HTTP(S) website, notes, and active state are optional.
 
-!!! tip "Searching Suppliers"
-    Use the search bar to find suppliers by name, contact person, or email.
+The current application does not expose supplier-product linking, primary supplier selection, supplier SKUs, pricing histories, purchase orders, or supplier performance. Do not expect changes here to update a product.
 
-## Creating a Supplier
+## Delete or deactivate
 
-1. Click the **Create Supplier** button
-2. Fill in the supplier details
-3. Click **Save**
+Delete removes the master-data record after server validation. Deactivate a supplier when you need to retain it for operational context. Products do not currently have a user-operable supplier relationship in this UI.
 
-### Supplier Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| Name | Yes | Supplier company name |
-| Contact Person | No | Primary point of contact |
-| Email | No | Contact email address |
-| Phone | No | Contact phone number |
-| Address | No | Physical address |
-| Website | No | Supplier website URL |
-| Notes | No | Additional notes (e.g., speciality, payment terms) |
-| Is Active | No | Whether the supplier is currently active (defaults to true) |
-
-## Editing Suppliers
-
-1. Click on a supplier row to open the edit form
-2. Modify the fields as needed
-3. Click **Save** to apply changes
-
-!!! warning "Deleting Suppliers"
-    Deleting a supplier will **fail** if products reference it as their primary supplier. Reassign or remove the supplier link from all products before deleting.
-
-## Supplier-Product Linking
-
-Products can be linked to one or more suppliers via the **supplier products** relationship. This tracks supplier-specific details for each product:
-
-| Field | Description |
-|-------|-------------|
-| Supplier SKU | The supplier's own SKU for the product |
-| Cost Per Unit | Purchase price from this supplier |
-| Lead Time (Days) | Expected delivery time |
-| Minimum Order Quantity | Minimum units per order |
-| Is Preferred | Whether this is the preferred supplier for the product |
-
-### Primary Supplier
-
-Each product can designate one **primary supplier** — used as the default for reordering. This is set on the product record itself, not on the supplier-product link.
-
-## Best Practices
-
-1. **Keep contact info current** - Enables quick reordering during urgent provisions
-2. **Track lead times** - Critical for planning yacht provisioning with tight deadlines
-3. **Use the preferred flag** - Marks the go-to supplier when multiple options exist
-4. **Set minimum order quantities** - Prevents under-ordering and rejected purchase orders
-5. **Deactivate rather than delete** - Keep historical supplier data for audit purposes
+Viewing needs `SUPPLIERS.READ`; changes need `SUPPLIERS.WRITE`.

--- a/docs/user-guide/users-roles.fr.md
+++ b/docs/user-guide/users-roles.fr.md
@@ -1,0 +1,39 @@
+# Utilisateurs et rôles
+
+Ouvrez **Administration → Utilisateurs** (`/users`) et **Administration → Rôles** (`/roles`). Les permissions `USERS` et `ROLES` contrôlent séparément lecture et écriture.
+
+## Utilisateurs
+
+Créez un utilisateur avec nom, e-mail et mot de passe d'au moins huit caractères ; les rôles sont facultatifs. La liste propose recherche et filtre de rôle ; le backend actuel recherche le nom, pas l'e-mail.
+
+Avec `USERS.WRITE`, vous pouvez :
+
+- modifier les rôles ;
+- bannir ou réactiver immédiatement ;
+- révoquer toutes les sessions ;
+- supprimer l'utilisateur.
+
+Le bannissement actuel n'a ni motif, ni expiration, ni confirmation. Il est global au compte Better Auth dans tous ses tenants et ne révoque pas seul les sessions existantes ; utilisez aussi **Révoquer les sessions** pour couper immédiatement l'accès. Un changement de rôle invalide le cache. Un utilisateur sans rôle n'a aucune permission tenant : attribuez toujours un rôle intentionnel.
+
+## Modèle de permissions
+
+Une permission associe une ressource à `READ` ou `WRITE`. Ressources actuelles : Dashboard, Orders, Clients, Suppliers, Stock Movements, Products, Locations, Inventory, Audit Logs, Users, Settings et Roles. Une fonctionnalité tenant, comme Orders ou Smart Import, peut encore restreindre une route autorisée.
+
+## Rôles système initiaux
+
+| Rôle | Droits actuels |
+| --- | --- |
+| Admin | Dashboard L ; Orders, Clients, Suppliers, Stock Movements, Products, Locations, Inventory, Users, Settings, Roles L/É ; Audit Logs L. |
+| Warehouse Manager | Dashboard L ; Stock Movements, Suppliers, Products, Locations, Inventory, Settings L/É. |
+| Picker | Dashboard, Orders, Stock Movements, Products, Locations L ; Inventory et Settings L/É. |
+| Sales | Dashboard L ; Orders et Clients L/É ; Products et Inventory L ; Settings L/É. |
+
+Il s'agit des définitions semées, pas de modèles immuables. Les rôles système sont actuellement modifiables mais pas supprimables.
+
+## Rôles personnalisés
+
+Créez un nom puis choisissez chaque paire ressource/action. Un rôle personnalisé peut être modifié ou supprimé. Sa suppression retire ses affectations utilisateur au lieu d'être bloquée : examinez les comptes concernés et attribuez un remplacement d'abord.
+
+## Administration sûre
+
+Conservez au moins un compte Admin opérationnel. Testez un rôle personnalisé avec un compte non critique. Révoquez les sessions après une compromission ; retirer un rôle ne clôt pas la session authentifiée, même si l'autorisation est recalculée.

--- a/docs/user-guide/users-roles.md
+++ b/docs/user-guide/users-roles.md
@@ -1,161 +1,39 @@
-# Users & Roles
+# Users and Roles
 
-Stocket uses role-based access control (RBAC) to manage what each user can see and do. Roles contain permissions, and users are assigned one or more roles.
+Open **Admin → Users** (`/users`) and **Admin → Roles** (`/roles`). Access is controlled separately by `USERS` and `ROLES` read/write permissions.
 
-## Understanding Permissions
+## Users
 
-Permissions are defined as a combination of **Resource** and **Permission level**:
+Create a user with name, email, and a password of at least eight characters; role assignment is optional. The list has a search field and role filter; the current backend search matches the user's name, not email.
 
-| Resource | Description |
-|----------|-------------|
-| DASHBOARD | Home dashboard |
-| STOCK | Stock overview and movements |
-| PRODUCTS | Product catalog |
-| LOCATIONS | Locations and areas |
-| INVENTORY | Inventory records |
-| AUDIT_LOGS | Audit log viewer |
-| USERS | User management |
-| SETTINGS | Application settings |
-| ROLES | Role management |
+Available actions depend on `USERS.WRITE`:
 
-Each resource supports two permission levels:
+- edit a user's roles;
+- ban or unban immediately;
+- revoke all active sessions;
+- delete the user.
 
-| Level | Description |
-|-------|-------------|
-| **READ** | View data |
-| **WRITE** | Create, update, and delete data |
+The current ban action has no reason, expiry, or confirmation step. A ban is global to the Better Auth account across tenant memberships and does not itself revoke existing sessions; use **Revoke sessions** as well when access must end immediately. Role changes invalidate the normal permission cache immediately. A user with no assigned role has no tenant permissions; always assign an intentional role.
 
-!!! info "Default Permissions"
-    Users with no roles assigned receive default permissions: Dashboard (read) and Settings (read/write).
+## Permission model
 
-## System Roles
+Permissions combine a resource with `READ` or `WRITE`. Current resources are Dashboard, Orders, Clients, Suppliers, Stock Movements, Products, Locations, Inventory, Audit Logs, Users, Settings, and Roles. A tenant feature such as Orders or Smart Import can further restrict a permitted route.
 
-Four built-in roles are created automatically on first startup:
+## Seeded system roles
 
-| Role | Permissions |
-|------|-------------|
-| **Admin** | Full access — all resources, read and write |
-| **Warehouse Manager** | Stock, Products, Locations, Inventory (R/W) + Settings (R/W) |
-| **Picker** | Stock, Products, Locations (read) + Inventory (R/W) + Settings (R/W) |
-| **Sales** | Stock, Products, Inventory (read) + Settings (R/W) |
+| Role | Current grants |
+| --- | --- |
+| Admin | Dashboard R; Orders, Clients, Suppliers, Stock Movements, Products, Locations, Inventory, Users, Settings, Roles R/W; Audit Logs R. |
+| Warehouse Manager | Dashboard R; Stock Movements, Suppliers, Products, Locations, Inventory, Settings R/W. |
+| Picker | Dashboard, Orders, Stock Movements, Products, Locations R; Inventory and Settings R/W. |
+| Sales | Dashboard R; Orders and Clients R/W; Products and Inventory R; Settings R/W. |
 
-!!! warning "System roles cannot be deleted"
-    The four built-in roles are marked as system roles and cannot be removed. You can create additional custom roles to suit your organization.
+These are the seeded definitions, not immutable templates. System roles can currently be edited, but cannot be deleted.
 
-## Managing Roles
+## Custom roles
 
-### Viewing Roles
+Create a role name and choose each resource/action pair. Custom roles can be edited and deleted. Deleting a custom role removes its user assignments rather than being blocked, so review affected users first and give them a replacement role.
 
-Navigate to **Settings > Roles** to see all roles. Each role shows its name, description, and whether it's a system role.
+## Safe administration
 
-### Creating a Custom Role
-
-1. Click **Create Role**
-2. Enter a **Name** and **Description**
-3. Use the **Permissions Matrix** to select which resources the role can read or write
-4. Click **Save**
-
-The permissions matrix displays a grid of resources (rows) and permission levels (columns). Check the boxes to grant access.
-
-### Editing a Role
-
-1. Click on a role to open the edit form
-2. Modify the name, description, or permissions
-3. Click **Save**
-
-!!! tip "Permission Changes Take Effect Quickly"
-    Permission lookups are cached for 1 minute. After changing a role's permissions, affected users will see the changes within 60 seconds without needing to log out.
-
-### Deleting a Role
-
-1. Click the delete button on a custom role
-2. Confirm the deletion
-
-System roles cannot be deleted. Custom roles can only be deleted if they are not currently assigned to users.
-
-## Managing Users
-
-### Viewing Users
-
-Navigate to **Settings > Users** to see all user accounts. The user list shows:
-
-- **Name** - Display name
-- **Email** - Login email
-- **Roles** - Assigned roles
-- **Status** - Active, banned, etc.
-- **Created** - Account creation date
-
-Use the search bar to find users by name or email. Filter by role to see all users with a specific role.
-
-### Assigning Roles
-
-1. Click on a user to open their profile
-2. Click **Update Roles**
-3. Select one or more roles from the list
-4. Click **Save**
-
-Users can have multiple roles. Permissions are merged — a user gets the union of all permissions from their assigned roles.
-
-### Banning a User
-
-If you need to temporarily or permanently restrict a user:
-
-1. Click on the user
-2. Click **Ban User**
-3. Enter a **Reason** for the ban
-4. Optionally set an **Expiry Date** for a temporary ban
-5. Confirm
-
-Banned users are immediately logged out and cannot sign in until unbanned or the ban expires.
-
-### Unbanning a User
-
-1. Click on the banned user
-2. Click **Unban User**
-3. Confirm
-
-### Revoking Sessions
-
-To force a user to log in again (e.g., after a security concern):
-
-1. Click on the user
-2. Click **Revoke Sessions**
-3. Confirm
-
-This invalidates all active sessions. The user will need to sign in again.
-
-### Deleting a User
-
-1. Click on the user
-2. Click **Delete User**
-3. Confirm
-
-!!! danger "User deletion is permanent"
-    Deleting a user removes their account entirely. Audit logs referencing the user will retain the user ID but the account cannot be recovered.
-
-## Permission Resolution
-
-When a user makes a request, the system resolves their permissions by:
-
-1. Loading all roles assigned to the user
-2. Collecting all permissions from those roles
-3. Merging permissions (union) — if any role grants access, the user has access
-
-```mermaid
-graph LR
-    A[User] --> B[Role: Admin]
-    A --> C[Role: Custom]
-    B --> D[Products: R/W]
-    B --> E[Users: R/W]
-    C --> F[Products: R]
-    C --> G[Inventory: R/W]
-    D & E & F & G --> H[Merged: Products R/W, Users R/W, Inventory R/W]
-```
-
-## Best Practices
-
-1. **Use the principle of least privilege** — Assign the minimum roles needed for each user's job
-2. **Create custom roles for specialized needs** — Don't modify system roles; create new ones
-3. **Review role assignments periodically** — Remove unnecessary permissions as responsibilities change
-4. **Use ban with expiry for temporary restrictions** — Avoids forgetting to unban later
-5. **Revoke sessions after role changes** — Ensures the user picks up new permissions immediately
+Keep at least one working Admin account. Test a custom role with a non-critical user before broad assignment. Revoke sessions after suspected account compromise; role removal alone does not end an already authenticated session, although authorization is reevaluated.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: Stocket Inventory Documentation
-site_description: Yacht provisioning inventory management system
+site_name: Stocket Documentation
+site_description: Multi-tenant inventory, operations, and platform documentation
 site_url: https://stocketfr.github.io/documentation/
 repo_url: https://github.com/stocketfr/documentation
-repo_name: stocket/documentation
-copyright: Copyright &copy; 2025 Stocket Inventory
+repo_name: stocketfr/documentation
+copyright: Copyright &copy; 2026 Stocket
 
 theme:
   name: material
@@ -48,13 +48,13 @@ plugins:
           default: true
           name: English
           build: true
-          site_name: "Stocket Inventory Documentation"
-          site_description: "Yacht provisioning inventory management system"
+          site_name: "Stocket Documentation"
+          site_description: "Multi-tenant inventory, operations, and platform documentation"
         - locale: fr
           name: Français
           build: true
-          site_name: "Documentation Stocket Inventory"
-          site_description: "Système de gestion d'inventaire pour yachts"
+          site_name: "Documentation Stocket"
+          site_description: "Documentation de l'inventaire, des opérations et de la plateforme multi-tenant"
           nav_translations:
             Home: Accueil
             Getting Started: Démarrage
@@ -62,7 +62,8 @@ plugins:
             Quick Start: Démarrage rapide
             Configuration: Configuration
             User Guide: Guide Utilisateur
-            Overview: Aperçu
+            Authentication: Authentification
+            Dashboard: Tableau de bord
             Products: Produits
             Categories: Catégories
             Locations: Emplacements
@@ -74,9 +75,13 @@ plugins:
             Stock Movements: Mouvements de stock
             Users & Roles: Utilisateurs & Rôles
             Branding: Personnalisation
+            Settings: Paramètres
+            Notifications: Notifications
+            Platform Administration: Administration plateforme
             Audit Logs: Journaux d'audit
             Development: Développement
             Architecture: Architecture
+            Project & Module Map: Carte des projets et modules
             Setup: Configuration
             Code Style: Style de code
             Testing: Tests
@@ -143,6 +148,8 @@ nav:
       - Configuration: getting-started/configuration.md
   - User Guide:
       - user-guide/index.md
+      - Authentication: user-guide/authentication.md
+      - Dashboard: user-guide/dashboard.md
       - Products: user-guide/products.md
       - Categories: user-guide/categories.md
       - Suppliers: user-guide/suppliers.md
@@ -154,10 +161,14 @@ nav:
       - Orders: user-guide/orders.md
       - Users & Roles: user-guide/users-roles.md
       - Branding: user-guide/branding.md
+      - Settings: user-guide/settings.md
+      - Notifications: user-guide/notifications.md
       - Audit Logs: user-guide/audit-logs.md
+      - Platform Administration: user-guide/platform-administration.md
   - Development:
       - development/index.md
       - Architecture: development/architecture.md
+      - Project & Module Map: development/project-map.md
       - Setup: development/setup.md
       - Code Style: development/code-style.md
       - Testing: development/testing.md

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -1,0 +1,175 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const docsRoot = path.join(root, 'docs')
+const markdownFiles = []
+
+function walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name)
+    if (entry.isDirectory()) walk(filePath)
+    else if (entry.isFile() && entry.name.endsWith('.md')) {
+      markdownFiles.push(filePath)
+    }
+  }
+}
+
+walk(docsRoot)
+
+const toPosix = (filePath) => filePath.split(path.sep).join('/')
+const fromRoot = (filePath) => toPosix(path.relative(root, filePath))
+const englishFiles = markdownFiles.filter(
+  (filePath) => !filePath.endsWith('.fr.md'),
+)
+const frenchFiles = markdownFiles.filter((filePath) =>
+  filePath.endsWith('.fr.md'),
+)
+const errors = []
+
+for (const filePath of englishFiles) {
+  const counterpart = filePath.replace(/\.md$/, '.fr.md')
+  if (!fs.existsSync(counterpart)) errors.push(`Missing FR: ${fromRoot(filePath)}`)
+}
+
+for (const filePath of frenchFiles) {
+  const counterpart = filePath.replace(/\.fr\.md$/, '.md')
+  if (!fs.existsSync(counterpart)) errors.push(`Missing EN: ${fromRoot(filePath)}`)
+}
+
+function structureFor(filePath) {
+  const lines = fs.readFileSync(filePath, 'utf8').split('\n')
+  const headings = []
+  let fences = 0
+  let tableRows = 0
+  let openFence
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      fences += 1
+      const marker = fenceMatch[1]
+      if (!openFence) {
+        openFence = marker
+      } else if (
+        marker[0] === openFence[0] &&
+        marker.length >= openFence.length
+      ) {
+        openFence = undefined
+      }
+      continue
+    }
+    if (openFence) continue
+
+    const headingMatch = line.match(/^(#{1,6}) /)
+    if (headingMatch) headings.push(headingMatch[1].length)
+    if (/^\|(?:.*\|)+\s*$/.test(line)) tableRows += 1
+  }
+
+  return {
+    headings,
+    fences,
+    tableRows,
+  }
+}
+
+for (const filePath of markdownFiles) {
+  const contents = fs.readFileSync(filePath, 'utf8')
+  const structure = structureFor(filePath)
+  if (!contents.trim()) errors.push(`Empty page: ${fromRoot(filePath)}`)
+  if (structure.headings.filter((level) => level === 1).length !== 1) {
+    errors.push(`Page must contain exactly one H1: ${fromRoot(filePath)}`)
+  }
+  if (structure.fences % 2 !== 0) {
+    errors.push(`Unbalanced code fence: ${fromRoot(filePath)}`)
+  }
+}
+
+for (const filePath of englishFiles) {
+  const counterpart = filePath.replace(/\.md$/, '.fr.md')
+  if (!fs.existsSync(counterpart)) continue
+
+  const english = structureFor(filePath)
+  const french = structureFor(counterpart)
+  if (JSON.stringify(english.headings) !== JSON.stringify(french.headings)) {
+    errors.push(`Heading structure differs: ${fromRoot(filePath)}`)
+  }
+  if (english.fences !== french.fences) {
+    errors.push(`Code-fence parity differs: ${fromRoot(filePath)}`)
+  }
+  if (english.tableRows !== french.tableRows) {
+    errors.push(`Table-row parity differs: ${fromRoot(filePath)}`)
+  }
+}
+
+const linkFiles = [...markdownFiles, path.join(root, 'README.md')].filter(
+  fs.existsSync,
+)
+for (const filePath of linkFiles) {
+  const contents = fs.readFileSync(filePath, 'utf8')
+  const markdownLink = /\[[^\]]*\]\(([^)]+)\)/g
+  for (const match of contents.matchAll(markdownLink)) {
+    let target = match[1].trim()
+    if (target.startsWith('<') && target.endsWith('>')) {
+      target = target.slice(1, -1)
+    }
+    target = target.split(/\s+["']/)[0]
+    if (!target || /^(?:https?:|mailto:|#)/.test(target)) continue
+
+    target = decodeURIComponent(target.split('#')[0].split('?')[0])
+    if (!target) continue
+    if (!fs.existsSync(path.resolve(path.dirname(filePath), target))) {
+      errors.push(`Broken link: ${fromRoot(filePath)} -> ${match[1]}`)
+    }
+  }
+}
+
+const mkdocs = fs.readFileSync(path.join(root, 'mkdocs.yml'), 'utf8')
+const navStart = mkdocs.indexOf('\nnav:')
+const navText = navStart >= 0 ? mkdocs.slice(navStart) : ''
+const navPaths = Array.from(
+  navText.matchAll(/(?:^|\s)([A-Za-z0-9_./-]+\.md)(?:\s|$)/gm),
+  (match) => match[1],
+)
+const navSet = new Set(navPaths)
+const englishPaths = englishFiles.map((filePath) =>
+  toPosix(path.relative(docsRoot, filePath)),
+)
+
+for (const navPath of navSet) {
+  if (!fs.existsSync(path.join(docsRoot, navPath))) {
+    errors.push(`Missing nav target: ${navPath}`)
+  }
+  if (!englishPaths.includes(navPath)) {
+    errors.push(`Nav target is not an English source page: ${navPath}`)
+  }
+}
+
+for (const englishPath of englishPaths) {
+  if (!navSet.has(englishPath)) {
+    errors.push(`English page absent from nav: ${englishPath}`)
+  }
+}
+
+if (navPaths.length !== navSet.size) errors.push('Duplicate nav page path')
+
+if (errors.length > 0) {
+  console.error(errors.join('\n'))
+  process.exitCode = 1
+} else {
+  console.log(
+    JSON.stringify(
+      {
+        markdownFiles: markdownFiles.length,
+        englishPages: englishFiles.length,
+        frenchPages: frenchFiles.length,
+        navPages: navSet.size,
+        pageIntegrity: 'ok',
+        relativeLinks: 'ok',
+        localeStructure: 'ok',
+      },
+      null,
+      2,
+    ),
+  )
+}


### PR DESCRIPTION
## Summary

- audit every existing documentation page against the current `meta`, backend, frontend, packages, remote-desktop, infrastructure, landing, and documentation repositories
- rewrite architecture, setup, development, reference, contribution, roadmap, and user guidance for the federated repository/runtime model and current product behavior
- add a bilingual project/module map plus missing English/French guides for authentication, dashboard, notifications, settings, platform administration, and previously untranslated modules
- add a dependency-free documentation audit and run it before both pull-request builds and Pages deployment
- update the documentation workflows to current GitHub Action runtimes

## Notable accuracy updates

- documents the separate API/task-worker runtime, SSR same-origin API path, durable Smart Import flow, and current environment/migration requirements
- distinguishes inventory from the immutable stock-movement ledger and calls out best-effort audit logging, unmounted fulfillment, and limited PWA offline behavior
- records the settled no-persistent-CD boundary after the audited one-off July rollout, including the infrastructure helper's exact health and failure-recovery limits
- aligns user workflows with current permissions, tenancy, global account effects, feature gates, route behavior, and UI limitations

## Verification

- `node --check scripts/audit-docs.mjs`
- `node scripts/audit-docs.mjs` — 80 Markdown pages, 40 EN/FR pairs, 40 nav pages, page integrity/relative links/locale structure all OK
- `git diff origin/main...HEAD --check`
- repository/module/package coverage check and confirmation that every pre-existing documentation page was treated
- two independent final source-backed re-audits found no remaining actionable issues
- [GitHub Actions CI](https://github.com/stocketfr/documentation/actions/runs/29260032801) — audit and `mkdocs build --strict` passed

The strict build was not run locally because local builds were not requested; the pull-request workflow completed it successfully.
