### PR TITLE
docs(mcp): document architecture and safety model

### DIFF
--- a/docs/development/index.fr.md
+++ b/docs/development/index.fr.md
@@ -14,6 +14,8 @@ Stocket Inventory est un workspace multi-repo contenant :
 ## Liens Rapides
 
 - [Architecture](architecture.md) - Conception du système et stack technique
+- [Architecture IA et MCP](mcp-api.md) - capacités IA typées, confirmation,
+  changements durables, annulation et frontières d'accès distant
 - [Configuration](setup.md) - Configuration de l'environnement de développement
 - [Style de Code](code-style.md) - ESLint, Prettier et conventions
 - [Tests](testing.md) - Patterns de tests Vitest

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -18,6 +18,8 @@ Stocket Inventory is a **pnpm monorepo** containing:
 ## Quick Links
 
 - [Architecture](architecture.md) — System design and tech stack
+- [AI and MCP Architecture](mcp-api.md) — typed AI capabilities, confirmation,
+  durable changes, undo, and remote-access boundaries
 - [Setup](setup.md) — Development environment configuration
 - [Code Style](code-style.md) — oxlint, Prettier, and conventions
 - [Testing](testing.md) — Vitest + Playwright patterns

--- a/docs/development/mcp-api.fr.md
+++ b/docs/development/mcp-api.fr.md
@@ -1,0 +1,353 @@
+# Architecture IA et MCP
+
+Stocket ajoute une frontière applicative Model Context Protocol (MCP) afin
+qu'un assistant IA puisse agir sur les données d'inventaire avec les mêmes
+règles métier que l'application web. La cible est MCP `2025-11-25`, exposé à
+l'hôte IA propriétaire via `/api/v1/mcp`.
+
+!!! warning "Périmètre actuel"
+    L'endpoint actuel est un prototype produit authentifié et same-origin pour
+    l'application Stocket intégrée. Ce n'est pas un serveur MCP distant public,
+    et le système durable de change sets nécessaire aux commandes bulk sûres
+    n'est pas encore implémenté. Les sections suivantes distinguent le
+    comportement actuel de l'architecture cible.
+
+## Implémentation actuelle
+
+La première tranche valide le transport Streamable HTTP, l'intégration Effect,
+l'identité attachée à la requête, les schémas typés et l'adaptateur du service
+produit. Elle expose ces outils produit :
+
+| Outil | Comportement actuel | Confirmation et récupération |
+|-------|---------------------|------------------------------|
+| `products_list` | Rechercher et paginer les produits | Lecture seule |
+| `products_get` | Lire un produit actif ou archivé | Lecture seule |
+| `products_create` | Créer un produit | Renvoie une instruction pour l'archiver |
+| `products_update` | Modifier certains champs d'un produit | Renvoie les anciennes valeurs modifiables ; best-effort uniquement |
+| `products_archive` | Déplacer un produit vers la corbeille | Demande une confirmation claire ; peut être restauré |
+| `products_restore` | Restaurer un produit depuis la corbeille | Peut être archivé à nouveau |
+
+Les middlewares Better Auth et de tenant habituels authentifient chaque
+requête. Une session MCP est liée à l'utilisateur, au tenant, à la destination
+et à l'origine vérifiés lors de sa création, et les permissions sont revérifiées
+à chaque appel d'outil. Les identifiants utilisateur et tenant ne sont jamais
+des arguments d'outil contrôlés par le modèle.
+
+Les sessions vivent actuellement dans la mémoire du processus API et expirent
+après 30 minutes d'inactivité. La mise à l'échelle horizontale en production
+nécessite donc un routage sticky pour le transport de session complet, ou une
+conception de transport partagé ou stateless.
+
+Les instructions inverses renvoyées aujourd'hui sont des indications UI utiles,
+pas une garantie durable d'annulation. Elles peuvent disparaître avec la
+conversation et l'inversion d'une mise à jour pourrait écraser un travail plus
+récent. Le renommage, déplacement, archivage, import et toute autre commande
+bulk à fort impact doivent attendre le système transactionnel de change sets.
+
+## Principes de conception
+
+- MCP est un adaptateur au-dessus des services de domaine Effect propriétaires.
+  Il n'est pas généré depuis les routes HTTP et n'appelle pas directement les
+  repositories fonctionnels.
+- Exposer des requêtes et commandes étroites et sémantiques plutôt qu'un CRUD
+  générique, du SQL, des changements de statut arbitraires ou l'exécution brute
+  de tâches.
+- Décoder l'entrée externe une seule fois avec Effect Schema et renvoyer une
+  sortie structurée concise contenant des identifiants et versions stables.
+- Conserver les clôtures de tenant, permissions, fonctionnalités, transactions,
+  garanties d'idempotence et invariants métier dans les services applicatifs
+  afin que toutes les interfaces puissent les réutiliser.
+- Traiter les annotations MCP comme des indications pour le modèle et l'UI. Le
+  serveur continue d'imposer chaque règle d'autorisation et de sécurité.
+- Ne jamais exposer la suppression définitive, les secrets, les jetons de
+  session, l'accès brut à la base ou les contrôles superadmin de la plateforme
+  à l'assistant du tenant.
+
+## Architecture du protocole
+
+```mermaid
+flowchart LR
+  Client["Hôte IA Stocket / client MCP"] --> Transport["Adaptateur Streamable HTTP"]
+  Transport --> Scope["Acteur, tenant, locale et capacités vérifiés"]
+  Scope --> Registry["Registre de capacités filtré par permissions"]
+  Registry --> Query["Requête typée"]
+  Registry --> Command["Commande typée"]
+  Query --> Domain["Service de domaine Effect propriétaire"]
+  Command --> Changes["Service d'exécution des changements"]
+  Changes --> Proposal["Proposition immuable"]
+  Proposal --> Policy["Politique d'approbation"]
+  Policy --> Apply["Application transactionnelle"]
+  Apply --> Domain
+  Apply --> History["Historique et annulation"]
+```
+
+Le module MCP possède le cycle de vie du protocole, le transport, la négociation
+des capacités, les codecs de schéma, l'enregistrement filtré, l'elicitation et
+le rendu sûr des erreurs de protocole. Les modules de domaine possèdent la
+correction métier, la persistance, les transactions et les compensations. Le
+service de change sets est une capacité applicative partagée avec les actions
+UI normales, pas du code de rollback propre à MCP.
+
+L'adaptateur actuel conserve Tool, Toolkit, Schema et le runtime Effect de
+`@effect/ai` comme modèle applicatif, tout en utilisant le SDK TypeScript MCP
+officiel pour le transport et les contrôles de sécurité du protocole plus
+récent. Ce pont pourra être réévalué lorsque le transport Effect natif installé
+offrira un comportement équivalent.
+
+## Modèle de capacités MCP
+
+| Primitive | Propriétaire de l'interaction | Usage Stocket |
+|-----------|-------------------------------|---------------|
+| Outils | Contrôlés par le modèle | Recherches, calculs et commandes métier nommées |
+| Ressources | Contrôlées par l'application | Snapshots stables d'entité, proposition, change set et opération |
+| Prompts | Contrôlés par l'utilisateur | Workflows optionnels sélectionnés par l'utilisateur |
+| Elicitation | UI demandée par le serveur | Approbation claire et configuration sécurisée d'intégration |
+| Tâches | Contrôlées par le demandeur, expérimentales | Vue optionnelle des opérations durables Stocket |
+| Progression | Liée à la requête | Retour borné pour validation, imports et travaux bulk |
+
+Les opérations applicatives restent la source de vérité du travail reprenable.
+Les tâches MCP pourront plus tard adapter ces opérations pour les clients
+compatibles, mais ne sont ni une file d'exécution, ni un historique, ni un
+registre d'annulation.
+
+## Définitions de capacités typées
+
+Chaque capacité doit avoir une définition réutilisable unique qui dérive ses
+schémas Effect d'entrée et de sortie, son descripteur MCP, ses annotations, sa
+politique d'accès, sa politique de sécurité, son handler et ses tests de
+conformité. Les registres fonctionnels se composent ensuite dans le registre du
+serveur.
+
+```ts
+const updateProduct = defineMcpCommand({
+  name: "products_update",
+  input: UpdateProductInput,
+  output: ProductCommandResult,
+  access: productWriteAccess,
+  safety: reversibleWrite,
+  execute: ({ input }) => ProductsService.update(input),
+})
+
+const productsMcp = defineMcpFeature({
+  domain: "products",
+  capabilities: [searchProducts, getProduct, updateProduct],
+})
+```
+
+Les schémas MCP sont des contrats de frontière JSON-native. Les parseurs de
+requêtes HTTP et les formes de lignes de base ne doivent pas être réutilisés si
+leur représentation filaire ne convient pas. Les handlers appellent le service
+propriétaire, tandis que la traduction pure des représentations reste dans les
+mappers locaux à la fonctionnalité.
+
+## Nommage, découverte et toolkits
+
+Les noms d'outils utilisent `<domaine_pluriel>_<intention>` en snake case, par
+exemple `products_search`, `products_update_many`, `inventory_transfer` et
+`change_sets_undo`. La cardinalité apparaît dans le nom lorsqu'elle modifie le
+contrat ou la politique de sécurité. Un contrat cassant reçoit une version
+parallèle plutôt qu'une modification incompatible sur place.
+
+`products_list` est le nom actuel du prototype et doit devenir
+`products_search` avant la release externe. Un manifeste de contrat généré
+rendra visibles dans la CI les changements accidentels de nom et de schéma.
+
+Le catalogue est filtré selon l'acteur authentifié, les permissions du tenant,
+les fonctionnalités activées, les scopes distants le cas échéant, le toolkit
+sélectionné et la maturité du workflow sous-jacent :
+
+| Toolkit | Surface prévue |
+|---------|----------------|
+| Par défaut | Contexte du workspace, données catalogue, lecture d'inventaire et historique des changements |
+| Opérations | Commandes d'inventaire, commandes client, fulfillment, imports et opérations longues |
+| Administration | Utilisateurs, rôles et workflows de sécurité du tenant dans une expérience admin dédiée |
+| Opérateur | Opérations superadmin de plateforme sur un serveur distinct, s'il est un jour créé |
+
+Le filtrage améliore la sélection du modèle ; ce n'est pas une autorisation. Le
+serveur réautorise chaque invocation et contrôle les commandes à nouveau juste
+avant une écriture. Une session ou un toolkit peut réduire l'accès, mais ne peut
+pas accorder de nouveaux privilèges. L'hôte IA propriétaire peut sélectionner
+progressivement les schémas pertinents pour le modèle, tandis que le serveur
+conserve des outils directs et typés plutôt qu'une échappatoire générique
+`call_tool`.
+
+## Confirmation et changements durables
+
+La confirmation évite une action involontaire. L'annulation permet de récupérer
+après qu'une action voulue a produit un résultat inattendu. Les workflows à fort
+impact ont besoin des deux.
+
+Toute commande IA qui modifie l'état métier utilisera ce cycle de vie :
+
+1. **Planifier :** résoudre une cible déterministe et persister une proposition
+   immuable et expirante avec ses entrées, données avant/après, versions, compte
+   et hash.
+2. **Autoriser :** évaluer les permissions actuelles du tenant, les
+   fonctionnalités, le scope client et la politique propre à l'opération.
+3. **Approuver si nécessaire :** lier un grant d'approbation à usage unique à
+   l'acteur, au tenant, au hash de proposition, au client et à l'expiration. Une
+   valeur `confirmed: true` fournie par le modèle ne suffit jamais.
+4. **Appliquer :** réautoriser et consommer atomiquement le grant, vérifier les
+   versions de lignes, appliquer les écritures métier dans une transaction et
+   persister les éléments de changement et leurs résultats.
+5. **Rapporter :** renvoyer les nombres réellement affectés, les conflits,
+   l'identifiant durable du change set et l'action de récupération disponible.
+
+Les écritures à faible risque peuvent passer directement de la planification à
+l'application lorsque la politique le permet. Les commandes destructrices,
+sensibles, externes ou bulk exigent une approbation explicite. La cible confirmée
+n'est jamais recalculée silencieusement ; une proposition obsolète expire ou
+renvoie un conflit afin que l'utilisateur examine une nouvelle prévisualisation.
+
+### Approbation présentée à l'utilisateur
+
+Les utilisateurs non techniques doivent approuver des effets métier, pas des
+appels d'outils ou des identifiants de base. Une confirmation doit indiquer :
+
+- l'action et le type d'objet affecté dans la langue de l'utilisateur ;
+- le compte exact, le périmètre, les filtres, la destination et les exceptions
+  importantes ;
+- des exemples représentatifs avec des détails dépliables pour les grands
+  ensembles ;
+- le résultat visible, le comportement atomique ou par lots et les effets
+  externes ;
+- si l'action peut être annulée, sous quelles conditions et pendant combien de
+  temps ; et
+- un libellé affirmatif précis, comme **Déplacer 84 produits vers Lyon**.
+
+Dans l'application intégrée, l'elicitation de formulaire MCP peut afficher des
+prompts simples. Pour les flux distants ou plus riches, l'acceptation doit avoir
+lieu sur une page Stocket authentifiée qui émet le grant durable à usage unique.
+Un client distant peut automatiser ou déformer l'elicitation de formulaire ;
+elle ne constitue donc pas à elle seule une preuve fiable d'approbation.
+
+### Annulation et concurrence
+
+L'annulation crée un nouveau change set d'inversion ; elle ne modifie jamais
+l'historique et ne restaure pas une sauvegarde de base. L'inversion traite les
+éléments d'origine dans un ordre sûr pour les dépendances et emploie des versions
+de lignes monotones avec des contrôles compare-and-swap. Si un travail humain ou
+IA plus récent a modifié une entité, le comportement par défaut est un conflit
+atomique plutôt que l'écrasement de ce travail.
+
+Les mises à jour et déplacements restaurent les anciennes valeurs capturées.
+Les archivages restaurent l'état d'archive précédent. Inverser une création
+effectue un archivage compensatoire, pas une suppression définitive, et des
+identifiants comme un SKU peuvent rester réservés. Certains effets externes ne
+peuvent pas être inversés ; cela doit être annoncé avant l'approbation.
+L'annulation n'est donc disponible que si l'opération définit une compensation
+sûre, si la durée de rétention reste ouverte et si les versions produites sont
+toujours actuelles.
+
+Le journal d'audit, l'état de conversation, la session MCP et l'état d'une tâche
+MCP ne stockent pas le rollback. Les enregistrements transactionnels de change
+set et de ses éléments sont la source de vérité durable.
+
+## Barrières de sécurité par domaine
+
+| Domaine | Capacités prévues | Barrière avant l'exposition des écritures |
+|---------|-------------------|-------------------------------------------|
+| Produits et catalogue | Rechercher, créer, modifier, archiver, restaurer et organiser en masse | Change sets durables et versionnés avant toute mutation bulk ; aucune suppression définitive |
+| Inventaire | Réceptionner, ajuster, compter, réserver, libérer et transférer le stock | Une opération stock atomique doit mettre à jour les positions et l'historique des mouvements ensemble |
+| Commandes | Lire et exécuter des transitions de fulfillment nommées | Validation propre à l'état, compensation et transitions compare-and-swap ; aucun setter de statut arbitraire |
+| Imports | Prévisualiser, valider, mapper et appliquer de grands jeux de données | Opération persistée, contrat explicite de lots/atomicité, checkpoints et lien vers le change set |
+| Enrichissement externe | Trouver des adresses, fournisseurs ou données catalogue | Prévisualisation open-world avec provenance, puis patch closed-world vérifié |
+| Administration tenant | Rôles, invitations, sessions et workflows de sécurité | Toolkit admin dédié et frontières de services sûres pour le tenant |
+| Opérations plateforme | Workflows inter-tenants et superadmin | Exclus du serveur tenant ; frontière opérateur séparée si elle est un jour créée |
+
+Les mutations d'inventaire et la création de l'historique des mouvements sont
+actuellement des chemins séparés ; aucun des deux ne peut donc être exposé
+directement en sécurité. Un workflow `StockOperations` et des contraintes de
+position/version en base doivent d'abord en faire une transaction unique. Les
+commandes client exposent de même uniquement des commandes nommées comme mettre
+en attente, reprendre, annuler, préparer et expédier après création des
+invariants et comportements de récupération de chaque transition.
+
+Les informations externes n'écrivent jamais directement dans Stocket.
+L'assistant renvoie d'abord des candidats avec source, date et confiance, puis
+propose un patch typé normal à vérifier. Les secrets fournisseur et la
+configuration OAuth passent par une elicitation URL sécurisée, et le jeton
+Bearer MCP n'est jamais transmis à un fournisseur externe.
+
+## Identité, tenancy et accès distant
+
+L'endpoint intégré s'appuie sur l'acteur vérifié de la requête applicative, le
+middleware tenant, les contrôles same-origin et des sessions liées à
+l'utilisateur et au tenant. Les entrées d'outil ne peuvent pas choisir le
+workspace ni usurper un autre utilisateur. L'autorisation est évaluée lors de
+la découverte, de l'invocation, au démarrage d'un worker et avant chaque
+checkpoint d'écriture repris.
+
+Les clients distants arbitraires relèvent d'un travail futur. Un endpoint public
+nécessite les métadonnées OAuth de ressource protégée, OAuth 2.1 avec PKCE, des
+indicateurs de ressource et la validation d'audience, des grants à scopes, une
+politique d'enregistrement des clients, la révocation des jetons, des limites de
+débit et le suivi des abus. Jusqu'à la fin de ce travail et d'une revue de
+sécurité, `/api/v1/mcp` doit rester un endpoint applicatif propriétaire.
+
+## Ressources et opérations longues
+
+Des ressources stables donneront aux clients des snapshots référençables tels
+que `stocket://workspace/context`, les produits et emplacements, les positions
+d'inventaire, les commandes, les change sets et les opérations. Les lectures
+restent disponibles comme outils pour les clients centrés sur les outils ; les
+ressources sont les liens canoniques vers les détails d'entité et de workflow.
+
+Les grands imports ou opérations peuvent s'exécuter en lots persistés. Leur
+prévisualisation et leur résultat doivent annoncer une atomicité plus faible
+lorsqu'une transaction unique est impraticable. Les workers reconstruisent
+l'acteur de confiance et réautorisent avant le travail et chaque checkpoint
+d'écriture. Les tâches MCP et la progression optionnelles peuvent représenter
+ce cycle sans remplacer l'opération applicative ou sa politique de rétention.
+
+## Séquence de livraison
+
+1. Consolider la tranche produit actuelle derrière des factories de requêtes et
+   commandes typées, un registre filtré par permissions et un manifeste de
+   contrat généré.
+2. Renommer `products_list` en `products_search`, ajouter les contrats de curseur
+   et conserver le comportement mono-produit couvert par les tests de conformité.
+3. Implémenter les change sets versionnés et transactionnels, les propositions
+   immuables, les grants d'approbation à usage unique et les change sets
+   d'inversion.
+4. Migrer les écritures produit vers le pipeline durable, puis activer les
+   commandes bulk produit vérifiées.
+5. Ajouter les surfaces de lecture sûres pour catégories, emplacements, zones,
+   fournisseurs, clients, inventaire, commandes, activité et opérations.
+6. Construire les opérations stock atomiques, les transitions de commande
+   nommées, les imports durables et l'enrichissement externe en deux étapes avant
+   d'exposer leurs commandes.
+7. Ajouter les ressources, abonnements et tâches MCP optionnelles uniquement
+   lorsque leur cycle de vie complet est implémenté.
+8. Ajouter les scopes OAuth et le durcissement des clients distants avant de
+   publier une intégration MCP distante.
+
+## Attentes de test
+
+- Les tests du registre imposent l'unicité des noms, la stabilité des schémas,
+  les annotations explicites, les métadonnées de permission et l'appartenance
+  aux toolkits.
+- Les tests de l'adaptateur couvrent le décodage, la validation de sortie, la
+  neutralisation des erreurs, le scope d'invocation, l'échec de confirmation et
+  les capacités client non prises en charge.
+- Chaque fonctionnalité passe une suite de conformité partagée pour l'isolation
+  des tenants, l'autorisation, l'idempotence, les versions obsolètes et la sortie
+  structurée.
+- Les tests d'intégration des change sets utilisent une vraie base pour prouver
+  l'application atomique, les retries, la consommation d'approbation, les
+  conflits concurrents et le comportement d'inversion.
+- Les évaluations de sélection par le modèle vérifient que les demandes en
+  langage courant sélectionnent l'outil étroit prévu et ne contournent pas la
+  confirmation.
+
+Voir [Architecture](architecture.md), [Développement API](api-development.md) et
+[Tests](testing.md) pour les conventions plus larges de la plateforme.
+
+## Références du protocole
+
+- [Outils MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [Ressources MCP](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)
+- [Elicitation MCP](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
+- [Tâches MCP](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
+- [Autorisation MCP](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [Transport Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)

--- a/docs/development/mcp-api.md
+++ b/docs/development/mcp-api.md
@@ -1,0 +1,321 @@
+# AI and MCP Architecture
+
+Stocket is adding a Model Context Protocol (MCP) application boundary so an AI
+assistant can work with inventory data through the same domain rules as the web
+application. The target is MCP `2025-11-25`, exposed to the first-party AI host
+at `/api/v1/mcp`.
+
+!!! warning "Current scope"
+    The current endpoint is an authenticated, same-origin product prototype for
+    the embedded Stocket application. It is not a public remote MCP server, and
+    the durable change-set system required for safe bulk commands is not yet
+    implemented. The sections below distinguish current behavior from the
+    target architecture.
+
+## Current Implementation
+
+The first slice proves the Streamable HTTP transport, Effect integration,
+request-scoped identity, typed schemas, and product service adapter. It exposes
+these product tools:
+
+| Tool | Current behavior | Confirmation and recovery |
+|------|------------------|---------------------------|
+| `products_list` | Search and page through products | Read-only |
+| `products_get` | Read one active or archived product | Read-only |
+| `products_create` | Create one product | Returns an instruction to archive it |
+| `products_update` | Change selected fields on one product | Returns previous editable values; best-effort only |
+| `products_archive` | Move one product to trash | Requires plain-language confirmation; can be restored |
+| `products_restore` | Restore one product from trash | Can be archived again |
+
+The normal Better Auth and tenant middleware authenticates every request. An
+MCP session is bound to the verified user, tenant, destination, and origin that
+created it, and permissions are checked again for every tool call. User and
+tenant identifiers are never accepted as model-controlled tool arguments.
+
+Sessions currently live in API process memory and expire after 30 minutes of
+inactivity. Production horizontal scaling therefore needs sticky routing for
+the complete session transport, or a redesigned shared/stateless transport.
+
+The inverse instructions returned today are convenient UI hints, not a durable
+undo guarantee. They can be lost with the conversation and an update reversal
+could overwrite newer work. Bulk rename, move, archive, import, and other
+high-impact commands must wait for the transactional change-set system.
+
+## Design Principles
+
+- MCP is an adapter over the owning Effect domain services. It is not generated
+  from HTTP routes and does not call feature repositories directly.
+- Expose narrow, semantic queries and commands rather than generic CRUD, SQL,
+  arbitrary status changes, or raw task execution.
+- Decode external input once with Effect Schema and return concise structured
+  output containing stable identifiers and versions.
+- Keep tenant fencing, permissions, feature checks, transactions, idempotency,
+  and domain invariants in application services where every interface can
+  reuse them.
+- Treat MCP annotations as model and UI hints. The server still enforces every
+  authorization and safety rule.
+- Never expose permanent deletion, secrets, session tokens, raw database
+  access, or platform-superadmin controls to the tenant assistant.
+
+## Protocol Architecture
+
+```mermaid
+flowchart LR
+  Client["Stocket AI host / MCP client"] --> Transport["Streamable HTTP adapter"]
+  Transport --> Scope["Verified actor, tenant, locale, capabilities"]
+  Scope --> Registry["Permission-aware capability registry"]
+  Registry --> Query["Typed query"]
+  Registry --> Command["Typed command"]
+  Query --> Domain["Owning Effect domain service"]
+  Command --> Changes["Change execution service"]
+  Changes --> Proposal["Immutable proposal"]
+  Proposal --> Policy["Approval policy"]
+  Policy --> Apply["Transactional apply"]
+  Apply --> Domain
+  Apply --> History["Change history and undo"]
+```
+
+The MCP module owns protocol lifecycle, transport, capability negotiation,
+schema codecs, filtered registration, elicitation, and protocol-safe error
+rendering. Domain modules own business correctness, persistence, transactions,
+and compensation. The change-set service is an application capability shared
+with normal UI actions, not MCP-only rollback code.
+
+The current adapter keeps `@effect/ai` Tool, Toolkit, Schema, and Effect runtime
+as the application model while using the official TypeScript MCP SDK for the
+newer protocol transport and security controls. This bridge can be revisited
+when the installed native Effect transport provides equivalent behavior.
+
+## MCP Capability Model
+
+| Primitive | Interaction owner | Stocket use |
+|-----------|-------------------|-------------|
+| Tools | Model-controlled | Searches, calculations, and named domain commands |
+| Resources | Application-controlled | Stable entity, proposal, change-set, and operation snapshots |
+| Prompts | User-controlled | Optional user-selected workflows |
+| Elicitation | Server-requested UI | Plain-language approval and secure integration setup |
+| Tasks | Requestor-controlled, experimental | Optional view over Stocket durable operations |
+| Progress | Request-scoped | Bounded feedback for validation, imports, and bulk work |
+
+Application operations remain the source of truth for resumable work. MCP
+Tasks may later adapt those operations for compatible clients, but they are not
+an execution queue, history store, or undo ledger.
+
+## Typed Capability Definitions
+
+Each capability should have one reusable definition that derives its Effect
+input and output schemas, MCP descriptor, annotations, access policy, safety
+policy, handler, and conformance tests. Feature registries then compose into
+the server registry.
+
+```ts
+const updateProduct = defineMcpCommand({
+  name: "products_update",
+  input: UpdateProductInput,
+  output: ProductCommandResult,
+  access: productWriteAccess,
+  safety: reversibleWrite,
+  execute: ({ input }) => ProductsService.update(input),
+})
+
+const productsMcp = defineMcpFeature({
+  domain: "products",
+  capabilities: [searchProducts, getProduct, updateProduct],
+})
+```
+
+MCP schemas are JSON-native boundary contracts. HTTP query parsers and database
+row shapes should not be reused when their wire representation is unsuitable.
+Handlers call the owning service, while pure representation translation stays
+in feature-local mappers.
+
+## Naming, Discovery, and Toolkits
+
+Tool names use `<plural_domain>_<intent>` in snake case, for example
+`products_search`, `products_update_many`, `inventory_transfer`, and
+`change_sets_undo`. Cardinality belongs in the name when it changes the contract
+or safety policy. Breaking contracts receive a parallel version instead of an
+in-place incompatible change.
+
+`products_list` is the current prototype name and should become
+`products_search` before external release. A generated contract manifest will
+make accidental name and schema changes visible in CI.
+
+The catalog is filtered by the authenticated actor, tenant permissions, enabled
+features, remote scopes when applicable, selected toolkit, and readiness of the
+underlying workflow:
+
+| Toolkit | Intended surface |
+|---------|------------------|
+| Default | Workspace context, catalog data, read inventory, and change history |
+| Operations | Inventory commands, orders, fulfillment, imports, and long-running operations |
+| Administration | Tenant users, roles, and security workflows in a dedicated admin experience |
+| Operator | Platform-superadmin operations on a separate server, if ever built |
+
+Filtering improves model selection; it is not authorization. The server
+reauthorizes every invocation and checks commands again immediately before a
+write. A session or toolkit can narrow access but cannot grant new privileges.
+The first-party AI host can progressively select relevant schemas for the
+model, while the server keeps direct, typed tools instead of a generic
+`call_tool` escape hatch.
+
+## Confirmation and Durable Changes
+
+Confirmation prevents an unintended action. Undo provides recovery after an
+intended action has an unexpected result. High-impact workflows need both.
+
+Every AI command that changes business state will use this lifecycle:
+
+1. **Plan:** resolve a deterministic target set and persist an immutable,
+   expiring proposal with its inputs, before/after data, versions, count, and
+   hash.
+2. **Authorize:** evaluate current tenant permissions, features, client scope,
+   and operation-specific policy.
+3. **Approve when required:** bind a one-time approval grant to the actor,
+   tenant, proposal hash, client, and expiry. A model-provided
+   `confirmed: true` value is never sufficient.
+4. **Apply:** reauthorize and atomically consume the grant, verify row versions,
+   apply domain writes in a transaction, and persist change items and their
+   outcomes.
+5. **Report:** return actual affected counts, conflicts, the durable change-set
+   identifier, and the available recovery action.
+
+Low-risk writes may pass from planning directly to apply when policy permits.
+Destructive, sensitive, external, or bulk commands require explicit approval.
+The confirmed target is never silently recomputed; a stale proposal expires or
+returns a conflict so the user can review a new preview.
+
+### User-Facing Approval
+
+Nontechnical users should approve business effects, not tool calls or database
+IDs. A confirmation must state:
+
+- the action and affected object type in the user's language;
+- the exact count, scope, filters, destination, and important exceptions;
+- representative examples with expandable details for large sets;
+- the visible result, atomicity or batching behavior, and external effects;
+- whether the action can be undone, under what conditions, and for how long;
+  and
+- a specific affirmative label, such as **Move 84 products to Lyon**.
+
+For the embedded application, MCP form elicitation can display simple prompts.
+For remote or richer flows, acceptance must occur on an authenticated Stocket
+page that issues the durable one-time grant. A remote client may automate or
+misrepresent form elicitation, so elicitation alone is not trusted proof of
+approval.
+
+### Undo and Concurrency
+
+Undo creates a new reversal change set; it never edits history or restores a
+database backup. The reversal processes original items in dependency-safe order
+and uses monotonic row versions with compare-and-swap checks. If newer human or
+AI work changed an entity, the default is an atomic conflict rather than
+overwriting that work.
+
+Updates and moves restore captured previous values. Archives restore the prior
+archive state. Reversing a create performs a compensating archive, not permanent
+deletion, and identifiers such as an SKU can remain reserved. Some external
+effects cannot be reversed; this must be disclosed before approval. Undo is
+therefore available only when the operation defines a safe compensation, the
+retention window is open, and the produced versions are still current.
+
+The audit log, conversation state, MCP session, and MCP Task state are not
+rollback storage. The transactional change-set and item records are the durable
+source of truth.
+
+## Domain Safety Gates
+
+| Domain | Intended capabilities | Gate before writes are exposed |
+|--------|-----------------------|--------------------------------|
+| Products and catalog | Search, create, edit, archive, restore, and bulk organization | Durable versioned change sets before bulk mutation; no permanent delete |
+| Inventory | Receive, adjust, count, reserve, release, and transfer stock | One atomic stock operation must update positions and movement history together |
+| Orders | Read and execute named fulfillment transitions | State-specific validation, compensation, and compare-and-swap transitions; no arbitrary status setter |
+| Imports | Preview, validate, map, and apply large data sets | Persisted operation, explicit batching/atomicity contract, checkpoints, and change-set linkage |
+| External enrichment | Find addresses, suppliers, or catalog data | Open-world preview with provenance, followed by a closed-world reviewed patch |
+| Tenant administration | Roles, invitations, sessions, and security workflows | Dedicated admin toolkit and tenant-safe service boundaries |
+| Platform operations | Cross-tenant and superadmin workflows | Excluded from the tenant server; separate operator boundary if ever built |
+
+Current inventory mutations and movement-history creation are separate paths,
+so neither is safe to expose directly. A `StockOperations` workflow and database
+position/version constraints must make them one transaction first. Orders
+similarly expose named commands such as hold, resume, cancel, pack, and ship only
+after each transition's invariants and recovery behavior exist.
+
+External information never writes directly into Stocket. The assistant first
+returns candidates with source, time, and confidence, then proposes a normal
+typed patch for review. Provider secrets and OAuth setup use secure URL
+elicitation, and the MCP bearer token is never forwarded to an external
+provider.
+
+## Identity, Tenancy, and Remote Access
+
+The embedded endpoint relies on the application's verified request actor,
+tenant middleware, same-origin checks, and user/tenant-bound sessions. Tool
+inputs cannot choose the workspace or impersonate another user. Authorization
+is evaluated at discovery, invocation, worker start, and before any resumed
+write checkpoint.
+
+Arbitrary remote clients are future work. A public endpoint requires OAuth
+protected-resource metadata, OAuth 2.1 with PKCE, resource indicators and
+audience validation, scoped grants, client registration policy, token
+revocation, rate limits, and abuse monitoring. Until that work and a security
+review are complete, `/api/v1/mcp` must remain a first-party application
+endpoint.
+
+## Resources and Long-Running Operations
+
+Stable resources will give clients linkable snapshots such as
+`stocket://workspace/context`, product and location records, inventory
+positions, orders, change sets, and operations. Reads remain available as tools
+for tool-centric clients; resources are the canonical links for entity and
+workflow details.
+
+Large imports or operations may run in persisted batches. Their preview and
+result must disclose weaker atomicity when one transaction is impractical.
+Workers reconstruct the trusted actor and reauthorize before work and every
+write checkpoint. Optional MCP Tasks and progress can represent this lifecycle
+without replacing the application operation or its retention policy.
+
+## Delivery Sequence
+
+1. Consolidate the current product slice behind typed query and command
+   factories, a permission-aware registry, and a generated contract manifest.
+2. Rename `products_list` to `products_search`, add cursor contracts, and keep
+   existing single-product behavior covered by conformance tests.
+3. Implement versioned, transactional change sets, immutable proposals,
+   one-time approval grants, and reversal change sets.
+4. Migrate product writes to the durable pipeline, then enable reviewed bulk
+   product commands.
+5. Add safe read surfaces for categories, locations, areas, suppliers, clients,
+   inventory, orders, activity, and operations.
+6. Build atomic stock operations, named order transitions, durable imports, and
+   two-stage external enrichment before exposing their commands.
+7. Add resources, subscriptions, and optional MCP Tasks only when their complete
+   lifecycle is implemented.
+8. Add OAuth scopes and remote-client hardening before publishing a remote MCP
+   integration.
+
+## Testing Expectations
+
+- Registry tests enforce unique names, schema stability, explicit annotations,
+  permission metadata, and toolkit membership.
+- Adapter tests cover decoding, output validation, error sanitization,
+  invocation scope, confirmation failure, and unsupported client capabilities.
+- Every feature passes a shared conformance suite for tenant isolation,
+  authorization, idempotency, stale versions, and structured output.
+- Change-set integration tests use a real database to prove atomic apply,
+  retries, approval consumption, concurrent conflicts, and reversal behavior.
+- Model-selection evaluations verify that users' plain-language requests select
+  the intended narrow tool and do not bypass confirmation.
+
+See [Architecture](architecture.md), [API Development](api-development.md), and
+[Testing](testing.md) for the wider platform conventions.
+
+## Protocol References
+
+- [MCP tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [MCP resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)
+- [MCP elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
+- [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
+- [MCP authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ plugins:
             Audit Logs: Journaux d'audit
             Development: Développement
             Architecture: Architecture
+            AI & MCP Architecture: Architecture IA & MCP
             Setup: Configuration
             Code Style: Style de code
             Testing: Tests
@@ -158,6 +159,7 @@ nav:
   - Development:
       - development/index.md
       - Architecture: development/architecture.md
+      - AI & MCP Architecture: development/mcp-api.md
       - Setup: development/setup.md
       - Code Style: development/code-style.md
       - Testing: development/testing.md


### PR DESCRIPTION
## Summary

- add English and French development documentation for Stocket's AI and MCP architecture
- distinguish the current embedded product prototype from the target platform-wide capability model
- document typed Effect capability definitions, naming, discovery, and toolkits
- define the plain-language approval and durable change-set lifecycle for destructive and bulk actions
- describe conditional undo, concurrency protection, domain safety gates, remote OAuth requirements, rollout, and testing expectations
- add the page to both development indexes and MkDocs navigation

## Impact

Developers now have a public, bilingual design reference explaining which MCP behavior exists today and which safety infrastructure must land before inventory, orders, imports, external enrichment, bulk changes, or remote clients are exposed.

## Validation

- English/French MCP pages have matching heading, fence, and table structure
- relative links in both new pages resolve
- navigation and development-index entries are present
- `git diff --check`

The documentation `main` branch predates the newer repository-wide audit baseline and already fails that audit for unrelated missing translations, structural mismatches, and screenshot links. The MCP page pair itself passes the equivalent focused structure and link checks.
